### PR TITLE
fix: drag drop options sticking to mouse pointer

### DIFF
--- a/custom-elements.json
+++ b/custom-elements.json
@@ -6503,6 +6503,21 @@
             },
             {
               "kind": "field",
+              "name": "onMove",
+              "privacy": "private"
+            },
+            {
+              "kind": "field",
+              "name": "onEnd",
+              "privacy": "private"
+            },
+            {
+              "kind": "field",
+              "name": "onCancel",
+              "privacy": "private"
+            },
+            {
+              "kind": "field",
               "name": "MIN_DRAG_DISTANCE",
               "type": {
                 "text": "number"
@@ -7973,6 +7988,33 @@
               },
               "privacy": "private",
               "default": "null",
+              "inheritedFrom": {
+                "name": "DragDropInteractionMixin",
+                "module": "src/lib/qti-components/qti-interaction/internal/drag-drop/drag-drop-interaction-mixin.ts"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "onMove",
+              "privacy": "private",
+              "inheritedFrom": {
+                "name": "DragDropInteractionMixin",
+                "module": "src/lib/qti-components/qti-interaction/internal/drag-drop/drag-drop-interaction-mixin.ts"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "onEnd",
+              "privacy": "private",
+              "inheritedFrom": {
+                "name": "DragDropInteractionMixin",
+                "module": "src/lib/qti-components/qti-interaction/internal/drag-drop/drag-drop-interaction-mixin.ts"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "onCancel",
+              "privacy": "private",
               "inheritedFrom": {
                 "name": "DragDropInteractionMixin",
                 "module": "src/lib/qti-components/qti-interaction/internal/drag-drop/drag-drop-interaction-mixin.ts"
@@ -11053,6 +11095,33 @@
             },
             {
               "kind": "field",
+              "name": "onMove",
+              "privacy": "private",
+              "inheritedFrom": {
+                "name": "DragDropInteractionMixin",
+                "module": "src/lib/qti-components/qti-interaction/internal/drag-drop/drag-drop-interaction-mixin.ts"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "onEnd",
+              "privacy": "private",
+              "inheritedFrom": {
+                "name": "DragDropInteractionMixin",
+                "module": "src/lib/qti-components/qti-interaction/internal/drag-drop/drag-drop-interaction-mixin.ts"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "onCancel",
+              "privacy": "private",
+              "inheritedFrom": {
+                "name": "DragDropInteractionMixin",
+                "module": "src/lib/qti-components/qti-interaction/internal/drag-drop/drag-drop-interaction-mixin.ts"
+              }
+            },
+            {
+              "kind": "field",
               "name": "MIN_DRAG_DISTANCE",
               "type": {
                 "text": "number"
@@ -13029,6 +13098,33 @@
               },
               "privacy": "private",
               "default": "null",
+              "inheritedFrom": {
+                "name": "DragDropInteractionMixin",
+                "module": "src/lib/qti-components/qti-interaction/internal/drag-drop/drag-drop-interaction-mixin.ts"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "onMove",
+              "privacy": "private",
+              "inheritedFrom": {
+                "name": "DragDropInteractionMixin",
+                "module": "src/lib/qti-components/qti-interaction/internal/drag-drop/drag-drop-interaction-mixin.ts"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "onEnd",
+              "privacy": "private",
+              "inheritedFrom": {
+                "name": "DragDropInteractionMixin",
+                "module": "src/lib/qti-components/qti-interaction/internal/drag-drop/drag-drop-interaction-mixin.ts"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "onCancel",
+              "privacy": "private",
               "inheritedFrom": {
                 "name": "DragDropInteractionMixin",
                 "module": "src/lib/qti-components/qti-interaction/internal/drag-drop/drag-drop-interaction-mixin.ts"
@@ -16248,6 +16344,33 @@
             },
             {
               "kind": "field",
+              "name": "onMove",
+              "privacy": "private",
+              "inheritedFrom": {
+                "name": "DragDropInteractionMixin",
+                "module": "src/lib/qti-components/qti-interaction/internal/drag-drop/drag-drop-interaction-mixin.ts"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "onEnd",
+              "privacy": "private",
+              "inheritedFrom": {
+                "name": "DragDropInteractionMixin",
+                "module": "src/lib/qti-components/qti-interaction/internal/drag-drop/drag-drop-interaction-mixin.ts"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "onCancel",
+              "privacy": "private",
+              "inheritedFrom": {
+                "name": "DragDropInteractionMixin",
+                "module": "src/lib/qti-components/qti-interaction/internal/drag-drop/drag-drop-interaction-mixin.ts"
+              }
+            },
+            {
+              "kind": "field",
               "name": "MIN_DRAG_DISTANCE",
               "type": {
                 "text": "number"
@@ -17574,6 +17697,33 @@
               },
               "privacy": "private",
               "default": "null",
+              "inheritedFrom": {
+                "name": "DragDropInteractionMixin",
+                "module": "src/lib/qti-components/qti-interaction/internal/drag-drop/drag-drop-interaction-mixin.ts"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "onMove",
+              "privacy": "private",
+              "inheritedFrom": {
+                "name": "DragDropInteractionMixin",
+                "module": "src/lib/qti-components/qti-interaction/internal/drag-drop/drag-drop-interaction-mixin.ts"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "onEnd",
+              "privacy": "private",
+              "inheritedFrom": {
+                "name": "DragDropInteractionMixin",
+                "module": "src/lib/qti-components/qti-interaction/internal/drag-drop/drag-drop-interaction-mixin.ts"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "onCancel",
+              "privacy": "private",
               "inheritedFrom": {
                 "name": "DragDropInteractionMixin",
                 "module": "src/lib/qti-components/qti-interaction/internal/drag-drop/drag-drop-interaction-mixin.ts"
@@ -22880,12 +23030,6 @@
     },
     {
       "kind": "javascript-module",
-      "path": "src/lib/qti-components/qti-response-processing/qti-expression/qti-gcd/qti.gcd.spec.ts",
-      "declarations": [],
-      "exports": []
-    },
-    {
-      "kind": "javascript-module",
       "path": "src/lib/qti-components/qti-interaction/internal/choices/choices.spec.ts",
       "declarations": [
         {
@@ -23309,6 +23453,12 @@
           }
         }
       ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/lib/qti-components/qti-response-processing/qti-expression/qti-gcd/qti.gcd.spec.ts",
+      "declarations": [],
+      "exports": []
     },
     {
       "kind": "javascript-module",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5204,24 +5204,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/cli-highlight/node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
     "node_modules/cli-highlight/node_modules/yargs": {
       "version": "16.2.0",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
@@ -5316,24 +5298,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/cliui/node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/clone": {
@@ -8165,6 +8129,16 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/ignore-walk": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.4.tgz",
+      "integrity": "sha512-PY6Ii8o1jMRA1z4F2hRkH/xN59ox43DavKvD3oDpfurRlOJyAHpifIwpbdv1n4jt4ov0jSpw3kQ4GhJnpBL6WQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minimatch": "^3.0.4"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -10763,16 +10737,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/npm-packlist/node_modules/ignore-walk": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.4.tgz",
-      "integrity": "sha512-PY6Ii8o1jMRA1z4F2hRkH/xN59ox43DavKvD3oDpfurRlOJyAHpifIwpbdv1n4jt4ov0jSpw3kQ4GhJnpBL6WQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "minimatch": "^3.0.4"
       }
     },
     "node_modules/npm-run-all": {
@@ -13493,9 +13457,9 @@
       }
     },
     "node_modules/strip-ansi": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -15403,6 +15367,24 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/wrap-ansi-cjs": {
       "name": "wrap-ansi",
       "version": "7.0.0",
@@ -15433,6 +15415,29 @@
       }
     },
     "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
@@ -15618,24 +15623,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4.0.0"
-      }
-    },
-    "node_modules/yalc/node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/yalc/node_modules/yargs": {

--- a/src/lib/qti-components/qti-interaction/internal/drag-drop/drag-drop-interaction-mixin.ts
+++ b/src/lib/qti-components/qti-interaction/internal/drag-drop/drag-drop-interaction-mixin.ts
@@ -43,6 +43,10 @@ export const DragDropInteractionMixin = <T extends Constructor<Interaction>>(
     private lastTarget = null; // Last touch target
     private currentDropTarget = null; // Current droppable element
 
+    private onMove = this.handleTouchMove.bind(this);
+    private onEnd = this.handleTouchEnd.bind(this);
+    private onCancel = this.handleTouchCancel.bind(this);
+
     private readonly MIN_DRAG_DISTANCE = 5; // Minimum pixel movement to start dragging
     private readonly DRAG_CLONE_OPACITY = 1; // Opacity of the drag clone element
 
@@ -110,11 +114,11 @@ export const DragDropInteractionMixin = <T extends Constructor<Interaction>>(
       if (this.isMatchTabular()) return;
       const disabled = this.hasAttribute('disabled');
       if (!disabled) {
-        document.addEventListener('touchmove', this.handleTouchMove.bind(this), { passive: false });
-        document.addEventListener('mousemove', this.handleTouchMove.bind(this), { passive: false });
-        document.addEventListener('touchend', this.handleTouchEnd.bind(this), { passive: false });
-        document.addEventListener('mouseup', this.handleTouchEnd.bind(this), { passive: false });
-        document.addEventListener('touchcancel', this.handleTouchCancel.bind(this), { passive: false });
+        document.addEventListener('mousemove', this.onMove, { passive: false });
+        document.addEventListener('mouseup', this.onEnd, { passive: false });
+        document.addEventListener('touchmove', this.onMove, { passive: false });
+        document.addEventListener('touchend', this.onEnd, { passive: false });
+        document.addEventListener('touchcancel', this.onCancel, { passive: false });
       }
       const draggables = Array.from(this.querySelectorAll(draggablesSelector) || []).concat(
         Array.from(this.shadowRoot?.querySelectorAll(draggablesSelector) || [])
@@ -342,11 +346,11 @@ export const DragDropInteractionMixin = <T extends Constructor<Interaction>>(
       }
 
       // Remove global event listeners
-      document.removeEventListener('touchmove', this.handleTouchMove);
-      document.removeEventListener('mousemove', this.handleTouchMove);
-      document.removeEventListener('touchend', this.handleTouchEnd);
-      document.removeEventListener('mouseup', this.handleTouchEnd);
-      document.removeEventListener('touchcancel', this.handleTouchCancel);
+      document.removeEventListener('mousemove', this.onMove);
+      document.removeEventListener('mouseup', this.onEnd);
+      document.removeEventListener('touchmove', this.onMove);
+      document.removeEventListener('touchend', this.onEnd);
+      document.removeEventListener('touchcancel', this.onCancel);
     }
 
     private handleTouchMove(e) {
@@ -391,7 +395,7 @@ export const DragDropInteractionMixin = <T extends Constructor<Interaction>>(
 
     private handleTouchEnd(e) {
       if (this.isMatchTabular()) return;
-      if (this.isDragging) {
+      if (this.isDragging || this.isDraggable || this.dragClone) {
         this.resetDragState();
       }
       this._internals.states.delete('--dragzone-active');


### PR DESCRIPTION
Also reset drag state for draggable and dragClone, preventing options from sticking to the mouse pointer after click. Also store the bound handlers and clear those, rather than clearing unrelated method references later.