### PR TITLE
chore: add changeset for MathML namespace fix (#153)

### DIFF
--- a/.changeset/mathml-namespace-support.md
+++ b/.changeset/mathml-namespace-support.md
@@ -1,0 +1,8 @@
+---
+'@qti-components/transformers': patch
+'@qti-components/inline-choice-interaction': patch
+'@qti-components/match-interaction': patch
+'@citolab/qti-components': patch
+---
+
+Preserve MathML (and other foreign) namespaces when transforming QTI XML to HTML so `<math>` and its descendants render correctly in the browser. Inline-choice and match interactions now clone child nodes instead of injecting `innerHTML`/`textContent`, so embedded MathML in choices is preserved as well.


### PR DESCRIPTION
#153, #154 and #155 were merged without a changeset, so the release workflow (#40) produces no version bump.

This adds a `patch` changeset for the MathML namespace fix (#153), covering the directly-changed published packages:
- `@qti-components/transformers`
- `@qti-components/inline-choice-interaction`
- `@qti-components/match-interaction`
- `@citolab/qti-components`

Via `updateInternalDependencies: patch` the remaining packages patch-bump through the internal dependency graph (same effective outcome as the previous release's changeset). #154 (test-only) and #155 (CI/tooling-only) don't change published behaviour, so they need no changeset.