### PR TITLE
Fix associate interaction line visibility

### DIFF
--- a/packages/qti-interactions/src/components/qti-associate-interaction/qti-associate-interaction.styles.ts
+++ b/packages/qti-interactions/src/components/qti-associate-interaction/qti-associate-interaction.styles.ts
@@ -9,7 +9,7 @@ export default css`
     align-items: flex-start;
     flex: 1;
     border: 2px solid transparent;
-    padding: 0.3rem;
+    margin: 1rem 0;
     border-radius: 0.3rem;
     gap: 0.5rem;
   }
@@ -19,18 +19,23 @@ export default css`
     background-color: var(--qti-bg-active) !important;
   }
 
+  [part='drop-container'] {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
   [part='drop-list'][enabled] {
     background-color: var(--qti-bg-active) !important;
   }
 
   :host::part(associables-container) {
     display: flex;
-    padding: 0.5rem;
     justify-content: space-between;
     background: linear-gradient(
       180deg,
       rgb(0 0 0 / 0%) calc(50% - 1px),
-      var(--qti-border-color-gray) calc(50%),
+      var(--qti-border-color) calc(50%),
       rgb(0 0 0 / 0%) calc(50% + 1px)
     );
   }


### PR DESCRIPTION
Fixes #116

## Changes
- Changed padding to margin on associable choices for better spacing
- Added drop-container styling for improved layout
- Fixed center line color to use `var(--qti-border-color)` instead of `var(--qti-border-color-gray)`
- Removed conflicting padding from associables-container

The connector lines in the associate interaction are now properly visible.