### PR TITLE
feat(base): move shuffle seed to QTI_CONTEXT with typed Seed

### DIFF
--- a/.changeset/transform-item-shuffle-options.md
+++ b/.changeset/transform-item-shuffle-options.md
@@ -15,10 +15,11 @@ Shuffling is now deterministic when a seed is provided:
 
 Omitting the seed is also deterministic (no longer `Math.random`): both methods emit a `console.warn` and fall back to a deterministic seed derived from the loaded URI (`load()`), or the constant `default-item-seed` / `default-test-seed` when no URI is available (e.g. after `parse()`).
 
-Deterministic delivery now uses `configContext.shuffleSeed`:
+Deterministic delivery now uses `QTI_CONTEXT.seed` (a validated, branded `Seed`):
 
-- Item delivery: provide `configContext.shuffleSeed` on `<qti-item>` for seeded interaction shuffling in `item-container`.
-- Test delivery: provide `configContext.shuffleSeed` on `<qti-test>` for seeded test ordering in `test-container` and seeded item shuffling in test navigation. When set, all navigated items share this single seed; when omitted, each item falls back to its own URI-derived deterministic seed.
+- The seed moved off `configContext.shuffleSeed` onto the QTI runtime context `QTI_CONTEXT.seed`. It is typed as a branded `Seed` (non-empty letters/digits/hyphens); use the exported `isSeed` / `asSeed` guards at boundaries.
+- Item delivery: provide `QTI_CONTEXT.seed` via the `qtiContext` provided by `<qti-item>` for seeded interaction shuffling in `item-container`.
+- Test delivery: provide `QTI_CONTEXT.seed` via the `qtiContext` on `<test-navigation>` for seeded test ordering in `test-container` and seeded item shuffling during navigation. When set, all navigated items share this single seed; when omitted, each item falls back to its own URI-derived deterministic seed.
 
 Config context ownership in test delivery was also lifted to the top-level test host:
 

--- a/packages/qti-base/src/context/config.context.ts
+++ b/packages/qti-base/src/context/config.context.ts
@@ -7,11 +7,6 @@ export type CorrectResponseMode = 'internal' | 'full';
  */
 export interface ConfigContext {
   /**
-   * Optional deterministic seed used for test/item shuffling in container components.
-   */
-  shuffleSeed?: string | null;
-
-  /**
    * Optional category label for info items, used for reporting or display purposes.
    * Example: "General Information", "Instructions".
    */

--- a/packages/qti-base/src/context/qti.context.ts
+++ b/packages/qti-base/src/context/qti.context.ts
@@ -1,9 +1,49 @@
 import { createContext } from '@lit/context';
 
+/**
+ * A validated deterministic shuffle seed.
+ *
+ * Branded so that only values verified through {@link isSeed} (or constructed via
+ * {@link asSeed}) can be assigned where a seed is expected. This prevents arbitrary
+ * strings from silently being used as a seed.
+ *
+ * A usable seed is a non-empty string of letters, digits and hyphens (e.g. a GUID
+ * "N" format like `8f14e45fceea167a5a36dedd4bea2543`, or a readable label like
+ * `delivery-2026-06-05`). Whitespace and other characters are rejected.
+ */
+export type Seed = string & { readonly __seedBrand: 'Seed' };
+
+/** Format a value must match to be usable as a {@link Seed}. */
+const SEED_PATTERN = /^[A-Za-z0-9-]+$/;
+
+/**
+ * Runtime type guard that narrows an unknown value to a {@link Seed}.
+ * Use this at boundaries (e.g. values coming from XML, a host application or a
+ * backend) before treating a string as a seed.
+ */
+export const isSeed = (value: unknown): value is Seed => typeof value === 'string' && SEED_PATTERN.test(value);
+
+/**
+ * Validates and brands a value as a {@link Seed}, returning `undefined` when the
+ * value is missing or not in a usable seed format.
+ */
+export const asSeed = (value: unknown): Seed | undefined => (isSeed(value) ? value : undefined);
+
 export type QtiContextType = {
   testIdentifier: string;
   candidateIdentifier: string;
   environmentIdentifier: string;
+  /**
+   * Optional deterministic seed for shuffling.
+   *
+   * When set, it is used to reproduce a stable shuffle order across reloads/restarts:
+   * - test ordering in `test-container` (`<qti-ordering shuffle="true">`),
+   * - seeded item interaction shuffling in `item-container` and during test navigation.
+   *
+   * Typically generated once per session by the host/backend and passed in via
+   * `QTI_CONTEXT`. When omitted, each item falls back to its own URI-derived seed.
+   */
+  seed?: Seed;
   [key: string]: string | string[]; // Allow for additional context variables
 };
 

--- a/packages/qti-components/custom-elements.json
+++ b/packages/qti-components/custom-elements.json
@@ -27313,11 +27313,63 @@
       "path": "packages/qti-base/src/context/qti.context.ts",
       "declarations": [
         {
+          "kind": "function",
+          "name": "asSeed",
+          "return": {
+            "type": {
+              "text": "Seed | undefined"
+            }
+          },
+          "parameters": [
+            {
+              "name": "value",
+              "type": {
+                "text": "unknown"
+              }
+            }
+          ],
+          "description": "Validates and brands a value as a Seed, returning `undefined` when the\nvalue is missing or not in a usable seed format."
+        },
+        {
+          "kind": "function",
+          "name": "isSeed",
+          "return": {
+            "type": {
+              "text": "value is Seed"
+            }
+          },
+          "parameters": [
+            {
+              "name": "value",
+              "type": {
+                "text": "unknown"
+              }
+            }
+          ],
+          "description": "Runtime type guard that narrows an unknown value to a Seed.\nUse this at boundaries (e.g. values coming from XML, a host application or a\nbackend) before treating a string as a seed."
+        },
+        {
           "kind": "variable",
           "name": "qtiContext"
         }
       ],
       "exports": [
+        {
+          "kind": "js",
+          "name": "asSeed",
+          "declaration": {
+            "name": "asSeed",
+            "module": "packages/qti-base/src/context/qti.context.ts"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "isSeed",
+          "declaration": {
+            "name": "isSeed",
+            "module": "packages/qti-base/src/context/qti.context.ts"
+          }
+        },
         {
           "kind": "js",
           "name": "qtiContext",
@@ -30421,15 +30473,6 @@
               "description": "Template content if provided"
             },
             {
-              "kind": "field",
-              "name": "configContext",
-              "type": {
-                "text": "ConfigContext"
-              },
-              "privacy": "protected",
-              "default": "{}"
-            },
-            {
               "kind": "method",
               "name": "handleItemURLChange",
               "privacy": "protected"
@@ -30466,6 +30509,15 @@
               },
               "default": "null",
               "description": "The raw XML string"
+            },
+            {
+              "kind": "field",
+              "name": "qtiContext",
+              "type": {
+                "text": "QtiContext"
+              },
+              "privacy": "protected",
+              "default": "{ QTI_CONTEXT: { testIdentifier: '', candidateIdentifier: '', environmentIdentifier: 'default' } }"
             }
           ],
           "attributes": [
@@ -31164,6 +31216,16 @@
               },
               "privacy": "public",
               "default": "{}"
+            },
+            {
+              "kind": "field",
+              "name": "qtiContext",
+              "type": {
+                "text": "QtiContext"
+              },
+              "privacy": "public",
+              "default": "{ QTI_CONTEXT: { testIdentifier: '', candidateIdentifier: '', environmentIdentifier: 'default' } }",
+              "description": "Provided so that descendants (e.g. `<item-container>`) can read the QTI runtime\ncontext for standalone item delivery, including the optional shuffle `seed`."
             }
           ],
           "superclass": {
@@ -41408,15 +41470,6 @@
               "description": "Template content if provided"
             },
             {
-              "kind": "field",
-              "name": "configContext",
-              "type": {
-                "text": "ConfigContext"
-              },
-              "privacy": "protected",
-              "default": "{}"
-            },
-            {
               "kind": "method",
               "name": "handleTestURLChange",
               "privacy": "protected",
@@ -41426,6 +41479,15 @@
               "kind": "method",
               "name": "handleTestXMLChange",
               "privacy": "protected"
+            },
+            {
+              "kind": "field",
+              "name": "qtiContext",
+              "type": {
+                "text": "QtiContext"
+              },
+              "privacy": "protected",
+              "default": "{ QTI_CONTEXT: { testIdentifier: '', candidateIdentifier: '', environmentIdentifier: 'default' } }"
             },
             {
               "kind": "field",

--- a/packages/qti-item/src/components/item-container/item-container.ts
+++ b/packages/qti-item/src/components/item-container/item-container.ts
@@ -3,14 +3,14 @@ import { LitElement, html } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { until } from 'lit/directives/until.js';
 
-import { configContext } from '@qti-components/base';
+import { qtiContext } from '@qti-components/base';
 import { watch } from '@qti-components/utilities';
 import { qtiTransformItem } from '@qti-components/transformers';
 
 // eslint-disable-next-line import/no-relative-packages
 import itemCss from '../../../../qti-theme/src/item.css?inline';
 
-import type { ConfigContext } from '@qti-components/base';
+import type { QtiContext } from '@qti-components/base';
 
 /**
  * `<item-container>` is a custom element designed for hosting the qti-assessment-item.
@@ -41,8 +41,10 @@ export class ItemContainer extends LitElement {
   itemXML: string = null;
 
   @state()
-  @consume({ context: configContext, subscribe: true })
-  protected configContext: ConfigContext = {};
+  @consume({ context: qtiContext, subscribe: true })
+  protected qtiContext: QtiContext = {
+    QTI_CONTEXT: { testIdentifier: '', candidateIdentifier: '', environmentIdentifier: 'default' }
+  };
 
   /** Template content if provided */
   #templateContent: unknown = null;
@@ -51,7 +53,7 @@ export class ItemContainer extends LitElement {
   protected async handleItemURLChange() {
     if (!this.itemURL) return;
     try {
-      const explicitSeed = this.configContext?.shuffleSeed;
+      const explicitSeed = this.qtiContext?.QTI_CONTEXT?.seed;
       const api = (await qtiTransformItem().load(this.itemURL)).shuffleInteractions(explicitSeed);
       this.itemDoc = api.htmlDoc();
     } catch (error) {

--- a/packages/qti-item/src/components/qti-item/qti-item.ts
+++ b/packages/qti-item/src/components/qti-item/qti-item.ts
@@ -4,9 +4,11 @@ import { customElement, state } from 'lit/decorators.js';
 
 import { computedItemContext } from '@qti-components/base';
 import { configContext } from '@qti-components/base';
+import { qtiContext } from '@qti-components/base';
 
 import type { QtiAssessmentItem } from '@qti-components/elements';
 import type { ConfigContext, CorrectResponseMode } from '@qti-components/base';
+import type { QtiContext } from '@qti-components/base';
 import type { ItemContext } from '@qti-components/base';
 import type { VariableDeclaration } from '@qti-components/base';
 import type { ComputedItemContext } from '@qti-components/base';
@@ -33,6 +35,20 @@ export class QtiItem extends LitElement {
   @state()
   @provide({ context: configContext })
   public configContext: ConfigContext = {};
+
+  /**
+   * Provided so that descendants (e.g. `<item-container>`) can read the QTI runtime
+   * context for standalone item delivery, including the optional shuffle `seed`.
+   */
+  @state()
+  @provide({ context: qtiContext })
+  public qtiContext: QtiContext = {
+    QTI_CONTEXT: {
+      testIdentifier: '',
+      candidateIdentifier: '',
+      environmentIdentifier: 'default'
+    }
+  };
 
   // Store event handlers as instance properties
   #onItemContextChanged = this.#handleItemContextChanged.bind(this);

--- a/packages/qti-test/src/components/test-container/test-container.ts
+++ b/packages/qti-test/src/components/test-container/test-container.ts
@@ -3,14 +3,14 @@ import { LitElement, html } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { until } from 'lit/directives/until.js';
 
-import { configContext } from '@qti-components/base';
+import { qtiContext } from '@qti-components/base';
 import { watch } from '@qti-components/utilities';
 import { qtiTransformTest } from '@qti-components/transformers';
 
 // eslint-disable-next-line import/no-relative-packages
 import itemCss from '../../../../qti-theme/src/item.css?inline';
 
-import type { ConfigContext } from '@qti-components/base';
+import type { QtiContext } from '@qti-components/base';
 
 /**
  * `<test-container>` is a custom element designed for hosting the qti-assessment-item.
@@ -40,8 +40,10 @@ export class TestContainer extends LitElement {
   testXML: string = null;
 
   @state()
-  @consume({ context: configContext, subscribe: true })
-  protected configContext: ConfigContext = {};
+  @consume({ context: qtiContext, subscribe: true })
+  protected qtiContext: QtiContext = {
+    QTI_CONTEXT: { testIdentifier: '', candidateIdentifier: '', environmentIdentifier: 'default' }
+  };
 
   /** Template content if provided */
   #templateContent: unknown = null;
@@ -53,7 +55,7 @@ export class TestContainer extends LitElement {
   protected async handleTestURLChange() {
     if (!this.testURL) return;
     try {
-      const explicitSeed = this.configContext?.shuffleSeed;
+      const explicitSeed = this.qtiContext?.QTI_CONTEXT?.seed;
       let api = (await qtiTransformTest().load(this.testURL)).shuffleOrdering(explicitSeed);
       // Apply external transformation if provided
       const qtiTest = this.closest('qti-test') as any; // Type assertion to access mixin properties

--- a/packages/qti-test/src/mixins/test-navigation.mixin.ts
+++ b/packages/qti-test/src/mixins/test-navigation.mixin.ts
@@ -8,6 +8,7 @@ import type { transformItemApi, transformTestApi } from '@qti-components/transfo
 import type { QtiAssessmentItemRef } from '../components/qti-assessment-item-ref/qti-assessment-item-ref';
 import type { QtiAssessmentSection } from '../components/qti-assessment-section/qti-assessment-section';
 import type { QtiAssessmentTest } from '../components/qti-assessment-test/qti-assessment-test';
+import type { TestNavigation } from '../components/test-navigation/test-navigation';
 import type { TestBaseInterface } from './test-base';
 
 type Constructor<T = {}> = abstract new (...args: any[]) => T;
@@ -473,7 +474,10 @@ export const TestNavigationMixin = <T extends Constructor<TestBaseInterface>>(su
 
     private async _loadSingleItem(itemRef: QtiAssessmentItemRef, navigationId: number, controller: AbortController) {
       try {
-        const seed = this.configContext?.shuffleSeed;
+        // The shuffle seed lives on QTI_CONTEXT, which is provided by the descendant
+        // `<test-navigation>`. Since context flows downward, read it from that element
+        // so seeded item shuffling during navigation matches `test-container`.
+        const seed = (this.querySelector('test-navigation') as TestNavigation | null)?.qtiContext?.QTI_CONTEXT?.seed;
         let transformer = (await qtiTransformItem().load(itemRef.href, controller.signal)).shuffleInteractions(seed);
 
         if (this.postLoadTransformCallback) {

--- a/packages/qti-transformers/src/qti-transform-item.ts
+++ b/packages/qti-transformers/src/qti-transform-item.ts
@@ -90,7 +90,7 @@ export const qtiTransformItem = () => {
       if (normalizedSeed === null || normalizedSeed === undefined || normalizedSeed === '') {
         const fallbackSeed = xmlUri || 'default-item-seed';
         console.warn(
-          `[qtiTransformItem] No configContext.shuffleSeed provided; using "${fallbackSeed}" as deterministic fallback seed.`
+          `[qtiTransformItem] No QTI_CONTEXT.seed provided; using "${fallbackSeed}" as deterministic fallback seed.`
         );
         shuffleInteractions(xmlFragment, fallbackSeed);
         return api;

--- a/packages/qti-transformers/src/qti-transform-test.ts
+++ b/packages/qti-transformers/src/qti-transform-test.ts
@@ -66,7 +66,7 @@ export const qtiTransformTest = (): transformTestApi => {
       if (normalizedSeed === null || normalizedSeed === undefined || normalizedSeed === '') {
         const fallbackSeed = xmlUri || 'default-test-seed';
         console.warn(
-          `[qtiTransformTest] No configContext.shuffleSeed provided; using "${fallbackSeed}" as deterministic fallback seed.`
+          `[qtiTransformTest] No QTI_CONTEXT.seed provided; using "${fallbackSeed}" as deterministic fallback seed.`
         );
         shuffleSectionsOrdering(xmlFragment, fallbackSeed);
         return api;


### PR DESCRIPTION
## Summary

Moves the deterministic shuffle seed off `configContext.shuffleSeed` and onto `QTI_CONTEXT.seed`, typed as a branded `Seed` with runtime guards.

## Changes
- **qti-base**: add `Seed` branded type + `isSeed`/`asSeed` guards to `QtiContextType`; remove `shuffleSeed` from `ConfigContext`.
- **qti-item**: `<qti-item>` now provides `qtiContext`; `item-container` reads `QTI_CONTEXT.seed`.
- **qti-test**: `test-container` and the navigation mixin read `QTI_CONTEXT.seed`.
- **qti-transformers**: update fallback warning messages.
- Regenerate `custom-elements.json` to document the new `isSeed`/`asSeed` exports.

## Versioning
Changeset `transform-item-shuffle-options` bumps `@qti-components/base`, `item`, `test`, `transformers` and `@citolab/qti-components` as **minor**.

## Notes
- The `Seed` format is validated against `/^[A-Za-z0-9-]+$/`.
- Consumer wiring (frontend `AssessmentPlayerView` + backend seed generation/tests) lives in a separate repo and is handled there.