### PR TITLE
feat(qti-test): add test-item-to-speech composable TTS player

### DIFF
--- a/apps/e2e/src/stories/test.stories.ts
+++ b/apps/e2e/src/stories/test.stories.ts
@@ -96,7 +96,15 @@ export const QtiTest: Story = {
           </test-paging-buttons-stamp>
 
           <div class="flex flex-col flex-1">
-            <test-view>View</test-view><test-scoring-buttons></test-scoring-buttons>
+            <div class="flex items-center gap-2 p-2">
+              <test-view>View</test-view><test-scoring-buttons></test-scoring-buttons>
+              <test-item-to-speech language="nl-NL">
+                <test-tts-prev>◀◀</test-tts-prev>
+                <test-tts-play></test-tts-play>
+                <test-tts-next>▶▶</test-tts-next>
+                <test-tts-stop>■</test-tts-stop>
+              </test-item-to-speech>
+            </div>
             <test-container class="flex-1 overflow-auto p-2" test-url="${testURL}"></test-container>
             <nav class="flex justify-between p-2">
               <test-end-attempt>End attempt</test-end-attempt>

--- a/custom-elements.json
+++ b/custom-elements.json
@@ -40277,6 +40277,14 @@
             "name": "*",
             "module": "packages/qti-test/src/components/test-check-item/test-check-item"
           }
+        },
+        {
+          "kind": "js",
+          "name": "*",
+          "declaration": {
+            "name": "*",
+            "module": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech"
+          }
         }
       ]
     },
@@ -41677,6 +41685,757 @@
           "declaration": {
             "name": "TestItemLink",
             "module": "packages/qti-test/src/components/test-item-link/test-item-link.ts"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts",
+      "declarations": [
+        {
+          "kind": "class",
+          "description": "`<test-item-to-speech>` is the controller and context provider. It manages\nspeech synthesis, word highlighting, and item element lookup. Compose your\nown player by placing control elements as children.",
+          "name": "TestItemToSpeech",
+          "members": [
+            {
+              "kind": "field",
+              "name": "_sessionContext",
+              "type": {
+                "text": "SessionContext | undefined"
+              },
+              "privacy": "protected"
+            },
+            {
+              "kind": "field",
+              "name": "_ttsContext",
+              "type": {
+                "text": "TtsContext"
+              },
+              "default": "{ state: 'idle', currentElementIndex: 0, elementCount: 0, play: () => this.#playSpeech(), pause: () => this.#pause(), resume: () => this.#resume(), stop: () => this.#stop(), prevElement: () => this.#prevElement(), nextElement: () => this.#nextElement() }"
+            },
+            {
+              "kind": "field",
+              "name": "#boundHandleItemConnected",
+              "privacy": "private"
+            },
+            {
+              "kind": "field",
+              "name": "#boundHandleNavigation",
+              "privacy": "private"
+            },
+            {
+              "kind": "method",
+              "name": "#clearAllHighlights",
+              "privacy": "private"
+            },
+            {
+              "kind": "method",
+              "name": "#clearWordHighlight",
+              "privacy": "private"
+            },
+            {
+              "kind": "method",
+              "name": "#collectTextNodes",
+              "privacy": "private",
+              "return": {
+                "type": {
+                  "text": "Text[]"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "root",
+                  "type": {
+                    "text": "Element"
+                  }
+                }
+              ],
+              "description": "Walk text nodes without crossing shadow DOM boundaries."
+            },
+            {
+              "kind": "field",
+              "name": "#currentElementIndex",
+              "privacy": "private",
+              "type": {
+                "text": "number"
+              },
+              "default": "0"
+            },
+            {
+              "kind": "field",
+              "name": "#elementHighlight",
+              "privacy": "private",
+              "default": "new Highlight()"
+            },
+            {
+              "kind": "method",
+              "name": "#ensureHighlightStyles",
+              "privacy": "private",
+              "description": "Add ::highlight() rules both to test-container's shadow root (where highlighted\ntext lives) and to the document (safety net — spec allows document rules to apply\nacross shadow DOM). Called lazily on first highlight use so test-container is\nguaranteed to be in the DOM by the time navigation or speech starts."
+            },
+            {
+              "kind": "field",
+              "name": "#eventHost",
+              "privacy": "private",
+              "type": {
+                "text": "EventTarget | null"
+              },
+              "default": "null"
+            },
+            {
+              "kind": "method",
+              "name": "#getReadingElements",
+              "privacy": "private",
+              "return": {
+                "type": {
+                  "text": "Element[]"
+                }
+              },
+              "description": "Return cached reading elements, collecting them lazily on first call for the active item."
+            },
+            {
+              "kind": "method",
+              "name": "#handleItemConnected",
+              "privacy": "private",
+              "parameters": [
+                {
+                  "name": "event",
+                  "type": {
+                    "text": "CustomEvent<QtiAssessmentItem>"
+                  }
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "#highlightElement",
+              "privacy": "private",
+              "parameters": [
+                {
+                  "name": "element",
+                  "type": {
+                    "text": "Element"
+                  }
+                }
+              ],
+              "description": "Highlight the whole element as the navigation cursor (blue)."
+            },
+            {
+              "kind": "field",
+              "name": "#internals",
+              "privacy": "private"
+            },
+            {
+              "kind": "field",
+              "name": "#itemElements",
+              "privacy": "private",
+              "default": "new Map<string, QtiAssessmentItem>()"
+            },
+            {
+              "kind": "method",
+              "name": "#nextElement",
+              "privacy": "private"
+            },
+            {
+              "kind": "method",
+              "name": "#pause",
+              "privacy": "private"
+            },
+            {
+              "kind": "method",
+              "name": "#playSpeech",
+              "privacy": "private"
+            },
+            {
+              "kind": "method",
+              "name": "#prevElement",
+              "privacy": "private"
+            },
+            {
+              "kind": "field",
+              "name": "#prevNavItemRefId",
+              "privacy": "private",
+              "type": {
+                "text": "string | null | undefined"
+              },
+              "default": "undefined"
+            },
+            {
+              "kind": "field",
+              "name": "#readingElements",
+              "privacy": "private",
+              "type": {
+                "text": "Element[] | null"
+              },
+              "default": "null"
+            },
+            {
+              "kind": "method",
+              "name": "#resume",
+              "privacy": "private"
+            },
+            {
+              "kind": "method",
+              "name": "#setSpeechState",
+              "privacy": "private",
+              "parameters": [
+                {
+                  "name": "state",
+                  "type": {
+                    "text": "SpeechState"
+                  }
+                }
+              ],
+              "description": "Update speech state on both the context (notifies children) and the host's CSS custom states."
+            },
+            {
+              "kind": "method",
+              "name": "#speakElement",
+              "privacy": "private",
+              "parameters": [
+                {
+                  "name": "index",
+                  "type": {
+                    "text": "number"
+                  }
+                }
+              ],
+              "description": "Speak the element at the given index, then auto-advance when it ends."
+            },
+            {
+              "kind": "method",
+              "name": "#stop",
+              "privacy": "private"
+            },
+            {
+              "kind": "field",
+              "name": "#textNodes",
+              "privacy": "private",
+              "type": {
+                "text": "Text[]"
+              },
+              "default": "[]"
+            },
+            {
+              "kind": "method",
+              "name": "#updateContext",
+              "privacy": "private",
+              "description": "Push currentElementIndex and elementCount into context so children can react."
+            },
+            {
+              "kind": "method",
+              "name": "#updateWordHighlight",
+              "privacy": "private",
+              "parameters": [
+                {
+                  "name": "charIndex",
+                  "type": {
+                    "text": "number"
+                  }
+                },
+                {
+                  "name": "charLength",
+                  "type": {
+                    "text": "number"
+                  }
+                }
+              ],
+              "description": "Highlight the current word within #textNodes (yellow, during speech)."
+            },
+            {
+              "kind": "field",
+              "name": "#wordHighlight",
+              "privacy": "private",
+              "default": "new Highlight()"
+            },
+            {
+              "kind": "method",
+              "name": "#wordLengthAt",
+              "privacy": "private",
+              "return": {
+                "type": {
+                  "text": "number"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "charIndex",
+                  "type": {
+                    "text": "number"
+                  }
+                },
+                {
+                  "name": "text",
+                  "type": {
+                    "text": "string"
+                  }
+                }
+              ],
+              "description": "Fallback word-length when charLength is 0."
+            },
+            {
+              "kind": "field",
+              "name": "language",
+              "type": {
+                "text": "string"
+              },
+              "default": "'nl-NL'",
+              "attribute": "language"
+            }
+          ],
+          "attributes": [
+            {
+              "name": "language",
+              "type": {
+                "text": "string"
+              },
+              "default": "'nl-NL'",
+              "fieldName": "language"
+            }
+          ],
+          "cssStates": [
+            {
+              "description": "No speech active",
+              "name": "idle"
+            },
+            {
+              "description": "Speech is paused",
+              "name": "paused"
+            },
+            {
+              "description": "Speech is playing",
+              "name": "playing"
+            }
+          ],
+          "superclass": {
+            "name": "LitElement",
+            "package": "lit"
+          },
+          "tagName": "test-item-to-speech",
+          "customElement": true,
+          "modulePath": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts",
+          "definitionPath": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts"
+        },
+        {
+          "kind": "class",
+          "description": "Next-element button — moves cursor to the next reading element and pauses.\nDisabled at the last element or when no elements are loaded.",
+          "name": "TestTtsNext",
+          "cssParts": [
+            {
+              "name": "button"
+            }
+          ],
+          "members": [
+            {
+              "kind": "field",
+              "name": "_tts",
+              "type": {
+                "text": "TtsContext | undefined"
+              },
+              "privacy": "protected",
+              "inheritedFrom": {
+                "name": "TtsButtonBase",
+                "module": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "#internals",
+              "privacy": "private",
+              "inheritedFrom": {
+                "name": "TtsButtonBase",
+                "module": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts"
+              }
+            }
+          ],
+          "cssStates": [
+            {
+              "description": "/ playing / paused",
+              "name": "idle"
+            }
+          ],
+          "superclass": {
+            "name": "TtsButtonBase",
+            "module": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts"
+          },
+          "tagName": "test-tts-next",
+          "customElement": true,
+          "modulePath": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts",
+          "definitionPath": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts"
+        },
+        {
+          "kind": "class",
+          "description": "Pause button — enabled only when playing.",
+          "name": "TestTtsPause",
+          "cssParts": [
+            {
+              "name": "button"
+            }
+          ],
+          "members": [
+            {
+              "kind": "field",
+              "name": "_tts",
+              "type": {
+                "text": "TtsContext | undefined"
+              },
+              "privacy": "protected",
+              "inheritedFrom": {
+                "name": "TtsButtonBase",
+                "module": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "#internals",
+              "privacy": "private",
+              "inheritedFrom": {
+                "name": "TtsButtonBase",
+                "module": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts"
+              }
+            }
+          ],
+          "cssStates": [
+            {
+              "description": "/ playing / paused",
+              "name": "idle"
+            }
+          ],
+          "superclass": {
+            "name": "TtsButtonBase",
+            "module": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts"
+          },
+          "tagName": "test-tts-pause",
+          "customElement": true,
+          "modulePath": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts",
+          "definitionPath": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts"
+        },
+        {
+          "kind": "class",
+          "description": "Play/pause/resume toggle button — always enabled, cycles through states.\nUse named slots `play` and `pause` to customise the icons/labels independently.",
+          "name": "TestTtsPlay",
+          "cssParts": [
+            {
+              "name": "button"
+            }
+          ],
+          "members": [
+            {
+              "kind": "field",
+              "name": "_tts",
+              "type": {
+                "text": "TtsContext | undefined"
+              },
+              "privacy": "protected",
+              "inheritedFrom": {
+                "name": "TtsButtonBase",
+                "module": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "#internals",
+              "privacy": "private",
+              "inheritedFrom": {
+                "name": "TtsButtonBase",
+                "module": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts"
+              }
+            },
+            {
+              "kind": "method",
+              "name": "#toggle",
+              "privacy": "private"
+            }
+          ],
+          "cssStates": [
+            {
+              "description": "/ playing / paused",
+              "name": "idle"
+            }
+          ],
+          "superclass": {
+            "name": "TtsButtonBase",
+            "module": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts"
+          },
+          "tagName": "test-tts-play",
+          "customElement": true,
+          "modulePath": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts",
+          "definitionPath": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts"
+        },
+        {
+          "kind": "class",
+          "description": "Prev-element button — moves cursor to the previous reading element and pauses.\nDisabled at the first element or when no elements are loaded.",
+          "name": "TestTtsPrev",
+          "cssParts": [
+            {
+              "name": "button"
+            }
+          ],
+          "members": [
+            {
+              "kind": "field",
+              "name": "_tts",
+              "type": {
+                "text": "TtsContext | undefined"
+              },
+              "privacy": "protected",
+              "inheritedFrom": {
+                "name": "TtsButtonBase",
+                "module": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "#internals",
+              "privacy": "private",
+              "inheritedFrom": {
+                "name": "TtsButtonBase",
+                "module": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts"
+              }
+            }
+          ],
+          "cssStates": [
+            {
+              "description": "/ playing / paused",
+              "name": "idle"
+            }
+          ],
+          "superclass": {
+            "name": "TtsButtonBase",
+            "module": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts"
+          },
+          "tagName": "test-tts-prev",
+          "customElement": true,
+          "modulePath": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts",
+          "definitionPath": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts"
+        },
+        {
+          "kind": "class",
+          "description": "Resume button — enabled only when paused.",
+          "name": "TestTtsResume",
+          "cssParts": [
+            {
+              "name": "button"
+            }
+          ],
+          "members": [
+            {
+              "kind": "field",
+              "name": "_tts",
+              "type": {
+                "text": "TtsContext | undefined"
+              },
+              "privacy": "protected",
+              "inheritedFrom": {
+                "name": "TtsButtonBase",
+                "module": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "#internals",
+              "privacy": "private",
+              "inheritedFrom": {
+                "name": "TtsButtonBase",
+                "module": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts"
+              }
+            }
+          ],
+          "cssStates": [
+            {
+              "description": "/ playing / paused",
+              "name": "idle"
+            }
+          ],
+          "superclass": {
+            "name": "TtsButtonBase",
+            "module": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts"
+          },
+          "tagName": "test-tts-resume",
+          "customElement": true,
+          "modulePath": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts",
+          "definitionPath": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts"
+        },
+        {
+          "kind": "class",
+          "description": "Stop button — enabled when playing or paused.",
+          "name": "TestTtsStop",
+          "cssParts": [
+            {
+              "name": "button"
+            }
+          ],
+          "members": [
+            {
+              "kind": "field",
+              "name": "_tts",
+              "type": {
+                "text": "TtsContext | undefined"
+              },
+              "privacy": "protected",
+              "inheritedFrom": {
+                "name": "TtsButtonBase",
+                "module": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "#internals",
+              "privacy": "private",
+              "inheritedFrom": {
+                "name": "TtsButtonBase",
+                "module": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts"
+              }
+            }
+          ],
+          "cssStates": [
+            {
+              "description": "/ playing / paused",
+              "name": "idle"
+            }
+          ],
+          "superclass": {
+            "name": "TtsButtonBase",
+            "module": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts"
+          },
+          "tagName": "test-tts-stop",
+          "customElement": true,
+          "modulePath": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts",
+          "definitionPath": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts"
+        },
+        {
+          "kind": "variable",
+          "name": "ttsContext"
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "SpeechState",
+          "declaration": {
+            "name": "SpeechState",
+            "module": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "name": "test-item-to-speech",
+          "declaration": {
+            "name": "TestItemToSpeech",
+            "module": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "name": "test-tts-next",
+          "declaration": {
+            "name": "TestTtsNext",
+            "module": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "name": "test-tts-pause",
+          "declaration": {
+            "name": "TestTtsPause",
+            "module": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "name": "test-tts-play",
+          "declaration": {
+            "name": "TestTtsPlay",
+            "module": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "name": "test-tts-prev",
+          "declaration": {
+            "name": "TestTtsPrev",
+            "module": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "name": "test-tts-resume",
+          "declaration": {
+            "name": "TestTtsResume",
+            "module": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "name": "test-tts-stop",
+          "declaration": {
+            "name": "TestTtsStop",
+            "module": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "TestItemToSpeech",
+          "declaration": {
+            "name": "TestItemToSpeech",
+            "module": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "TestTtsNext",
+          "declaration": {
+            "name": "TestTtsNext",
+            "module": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "TestTtsPause",
+          "declaration": {
+            "name": "TestTtsPause",
+            "module": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "TestTtsPlay",
+          "declaration": {
+            "name": "TestTtsPlay",
+            "module": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "TestTtsPrev",
+          "declaration": {
+            "name": "TestTtsPrev",
+            "module": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "TestTtsResume",
+          "declaration": {
+            "name": "TestTtsResume",
+            "module": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "TestTtsStop",
+          "declaration": {
+            "name": "TestTtsStop",
+            "module": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "ttsContext",
+          "declaration": {
+            "name": "ttsContext",
+            "module": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts"
           }
         }
       ]

--- a/packages/qti-components/custom-elements.json
+++ b/packages/qti-components/custom-elements.json
@@ -40277,6 +40277,14 @@
             "name": "*",
             "module": "packages/qti-test/src/components/test-check-item/test-check-item"
           }
+        },
+        {
+          "kind": "js",
+          "name": "*",
+          "declaration": {
+            "name": "*",
+            "module": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech"
+          }
         }
       ]
     },
@@ -41677,6 +41685,757 @@
           "declaration": {
             "name": "TestItemLink",
             "module": "packages/qti-test/src/components/test-item-link/test-item-link.ts"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts",
+      "declarations": [
+        {
+          "kind": "class",
+          "description": "`<test-item-to-speech>` is the controller and context provider. It manages\nspeech synthesis, word highlighting, and item element lookup. Compose your\nown player by placing control elements as children.",
+          "name": "TestItemToSpeech",
+          "members": [
+            {
+              "kind": "field",
+              "name": "_sessionContext",
+              "type": {
+                "text": "SessionContext | undefined"
+              },
+              "privacy": "protected"
+            },
+            {
+              "kind": "field",
+              "name": "_ttsContext",
+              "type": {
+                "text": "TtsContext"
+              },
+              "default": "{ state: 'idle', currentElementIndex: 0, elementCount: 0, play: () => this.#playSpeech(), pause: () => this.#pause(), resume: () => this.#resume(), stop: () => this.#stop(), prevElement: () => this.#prevElement(), nextElement: () => this.#nextElement() }"
+            },
+            {
+              "kind": "field",
+              "name": "#boundHandleItemConnected",
+              "privacy": "private"
+            },
+            {
+              "kind": "field",
+              "name": "#boundHandleNavigation",
+              "privacy": "private"
+            },
+            {
+              "kind": "method",
+              "name": "#clearAllHighlights",
+              "privacy": "private"
+            },
+            {
+              "kind": "method",
+              "name": "#clearWordHighlight",
+              "privacy": "private"
+            },
+            {
+              "kind": "method",
+              "name": "#collectTextNodes",
+              "privacy": "private",
+              "return": {
+                "type": {
+                  "text": "Text[]"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "root",
+                  "type": {
+                    "text": "Element"
+                  }
+                }
+              ],
+              "description": "Walk text nodes without crossing shadow DOM boundaries."
+            },
+            {
+              "kind": "field",
+              "name": "#currentElementIndex",
+              "privacy": "private",
+              "type": {
+                "text": "number"
+              },
+              "default": "0"
+            },
+            {
+              "kind": "field",
+              "name": "#elementHighlight",
+              "privacy": "private",
+              "default": "new Highlight()"
+            },
+            {
+              "kind": "method",
+              "name": "#ensureHighlightStyles",
+              "privacy": "private",
+              "description": "Add ::highlight() rules both to test-container's shadow root (where highlighted\ntext lives) and to the document (safety net — spec allows document rules to apply\nacross shadow DOM). Called lazily on first highlight use so test-container is\nguaranteed to be in the DOM by the time navigation or speech starts."
+            },
+            {
+              "kind": "field",
+              "name": "#eventHost",
+              "privacy": "private",
+              "type": {
+                "text": "EventTarget | null"
+              },
+              "default": "null"
+            },
+            {
+              "kind": "method",
+              "name": "#getReadingElements",
+              "privacy": "private",
+              "return": {
+                "type": {
+                  "text": "Element[]"
+                }
+              },
+              "description": "Return cached reading elements, collecting them lazily on first call for the active item."
+            },
+            {
+              "kind": "method",
+              "name": "#handleItemConnected",
+              "privacy": "private",
+              "parameters": [
+                {
+                  "name": "event",
+                  "type": {
+                    "text": "CustomEvent<QtiAssessmentItem>"
+                  }
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "#highlightElement",
+              "privacy": "private",
+              "parameters": [
+                {
+                  "name": "element",
+                  "type": {
+                    "text": "Element"
+                  }
+                }
+              ],
+              "description": "Highlight the whole element as the navigation cursor (blue)."
+            },
+            {
+              "kind": "field",
+              "name": "#internals",
+              "privacy": "private"
+            },
+            {
+              "kind": "field",
+              "name": "#itemElements",
+              "privacy": "private",
+              "default": "new Map<string, QtiAssessmentItem>()"
+            },
+            {
+              "kind": "method",
+              "name": "#nextElement",
+              "privacy": "private"
+            },
+            {
+              "kind": "method",
+              "name": "#pause",
+              "privacy": "private"
+            },
+            {
+              "kind": "method",
+              "name": "#playSpeech",
+              "privacy": "private"
+            },
+            {
+              "kind": "method",
+              "name": "#prevElement",
+              "privacy": "private"
+            },
+            {
+              "kind": "field",
+              "name": "#prevNavItemRefId",
+              "privacy": "private",
+              "type": {
+                "text": "string | null | undefined"
+              },
+              "default": "undefined"
+            },
+            {
+              "kind": "field",
+              "name": "#readingElements",
+              "privacy": "private",
+              "type": {
+                "text": "Element[] | null"
+              },
+              "default": "null"
+            },
+            {
+              "kind": "method",
+              "name": "#resume",
+              "privacy": "private"
+            },
+            {
+              "kind": "method",
+              "name": "#setSpeechState",
+              "privacy": "private",
+              "parameters": [
+                {
+                  "name": "state",
+                  "type": {
+                    "text": "SpeechState"
+                  }
+                }
+              ],
+              "description": "Update speech state on both the context (notifies children) and the host's CSS custom states."
+            },
+            {
+              "kind": "method",
+              "name": "#speakElement",
+              "privacy": "private",
+              "parameters": [
+                {
+                  "name": "index",
+                  "type": {
+                    "text": "number"
+                  }
+                }
+              ],
+              "description": "Speak the element at the given index, then auto-advance when it ends."
+            },
+            {
+              "kind": "method",
+              "name": "#stop",
+              "privacy": "private"
+            },
+            {
+              "kind": "field",
+              "name": "#textNodes",
+              "privacy": "private",
+              "type": {
+                "text": "Text[]"
+              },
+              "default": "[]"
+            },
+            {
+              "kind": "method",
+              "name": "#updateContext",
+              "privacy": "private",
+              "description": "Push currentElementIndex and elementCount into context so children can react."
+            },
+            {
+              "kind": "method",
+              "name": "#updateWordHighlight",
+              "privacy": "private",
+              "parameters": [
+                {
+                  "name": "charIndex",
+                  "type": {
+                    "text": "number"
+                  }
+                },
+                {
+                  "name": "charLength",
+                  "type": {
+                    "text": "number"
+                  }
+                }
+              ],
+              "description": "Highlight the current word within #textNodes (yellow, during speech)."
+            },
+            {
+              "kind": "field",
+              "name": "#wordHighlight",
+              "privacy": "private",
+              "default": "new Highlight()"
+            },
+            {
+              "kind": "method",
+              "name": "#wordLengthAt",
+              "privacy": "private",
+              "return": {
+                "type": {
+                  "text": "number"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "charIndex",
+                  "type": {
+                    "text": "number"
+                  }
+                },
+                {
+                  "name": "text",
+                  "type": {
+                    "text": "string"
+                  }
+                }
+              ],
+              "description": "Fallback word-length when charLength is 0."
+            },
+            {
+              "kind": "field",
+              "name": "language",
+              "type": {
+                "text": "string"
+              },
+              "default": "'nl-NL'",
+              "attribute": "language"
+            }
+          ],
+          "attributes": [
+            {
+              "name": "language",
+              "type": {
+                "text": "string"
+              },
+              "default": "'nl-NL'",
+              "fieldName": "language"
+            }
+          ],
+          "cssStates": [
+            {
+              "description": "No speech active",
+              "name": "idle"
+            },
+            {
+              "description": "Speech is paused",
+              "name": "paused"
+            },
+            {
+              "description": "Speech is playing",
+              "name": "playing"
+            }
+          ],
+          "superclass": {
+            "name": "LitElement",
+            "package": "lit"
+          },
+          "tagName": "test-item-to-speech",
+          "customElement": true,
+          "modulePath": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts",
+          "definitionPath": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts"
+        },
+        {
+          "kind": "class",
+          "description": "Next-element button — moves cursor to the next reading element and pauses.\nDisabled at the last element or when no elements are loaded.",
+          "name": "TestTtsNext",
+          "cssParts": [
+            {
+              "name": "button"
+            }
+          ],
+          "members": [
+            {
+              "kind": "field",
+              "name": "_tts",
+              "type": {
+                "text": "TtsContext | undefined"
+              },
+              "privacy": "protected",
+              "inheritedFrom": {
+                "name": "TtsButtonBase",
+                "module": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "#internals",
+              "privacy": "private",
+              "inheritedFrom": {
+                "name": "TtsButtonBase",
+                "module": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts"
+              }
+            }
+          ],
+          "cssStates": [
+            {
+              "description": "/ playing / paused",
+              "name": "idle"
+            }
+          ],
+          "superclass": {
+            "name": "TtsButtonBase",
+            "module": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts"
+          },
+          "tagName": "test-tts-next",
+          "customElement": true,
+          "modulePath": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts",
+          "definitionPath": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts"
+        },
+        {
+          "kind": "class",
+          "description": "Pause button — enabled only when playing.",
+          "name": "TestTtsPause",
+          "cssParts": [
+            {
+              "name": "button"
+            }
+          ],
+          "members": [
+            {
+              "kind": "field",
+              "name": "_tts",
+              "type": {
+                "text": "TtsContext | undefined"
+              },
+              "privacy": "protected",
+              "inheritedFrom": {
+                "name": "TtsButtonBase",
+                "module": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "#internals",
+              "privacy": "private",
+              "inheritedFrom": {
+                "name": "TtsButtonBase",
+                "module": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts"
+              }
+            }
+          ],
+          "cssStates": [
+            {
+              "description": "/ playing / paused",
+              "name": "idle"
+            }
+          ],
+          "superclass": {
+            "name": "TtsButtonBase",
+            "module": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts"
+          },
+          "tagName": "test-tts-pause",
+          "customElement": true,
+          "modulePath": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts",
+          "definitionPath": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts"
+        },
+        {
+          "kind": "class",
+          "description": "Play/pause/resume toggle button — always enabled, cycles through states.\nUse named slots `play` and `pause` to customise the icons/labels independently.",
+          "name": "TestTtsPlay",
+          "cssParts": [
+            {
+              "name": "button"
+            }
+          ],
+          "members": [
+            {
+              "kind": "field",
+              "name": "_tts",
+              "type": {
+                "text": "TtsContext | undefined"
+              },
+              "privacy": "protected",
+              "inheritedFrom": {
+                "name": "TtsButtonBase",
+                "module": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "#internals",
+              "privacy": "private",
+              "inheritedFrom": {
+                "name": "TtsButtonBase",
+                "module": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts"
+              }
+            },
+            {
+              "kind": "method",
+              "name": "#toggle",
+              "privacy": "private"
+            }
+          ],
+          "cssStates": [
+            {
+              "description": "/ playing / paused",
+              "name": "idle"
+            }
+          ],
+          "superclass": {
+            "name": "TtsButtonBase",
+            "module": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts"
+          },
+          "tagName": "test-tts-play",
+          "customElement": true,
+          "modulePath": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts",
+          "definitionPath": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts"
+        },
+        {
+          "kind": "class",
+          "description": "Prev-element button — moves cursor to the previous reading element and pauses.\nDisabled at the first element or when no elements are loaded.",
+          "name": "TestTtsPrev",
+          "cssParts": [
+            {
+              "name": "button"
+            }
+          ],
+          "members": [
+            {
+              "kind": "field",
+              "name": "_tts",
+              "type": {
+                "text": "TtsContext | undefined"
+              },
+              "privacy": "protected",
+              "inheritedFrom": {
+                "name": "TtsButtonBase",
+                "module": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "#internals",
+              "privacy": "private",
+              "inheritedFrom": {
+                "name": "TtsButtonBase",
+                "module": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts"
+              }
+            }
+          ],
+          "cssStates": [
+            {
+              "description": "/ playing / paused",
+              "name": "idle"
+            }
+          ],
+          "superclass": {
+            "name": "TtsButtonBase",
+            "module": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts"
+          },
+          "tagName": "test-tts-prev",
+          "customElement": true,
+          "modulePath": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts",
+          "definitionPath": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts"
+        },
+        {
+          "kind": "class",
+          "description": "Resume button — enabled only when paused.",
+          "name": "TestTtsResume",
+          "cssParts": [
+            {
+              "name": "button"
+            }
+          ],
+          "members": [
+            {
+              "kind": "field",
+              "name": "_tts",
+              "type": {
+                "text": "TtsContext | undefined"
+              },
+              "privacy": "protected",
+              "inheritedFrom": {
+                "name": "TtsButtonBase",
+                "module": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "#internals",
+              "privacy": "private",
+              "inheritedFrom": {
+                "name": "TtsButtonBase",
+                "module": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts"
+              }
+            }
+          ],
+          "cssStates": [
+            {
+              "description": "/ playing / paused",
+              "name": "idle"
+            }
+          ],
+          "superclass": {
+            "name": "TtsButtonBase",
+            "module": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts"
+          },
+          "tagName": "test-tts-resume",
+          "customElement": true,
+          "modulePath": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts",
+          "definitionPath": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts"
+        },
+        {
+          "kind": "class",
+          "description": "Stop button — enabled when playing or paused.",
+          "name": "TestTtsStop",
+          "cssParts": [
+            {
+              "name": "button"
+            }
+          ],
+          "members": [
+            {
+              "kind": "field",
+              "name": "_tts",
+              "type": {
+                "text": "TtsContext | undefined"
+              },
+              "privacy": "protected",
+              "inheritedFrom": {
+                "name": "TtsButtonBase",
+                "module": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "#internals",
+              "privacy": "private",
+              "inheritedFrom": {
+                "name": "TtsButtonBase",
+                "module": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts"
+              }
+            }
+          ],
+          "cssStates": [
+            {
+              "description": "/ playing / paused",
+              "name": "idle"
+            }
+          ],
+          "superclass": {
+            "name": "TtsButtonBase",
+            "module": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts"
+          },
+          "tagName": "test-tts-stop",
+          "customElement": true,
+          "modulePath": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts",
+          "definitionPath": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts"
+        },
+        {
+          "kind": "variable",
+          "name": "ttsContext"
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "SpeechState",
+          "declaration": {
+            "name": "SpeechState",
+            "module": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "name": "test-item-to-speech",
+          "declaration": {
+            "name": "TestItemToSpeech",
+            "module": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "name": "test-tts-next",
+          "declaration": {
+            "name": "TestTtsNext",
+            "module": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "name": "test-tts-pause",
+          "declaration": {
+            "name": "TestTtsPause",
+            "module": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "name": "test-tts-play",
+          "declaration": {
+            "name": "TestTtsPlay",
+            "module": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "name": "test-tts-prev",
+          "declaration": {
+            "name": "TestTtsPrev",
+            "module": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "name": "test-tts-resume",
+          "declaration": {
+            "name": "TestTtsResume",
+            "module": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "name": "test-tts-stop",
+          "declaration": {
+            "name": "TestTtsStop",
+            "module": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "TestItemToSpeech",
+          "declaration": {
+            "name": "TestItemToSpeech",
+            "module": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "TestTtsNext",
+          "declaration": {
+            "name": "TestTtsNext",
+            "module": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "TestTtsPause",
+          "declaration": {
+            "name": "TestTtsPause",
+            "module": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "TestTtsPlay",
+          "declaration": {
+            "name": "TestTtsPlay",
+            "module": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "TestTtsPrev",
+          "declaration": {
+            "name": "TestTtsPrev",
+            "module": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "TestTtsResume",
+          "declaration": {
+            "name": "TestTtsResume",
+            "module": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "TestTtsStop",
+          "declaration": {
+            "name": "TestTtsStop",
+            "module": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "ttsContext",
+          "declaration": {
+            "name": "ttsContext",
+            "module": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts"
           }
         }
       ]

--- a/packages/qti-test/src/components/index.ts
+++ b/packages/qti-test/src/components/index.ts
@@ -24,3 +24,4 @@ export * from './test-scoring-buttons/test-scoring-buttons';
 export * from './test-view-toggle/test-view-toggle';
 export * from './test-scoring-feedback/test-scoring-feedback';
 export * from './test-check-item/test-check-item';
+export * from './test-item-to-speech/test-item-to-speech';

--- a/packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts
+++ b/packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts
@@ -1,0 +1,589 @@
+import { html, LitElement, css } from 'lit';
+import { consume, provide, createContext } from '@lit/context';
+import { customElement, property, state } from 'lit/decorators.js';
+
+import { sessionContext } from '@qti-components/base';
+
+import type { PropertyValues } from 'lit';
+import type { SessionContext } from '@qti-components/base';
+import type { QtiAssessmentItem } from '@qti-components/elements';
+
+// ─── CSS Custom Highlight ─────────────────────────────────────────────────────
+
+const HIGHLIGHT_ELEMENT = 'tts-element'; // navigation cursor — whole element
+const HIGHLIGHT_WORD = 'tts-word'; // word boundary during speech
+
+// Shared across all instances — added to whichever shadow root needs it
+let highlightSheet: CSSStyleSheet | null = null;
+
+function getHighlightSheet(): CSSStyleSheet {
+  if (!highlightSheet) {
+    highlightSheet = new CSSStyleSheet();
+    highlightSheet.replaceSync(`
+      ::highlight(${HIGHLIGHT_ELEMENT}) { background-color: #dbeafe; color: inherit; }
+      ::highlight(${HIGHLIGHT_WORD})    { background-color: #ffe066; color: inherit; }
+    `);
+  }
+  return highlightSheet;
+}
+
+type SpeechState = 'idle' | 'playing' | 'paused';
+
+// ─── TTS Context ──────────────────────────────────────────────────────────────
+
+export interface TtsContext {
+  state: SpeechState;
+  /** Index of the currently highlighted reading element (0-based). */
+  currentElementIndex: number;
+  /** Total number of navigable reading elements in the current item. */
+  elementCount: number;
+  play(): void;
+  pause(): void;
+  resume(): void;
+  stop(): void;
+  prevElement(): void;
+  nextElement(): void;
+}
+
+export { SpeechState };
+export const ttsContext = createContext<TtsContext>(Symbol('tts-context'));
+
+// ─── Shared base for child button elements ────────────────────────────────────
+
+/**
+ * Base class shared by all TTS control elements. Consumes `ttsContext` and
+ * mirrors the current speech state onto CSS custom states so each child can
+ * be styled with `:state(playing)`, `:state(paused)`, `:state(idle)`.
+ */
+abstract class TtsButtonBase extends LitElement {
+  static override styles = css`
+    :host {
+      display: inline-block;
+    }
+    button {
+      cursor: pointer;
+    }
+    button:disabled {
+      opacity: 0.4;
+      cursor: default;
+    }
+  `;
+
+  #internals = this.attachInternals();
+
+  @consume({ context: ttsContext, subscribe: true })
+  protected _tts?: TtsContext;
+
+  override updated(changed: PropertyValues) {
+    if (changed.has('_tts')) {
+      this.#internals.states.clear();
+      if (this._tts?.state) this.#internals.states.add(this._tts.state);
+    }
+  }
+}
+
+// ─── Controller element ───────────────────────────────────────────────────────
+
+/**
+ * `<test-item-to-speech>` is the controller and context provider. It manages
+ * speech synthesis, word highlighting, and item element lookup. Compose your
+ * own player by placing control elements as children.
+ *
+ * @example
+ * ```html
+ * <test-item-to-speech language="nl-NL">
+ *   <test-tts-play></test-tts-play>
+ *   <test-tts-prev>◀◀</test-tts-prev>
+ *   <test-tts-next>▶▶</test-tts-next>
+ *   <test-tts-stop>■</test-tts-stop>
+ * </test-item-to-speech>
+ * ```
+ *
+ * @cssstate idle    - No speech active
+ * @cssstate playing - Speech is playing
+ * @cssstate paused  - Speech is paused
+ */
+@customElement('test-item-to-speech')
+export class TestItemToSpeech extends LitElement {
+  @property({ type: String }) language = 'nl-NL';
+
+  @consume({ context: sessionContext, subscribe: true })
+  protected _sessionContext?: SessionContext;
+
+  @state()
+  @provide({ context: ttsContext })
+  _ttsContext!: TtsContext;
+
+  #internals = this.attachInternals();
+  #itemElements = new Map<string, QtiAssessmentItem>();
+  #boundHandleItemConnected = this.#handleItemConnected.bind(this);
+  #eventHost: EventTarget | null = null;
+
+  // Current set of block-level reading elements for the active item
+  #readingElements: Element[] | null = null;
+  #currentElementIndex = 0;
+
+  // Text nodes of the element currently being spoken (for word-boundary highlight)
+  #textNodes: Text[] = [];
+
+  // Two separate CSS Highlight objects
+  #elementHighlight = new Highlight(); // whole-element cursor
+  #wordHighlight = new Highlight(); // current word during speech
+
+  // Tracks previous navItemRefId to detect item switches
+  #prevNavItemRefId: string | null | undefined = undefined;
+  #boundHandleNavigation = () => this.#stop();
+
+  constructor() {
+    super();
+    this._ttsContext = {
+      state: 'idle',
+      currentElementIndex: 0,
+      elementCount: 0,
+      play: () => this.#playSpeech(),
+      pause: () => this.#pause(),
+      resume: () => this.#resume(),
+      stop: () => this.#stop(),
+      prevElement: () => this.#prevElement(),
+      nextElement: () => this.#nextElement()
+    };
+  }
+
+  override willUpdate(changed: PropertyValues) {
+    // no property-driven context updates needed currently
+    void changed;
+  }
+
+  override updated(_changed: PropertyValues) {
+    const current = this._sessionContext?.navItemRefId ?? null;
+    // Stop speech when navItemRefId changes (ignore the initial undefined → value transition)
+    if (this.#prevNavItemRefId !== undefined && this.#prevNavItemRefId !== current) {
+      this.#stop();
+      // Reset element collection for the new item
+      this.#readingElements = null;
+      this.#currentElementIndex = 0;
+      this.#updateContext();
+    }
+    this.#prevNavItemRefId = current;
+  }
+
+  override connectedCallback() {
+    super.connectedCallback();
+    this.#setSpeechState('idle');
+    // NOTE: #ensureHighlightStyles() is called lazily on first highlight use
+    // because test-container may not be in the DOM yet at this point.
+    // qti-assessment-item-connected is bubbles+composed, so it reaches test-navigation / qti-test
+    this.#eventHost =
+      this.closest('test-navigation') ?? this.closest('qti-test') ?? (this.getRootNode() as EventTarget);
+    this.#eventHost.addEventListener('qti-assessment-item-connected', this.#boundHandleItemConnected as EventListener);
+    // qti-request-navigation fires synchronously when the user clicks prev/next — stop immediately
+    this.#eventHost.addEventListener('qti-request-navigation', this.#boundHandleNavigation);
+  }
+
+  override disconnectedCallback() {
+    super.disconnectedCallback();
+    speechSynthesis.cancel();
+    this.#clearAllHighlights();
+    this.#eventHost?.removeEventListener(
+      'qti-assessment-item-connected',
+      this.#boundHandleItemConnected as EventListener
+    );
+    this.#eventHost?.removeEventListener('qti-request-navigation', this.#boundHandleNavigation);
+    this.#eventHost = null;
+    this.#itemElements.clear();
+  }
+
+  override render() {
+    return html`<slot></slot>`;
+  }
+
+  #handleItemConnected(event: CustomEvent<QtiAssessmentItem>) {
+    const item = event.detail;
+    if (item?.identifier) {
+      this.#itemElements.set(item.identifier, item);
+    }
+  }
+
+  /** Update speech state on both the context (notifies children) and the host's CSS custom states. */
+  #setSpeechState(state: SpeechState) {
+    this._ttsContext = { ...this._ttsContext, state };
+    this.#internals.states.delete('idle');
+    this.#internals.states.delete('playing');
+    this.#internals.states.delete('paused');
+    this.#internals.states.add(state);
+  }
+
+  /** Push currentElementIndex and elementCount into context so children can react. */
+  #updateContext() {
+    this._ttsContext = {
+      ...this._ttsContext,
+      currentElementIndex: this.#currentElementIndex,
+      elementCount: this.#readingElements?.length ?? 0
+    };
+  }
+
+  /** Return cached reading elements, collecting them lazily on first call for the active item. */
+  #getReadingElements(): Element[] {
+    if (this.#readingElements !== null) return this.#readingElements;
+
+    const identifier = this._sessionContext?.navItemRefId;
+    if (!identifier) return [];
+
+    const assessmentItem = this.#itemElements.get(identifier);
+    if (!assessmentItem) return [];
+
+    const itemBody = assessmentItem.querySelector('qti-item-body');
+    if (!itemBody) return [];
+
+    // Collect block-level elements that contain readable text
+    const selector = 'p, h1, h2, h3, h4, h5, h6, li, blockquote, figcaption';
+    this.#readingElements = Array.from(itemBody.querySelectorAll(selector)).filter(
+      el => (el.textContent ?? '').trim().length > 0
+    );
+
+    return this.#readingElements;
+  }
+
+  #playSpeech() {
+    const elements = this.#getReadingElements();
+    if (!elements.length) {
+      console.warn('test-item-to-speech: no readable elements found in qti-item-body');
+      return;
+    }
+    this.#speakElement(this.#currentElementIndex);
+  }
+
+  /** Speak the element at the given index, then auto-advance when it ends. */
+  #speakElement(index: number) {
+    const elements = this.#readingElements ?? [];
+
+    if (index >= elements.length) {
+      // Finished all elements — stay on the last element so the user can walk back with prev
+      this.#clearWordHighlight();
+      this.#currentElementIndex = elements.length - 1;
+      if (elements.length > 0) this.#highlightElement(elements[this.#currentElementIndex]);
+      this.#setSpeechState('idle');
+      this.#updateContext();
+      return;
+    }
+
+    this.#currentElementIndex = index;
+    this.#updateContext();
+
+    const element = elements[index];
+    element.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+    this.#highlightElement(element);
+
+    // Collect text nodes of this element for word-boundary mapping
+    this.#textNodes = this.#collectTextNodes(element);
+    const text = this.#textNodes.map(n => n.textContent ?? '').join('');
+
+    if (!text.trim()) {
+      // Skip blank element and move to next
+      this.#speakElement(index + 1);
+      return;
+    }
+
+    const utterance = new SpeechSynthesisUtterance(text);
+    utterance.lang = this.language;
+    utterance.rate = 1;
+
+    utterance.onboundary = (event: SpeechSynthesisEvent) => {
+      if (event.name !== 'word') return;
+      this.#updateWordHighlight(event.charIndex, event.charLength ?? 0);
+    };
+
+    utterance.onend = () => {
+      this.#clearWordHighlight();
+      this.#speakElement(this.#currentElementIndex + 1);
+    };
+
+    speechSynthesis.speak(utterance);
+    this.#setSpeechState('playing');
+  }
+
+  #pause() {
+    speechSynthesis.pause();
+    this.#setSpeechState('paused');
+  }
+
+  #resume() {
+    speechSynthesis.resume();
+    this.#setSpeechState('playing');
+  }
+
+  #stop() {
+    speechSynthesis.cancel();
+    this.#clearAllHighlights();
+    this.#setSpeechState('idle');
+  }
+
+  #prevElement() {
+    const elements = this.#getReadingElements();
+    if (!elements.length) return;
+    speechSynthesis.cancel();
+    this.#clearWordHighlight();
+    this.#currentElementIndex = Math.max(0, this.#currentElementIndex - 1);
+    this.#updateContext();
+    const el = elements[this.#currentElementIndex];
+    el.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+    this.#highlightElement(el);
+    this.#setSpeechState('idle');
+  }
+
+  #nextElement() {
+    const elements = this.#getReadingElements();
+    if (!elements.length) return;
+    speechSynthesis.cancel();
+    this.#clearWordHighlight();
+    this.#currentElementIndex = Math.min(elements.length - 1, this.#currentElementIndex + 1);
+    this.#updateContext();
+    const el = elements[this.#currentElementIndex];
+    el.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+    this.#highlightElement(el);
+    this.#setSpeechState('idle');
+  }
+
+  /** Walk text nodes without crossing shadow DOM boundaries. */
+  #collectTextNodes(root: Element): Text[] {
+    const nodes: Text[] = [];
+    const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+    let node: Node | null;
+    while ((node = walker.nextNode())) {
+      if ((node.textContent ?? '').length > 0) {
+        nodes.push(node as Text);
+      }
+    }
+    return nodes;
+  }
+
+  /** Highlight the whole element as the navigation cursor (blue). */
+  #highlightElement(element: Element) {
+    if (!('highlights' in CSS)) return;
+    this.#ensureHighlightStyles();
+    this.#elementHighlight.clear();
+    const range = new Range();
+    range.selectNodeContents(element);
+    this.#elementHighlight.add(range);
+    CSS.highlights.set(HIGHLIGHT_ELEMENT, this.#elementHighlight);
+  }
+
+  /** Highlight the current word within #textNodes (yellow, during speech). */
+  #updateWordHighlight(charIndex: number, charLength: number) {
+    if (!('highlights' in CSS)) return;
+    this.#ensureHighlightStyles();
+    this.#wordHighlight.clear();
+
+    const text = this.#textNodes.map(n => n.textContent ?? '').join('');
+    const endIndex = charIndex + (charLength > 0 ? charLength : this.#wordLengthAt(charIndex, text));
+    let offset = 0;
+    let startNode: Text | null = null;
+    let startOffset = 0;
+    let endNode: Text | null = null;
+    let endOffset = 0;
+
+    for (const node of this.#textNodes) {
+      const len = node.textContent?.length ?? 0;
+      if (!startNode && offset + len > charIndex) {
+        startNode = node;
+        startOffset = charIndex - offset;
+      }
+      if (startNode && offset + len >= endIndex) {
+        endNode = node;
+        endOffset = endIndex - offset;
+        break;
+      }
+      offset += len;
+    }
+
+    if (startNode && endNode) {
+      const range = new Range();
+      range.setStart(startNode, startOffset);
+      range.setEnd(endNode, endOffset);
+      this.#wordHighlight.add(range);
+      CSS.highlights.set(HIGHLIGHT_WORD, this.#wordHighlight);
+    }
+  }
+
+  #clearWordHighlight() {
+    if (!('highlights' in CSS)) return;
+    this.#wordHighlight.clear();
+    CSS.highlights.delete(HIGHLIGHT_WORD);
+  }
+
+  #clearAllHighlights() {
+    if (!('highlights' in CSS)) return;
+    this.#wordHighlight.clear();
+    CSS.highlights.delete(HIGHLIGHT_WORD);
+    this.#elementHighlight.clear();
+    CSS.highlights.delete(HIGHLIGHT_ELEMENT);
+  }
+
+  /** Fallback word-length when charLength is 0. */
+  #wordLengthAt(charIndex: number, text: string): number {
+    const right = text.slice(charIndex).search(/\s/);
+    return right < 0 ? text.length - charIndex : right;
+  }
+
+  /**
+   * Add ::highlight() rules both to test-container's shadow root (where highlighted
+   * text lives) and to the document (safety net — spec allows document rules to apply
+   * across shadow DOM). Called lazily on first highlight use so test-container is
+   * guaranteed to be in the DOM by the time navigation or speech starts.
+   */
+  #ensureHighlightStyles() {
+    if (!('highlights' in CSS)) return;
+    const sheet = getHighlightSheet();
+
+    // 1. Document-level rule — applies broadly regardless of shadow DOM depth
+    if (!document.adoptedStyleSheets.includes(sheet)) {
+      document.adoptedStyleSheets = [...document.adoptedStyleSheets, sheet];
+    }
+
+    // 2. test-container shadow root — ensures correct cascade for slotted content
+    const testContainer =
+      this.closest('test-navigation')?.querySelector('test-container') ??
+      this.closest('qti-test')?.querySelector('test-container');
+    const root = testContainer?.shadowRoot;
+    if (root && !root.adoptedStyleSheets.includes(sheet)) {
+      root.adoptedStyleSheets = [...root.adoptedStyleSheets, sheet];
+    }
+  }
+}
+
+// ─── Child control elements ───────────────────────────────────────────────────
+
+/**
+ * Play/pause/resume toggle button — always enabled, cycles through states.
+ * Use named slots `play` and `pause` to customise the icons/labels independently.
+ *
+ * @example
+ * ```html
+ * <test-tts-play>
+ *   <span slot="play">▶ Play</span>
+ *   <span slot="pause">⏸ Pause</span>
+ * </test-tts-play>
+ * ```
+ *
+ * @cssstate idle / playing / paused
+ * @csspart button
+ */
+@customElement('test-tts-play')
+export class TestTtsPlay extends TtsButtonBase {
+  #toggle() {
+    if (!this._tts) return;
+    if (this._tts.state === 'idle') this._tts.play();
+    else if (this._tts.state === 'playing') this._tts.pause();
+    else this._tts.resume();
+  }
+
+  override render() {
+    const playing = this._tts?.state === 'playing';
+    return html`
+      <button part="button" @click=${this.#toggle}>
+        ${playing ? html`<slot name="pause">⏸</slot>` : html`<slot name="play">▶</slot>`}
+      </button>
+    `;
+  }
+}
+
+/**
+ * Pause button — enabled only when playing.
+ * @cssstate idle / playing / paused
+ * @csspart button
+ */
+@customElement('test-tts-pause')
+export class TestTtsPause extends TtsButtonBase {
+  override render() {
+    return html`
+      <button part="button" ?disabled=${this._tts?.state !== 'playing'} @click=${() => this._tts?.pause()}>
+        <slot>⏸</slot>
+      </button>
+    `;
+  }
+}
+
+/**
+ * Resume button — enabled only when paused.
+ * @cssstate idle / playing / paused
+ * @csspart button
+ */
+@customElement('test-tts-resume')
+export class TestTtsResume extends TtsButtonBase {
+  override render() {
+    return html`
+      <button part="button" ?disabled=${this._tts?.state !== 'paused'} @click=${() => this._tts?.resume()}>
+        <slot>▶</slot>
+      </button>
+    `;
+  }
+}
+
+/**
+ * Stop button — enabled when playing or paused.
+ * @cssstate idle / playing / paused
+ * @csspart button
+ */
+@customElement('test-tts-stop')
+export class TestTtsStop extends TtsButtonBase {
+  override render() {
+    return html`
+      <button part="button" ?disabled=${this._tts?.state === 'idle'} @click=${() => this._tts?.stop()}>
+        <slot>■</slot>
+      </button>
+    `;
+  }
+}
+
+/**
+ * Prev-element button — moves cursor to the previous reading element and pauses.
+ * Disabled at the first element or when no elements are loaded.
+ * @cssstate idle / playing / paused
+ * @csspart button
+ */
+@customElement('test-tts-prev')
+export class TestTtsPrev extends TtsButtonBase {
+  override render() {
+    const atStart = (this._tts?.currentElementIndex ?? 0) === 0;
+    const noElements = (this._tts?.elementCount ?? 0) === 0;
+    return html`
+      <button part="button" ?disabled=${noElements || atStart} @click=${() => this._tts?.prevElement()}>
+        <slot>◀◀</slot>
+      </button>
+    `;
+  }
+}
+
+/**
+ * Next-element button — moves cursor to the next reading element and pauses.
+ * Disabled at the last element or when no elements are loaded.
+ * @cssstate idle / playing / paused
+ * @csspart button
+ */
+@customElement('test-tts-next')
+export class TestTtsNext extends TtsButtonBase {
+  override render() {
+    const atEnd =
+      (this._tts?.elementCount ?? 0) > 0 && (this._tts?.currentElementIndex ?? 0) >= (this._tts?.elementCount ?? 0) - 1;
+    const noElements = (this._tts?.elementCount ?? 0) === 0;
+    return html`
+      <button part="button" ?disabled=${noElements || atEnd} @click=${() => this._tts?.nextElement()}>
+        <slot>▶▶</slot>
+      </button>
+    `;
+  }
+}
+
+// ─── Global type declarations ─────────────────────────────────────────────────
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'test-item-to-speech': TestItemToSpeech;
+    'test-tts-play': TestTtsPlay;
+    'test-tts-pause': TestTtsPause;
+    'test-tts-resume': TestTtsResume;
+    'test-tts-stop': TestTtsStop;
+    'test-tts-prev': TestTtsPrev;
+    'test-tts-next': TestTtsNext;
+  }
+}


### PR DESCRIPTION
## Summary

Adds a fully composable text-to-speech player for QTI test items, built on Lit context so consumers can assemble their own control bar from individual elements.

## New elements

| Element | Role |
|---|---|
| `test-item-to-speech` | Controller/provider — manages speech synthesis, highlights, item tracking |
| `test-tts-play` | Play/pause/resume toggle |
| `test-tts-prev` | Navigate to previous reading element |
| `test-tts-next` | Navigate to next reading element |
| `test-tts-stop` | Stop speech and clear highlights |
| `test-tts-pause` | Explicit pause (optional) |
| `test-tts-resume` | Explicit resume (optional) |

## How it works

- **Element navigation** — `test-tts-prev`/`test-tts-next` move a cursor through block-level reading elements (`p`, `h1–h6`, `li`, `blockquote`, `figcaption`) collected lazily from `qti-item-body`. Each step highlights the element in blue (`::highlight(tts-element)`) and scrolls it into view. Navigation always pauses speech.
- **Speech** — `test-tts-play` speaks from the current cursor element and auto-advances through the remaining elements. Word boundaries are highlighted in yellow (`::highlight(tts-word)`) via `SpeechSynthesisUtterance.onboundary`.
- **End of item** — when all elements are read, the cursor stays on the last element so the user can walk back with `test-tts-prev`.
- **Item switch** — speech stops immediately on `qti-request-navigation` (synchronous) and is also caught via `sessionContext.navItemRefId` change detection.
- **CSS highlights** — stylesheet injected lazily (on first use) into both `document.adoptedStyleSheets` and `test-container.shadowRoot.adoptedStyleSheets`.
- **CSS parts & states** — all buttons expose `part="button"` and the host + each child element expose `:state(idle)`, `:state(playing)`, `:state(paused)`.

## Usage

```html
<test-item-to-speech language="nl-NL">
  <test-tts-prev>◀◀</test-tts-prev>
  <test-tts-play></test-tts-play>
  <test-tts-next>▶▶</test-tts-next>
  <test-tts-stop>■</test-tts-stop>
</test-item-to-speech>
```

## Changes

- `packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts` — new file
- `packages/qti-test/src/components/index.ts` — export added
- `apps/e2e/src/stories/test.stories.ts` — TTS player moved to top bar