### PR TITLE
test: add unit test for MathML namespace preservation

### DIFF
--- a/packages/qti-transformers/test/qti-transform-item.spec.ts
+++ b/packages/qti-transformers/test/qti-transform-item.spec.ts
@@ -89,6 +89,43 @@ describe('qtiTransformItem API Methods', () => {
     );
   });
 
+  it('should preserve MathML namespaces when converting to HTML', async () => {
+    const htmlDoc = qtiTransformItem()
+      .parse(
+        xml`
+        <qti-assessment-item xmlns="http://www.imsglobal.org/xsd/imsqtiasi_v3p0" xmlns:m="http://www.w3.org/1998/Math/MathML">
+          <qti-item-body>
+            <qti-prompt>
+              mathml:
+              <m:math display="inline">
+                <m:semantics>
+                  <m:mfrac>
+                    <m:mn>1</m:mn>
+                    <m:msqrt>
+                      <m:mn>2</m:mn>
+                    </m:msqrt>
+                  </m:mfrac>
+                </m:semantics>
+              </m:math>
+            </qti-prompt>
+          </qti-item-body>
+        </qti-assessment-item>`
+      )
+      .htmlDoc();
+
+    const elements = Array.from(htmlDoc.querySelectorAll('*'));
+    const qtiItem = elements.find(element => element.localName === 'qti-assessment-item');
+    const math = elements.find(element => element.localName === 'math');
+    const fraction = elements.find(element => element.localName === 'mfrac');
+    const squareRoot = elements.find(element => element.localName === 'msqrt');
+
+    expect(qtiItem?.namespaceURI).toBe('http://www.w3.org/1999/xhtml');
+    expect(math?.namespaceURI).toBe('http://www.w3.org/1998/Math/MathML');
+    expect(math?.getAttribute('display')).toBe('inline');
+    expect(fraction?.namespaceURI).toBe('http://www.w3.org/1998/Math/MathML');
+    expect(squareRoot?.namespaceURI).toBe('http://www.w3.org/1998/Math/MathML');
+  });
+
   it('should update elements with pciHooks correctly', async () => {
     const parsedXML = qtiTransformItem()
       .parse(


### PR DESCRIPTION
Adds a unit test in `qti-transform-item.spec.ts` verifying that `qtiTransformItem` preserves the MathML namespace on `<math>` and its descendants (`mfrac`, `msqrt`) when converting QTI XML to HTML, while `qti-assessment-item` is mapped to the XHTML namespace.

Complements the Storybook play-test added in #153 (which fixed the underlying `stripNamespaces` behaviour for issue #152) with a fast, isolated unit-level check.