### PR TITLE
feat(qti-theme): expose ::part(drag) for editor fake-drags

### DIFF
--- a/.changeset/theme-part-drag.md
+++ b/.changeset/theme-part-drag.md
@@ -1,0 +1,11 @@
+---
+'@qti-components/theme': minor
+---
+
+Add `::part(drag)` selectors next to the existing draggable rules for
+associate, match, order, gap-match, and graphic-gap-match. Lets host
+applications (e.g. editors) style a placed fake-drag custom element exposed
+via `part="drag"` from inside the interaction's (or a child host's) shadow
+tree using the same `drag` declarations the runtime drags use. Runtime
+behavior unchanged — the existing tag-based selectors continue to style
+the light-DOM drags.

--- a/packages/qti-theme/src/styles/qti-theme/interactions/qti-associate-interaction.css
+++ b/packages/qti-theme/src/styles/qti-theme/interactions/qti-associate-interaction.css
@@ -10,7 +10,10 @@
       @apply dropping;
     }
     & qti-simple-associable-choice,
-    &::part(qti-simple-associable-choice) {
+    &::part(qti-simple-associable-choice),
+    /* Editor fake-drag projected into the interaction's drop-list shadow.
+       Same `drag` styling so editor previews match runtime visuals. */
+    &::part(drag) {
       @apply drag;
       &:hover {
         @apply hov;

--- a/packages/qti-theme/src/styles/qti-theme/interactions/qti-gap-match-interaction.css
+++ b/packages/qti-theme/src/styles/qti-theme/interactions/qti-gap-match-interaction.css
@@ -24,6 +24,17 @@
     &:state(--dragzone-enabled)::part(drags) {
       @apply dropping;
     }
+    /* Editor fake-drag projected into a filled <qti-gap>'s shadow. Same `drag`
+       styling so the editor preview matches runtime when a gap is filled. */
+    & qti-gap::part(drag) {
+      @apply drag;
+      &:hover {
+        @apply hov;
+      }
+      &:focus {
+        @apply foc;
+      }
+    }
     & qti-gap-text {
       @apply drag;
       &[dragging] {

--- a/packages/qti-theme/src/styles/qti-theme/interactions/qti-graphic-gap-match-interaction.css
+++ b/packages/qti-theme/src/styles/qti-theme/interactions/qti-graphic-gap-match-interaction.css
@@ -35,6 +35,17 @@
       align-items: center;
       cursor: grab;
     }
+    /* Editor fake-drag projected into a filled <qti-associable-hotspot>'s
+       shadow. Same `drag` styling so editor previews match runtime. */
+    & qti-associable-hotspot::part(drag) {
+      @apply drag;
+      &:hover {
+        @apply hov;
+      }
+      &:focus {
+        @apply foc;
+      }
+    }
     & qti-associable-hotspot {
       display: flex;
       justify-content: center;

--- a/packages/qti-theme/src/styles/qti-theme/interactions/qti-match-interaction.css
+++ b/packages/qti-theme/src/styles/qti-theme/interactions/qti-match-interaction.css
@@ -99,6 +99,19 @@
       background-color: var(--qti-incorrect, #f44336) !important;
     }
   }
+  /* Editor fake-drag projected into the target choice's `dropslot` shadow.
+     Reuses the same `drag` styling so the editor preview matches what students
+     see when an answer is dropped onto a target at runtime. */
+  qti-simple-associable-choice::part(drag) {
+    @apply drag;
+    &:hover {
+      @apply hov;
+    }
+    &:focus {
+      @apply foc;
+    }
+  }
+
   qti-match-interaction:not(.qti-match-tabular) {
     &:state(--dragzone-enabled) qti-simple-match-set:first-of-type {
       @apply dropping;

--- a/packages/qti-theme/src/styles/qti-theme/interactions/qti-order-interaction.css
+++ b/packages/qti-theme/src/styles/qti-theme/interactions/qti-order-interaction.css
@@ -7,7 +7,10 @@
       @apply dropping;
     }
     &::part(qti-simple-choice),
-    & qti-simple-choice {
+    & qti-simple-choice,
+    /* Editor fake-drag projected into the interaction's drop-list shadow.
+       Same `drag` styling so editor previews match runtime visuals. */
+    &::part(drag) {
       @apply drag;
       &[dragging] {
         @apply dragging;


### PR DESCRIPTION
Closes #169

## Summary
- Add `::part(drag)` selector next to the existing tag-based draggable rule in each of the five drag-drop interaction themes (associate, match, order, gap-match, graphic-gap-match).
- Each new rule applies the same `drag` / `hov` / `foc` declarations the runtime drags use, so a fake-drag custom element rendered inside a host's shadow tree gets the same visual without app-side reimplementation.
- Runtime behavior is unchanged — existing tag selectors still style the light-DOM drags. The new `::part(drag)` rules are inert in the runtime (nothing exposes that part there).

## Why
The editor (and any host application) needs to render a "placed drag" preview inside a drop target's shadow tree. Today the only way to match the theme's drag look is to duplicate the resolved `@apply drag` declarations in app CSS. With `part="drag"` on the editor's fake-drag element, `qti-theme` styles it directly.

Verified locally in the QTI Editor: a `<qti-fake-drag part="drag">` placed inside `qti-gap`'s shadow / `qti-order-interaction`'s shadow / `qti-simple-associable-choice::part(dropslot)` etc. computes the same border/bg/padding as the runtime drag.

A changeset (`.changeset/theme-part-drag.md`) is included for the minor release of `@qti-components/theme`.

## Test plan
- [ ] CI passes (lint, build, existing visual / unit tests).
- [ ] Storybook still renders the drag-drop interactions identically — no visual regression on runtime drags.
- [ ] Manual: import the published version in the QTI Editor; placed fake-drags pick up the theme `drag` look via `host::part(drag)` selectors.
