### PR TITLE
feat(qti-theme): add rubric-block styles and element stylesheet imports

### DIFF
--- a/packages/qti-theme/src/stories/qti-theme.stories.ts
+++ b/packages/qti-theme/src/stories/qti-theme.stories.ts
@@ -46,7 +46,8 @@ window.customElements.define('button-component', ButtonComponent);
 
 // grid grid-cols-6 gap-4
 export const Theme = (_mod: string) => html`
-  <css-variable-editor></css-variable-editor>
+  <div class="rubric-block">Rubric block — this is the scoring guidance shown to candidates or markers.</div>
+
   <div style="display:grid;grid-template-columns: repeat(7, minmax(0, 1fr));gap:2rem;">
     <style>
       button-component {

--- a/packages/qti-theme/src/styles/qti-theme/elements/qti-rubric-block.css
+++ b/packages/qti-theme/src/styles/qti-theme/elements/qti-rubric-block.css
@@ -1,0 +1,13 @@
+/* Apply .rubric-block for styling qti-rubric-block content */
+.rubric-block {
+  display: block;
+  border-left: 4px solid var(--qti-correct);
+  background-color: var(--qti-correct-light);
+  color: var(--qti-correct);
+  padding: var(--qti-padding-vertical) var(--qti-padding-horizontal);
+  border-radius: var(--qti-border-radius);
+}
+
+qti-rubric-block {
+  @apply rubric-block;
+}

--- a/packages/qti-theme/src/styles/qti-theme/index.css
+++ b/packages/qti-theme/src/styles/qti-theme/index.css
@@ -1,2 +1,3 @@
 @import url('./qti-base.css');
 @import url('./qti-interactions.css');
+@import url('./qti-elements.css');

--- a/packages/qti-theme/src/styles/qti-theme/qti-base.css
+++ b/packages/qti-theme/src/styles/qti-theme/qti-base.css
@@ -5,8 +5,8 @@
   --qti-border-active: #f86d70;
 
   /* Correct colors */
-  --qti-correct-light: #c8e6c9;
-  --qti-correct: #66bb6a;
+  --qti-correct-light: #e8f5e9;
+  --qti-correct: #2e7d32;
 
   /** Partially correct colors */
   --qti-partially-correct-light: #fff3e0;

--- a/packages/qti-theme/src/styles/qti-theme/qti-elements.css
+++ b/packages/qti-theme/src/styles/qti-theme/qti-elements.css
@@ -1,0 +1,1 @@
+@import url('./elements/qti-rubric-block.css');


### PR DESCRIPTION
Closes #166

## Summary
This PR adds dedicated qti-rubric-block styling, introduces qti-elements.css as the element style aggregation point, imports it from the theme index, updates the theme story sample, and adjusts correct-state color tokens for improved contrast.

## Validation
- pnpm --filter @qti-components/theme build
