### PR TITLE
fix(inline-choice): keep candidate answer visible when it is the correct answer

### DIFF
--- a/.changeset/inline-choice-correct-option-blanks-answer.md
+++ b/.changeset/inline-choice-correct-option-blanks-answer.md
@@ -1,0 +1,13 @@
+---
+'@qti-components/inline-choice-interaction': patch
+---
+
+Fix the inline-choice dropdown rendering empty when the candidate's answer is
+also the correct answer. `#updateOptions` builds each option's `content` once as
+an array of DOM nodes, and both the trigger's `part="value"` and the
+`part="correct-option"` marker bound those same nodes. A DOM node can only live
+in one place, so enabling the correct response moved the nodes into the marker
+and left the trigger blank — making a correct answer look unanswered in review,
+and not recoverable by switching the correct response back off (lit dirty-checks
+the unchanged node reference and never re-inserts it). The marker now renders its
+own copy of the nodes.

--- a/packages/interactions/inline-choice-interaction/src/qti-inline-choice-interaction.spec.ts
+++ b/packages/interactions/inline-choice-interaction/src/qti-inline-choice-interaction.spec.ts
@@ -1,0 +1,62 @@
+import '@citolab/qti-components';
+import { html, render } from 'lit';
+
+import type { QtiInlineChoiceInteraction } from './qti-inline-choice-interaction';
+
+describe('qti-inline-choice-interaction', () => {
+  beforeEach(async () => {
+    document.getElementsByTagName('html')[0].innerHTML = '';
+  }); // MANDATORY
+
+  const setup = async (): Promise<QtiInlineChoiceInteraction> => {
+    render(
+      html`
+        <qti-inline-choice-interaction response-identifier="RESPONSE" correct-response="B" shuffle="false">
+          <qti-inline-choice identifier="A"><span>Gorbatsjov</span></qti-inline-choice>
+          <qti-inline-choice identifier="B"><span>Kennedy</span></qti-inline-choice>
+        </qti-inline-choice-interaction>
+      `,
+      document.body
+    );
+    const element = document.querySelector('qti-inline-choice-interaction') as QtiInlineChoiceInteraction;
+    await element.updateComplete;
+    return element;
+  };
+
+  const triggerText = (element: QtiInlineChoiceInteraction) =>
+    element.shadowRoot?.querySelector('button[part="trigger"] span[part="value"]')?.textContent?.trim() ?? '';
+
+  const correctOptionText = (element: QtiInlineChoiceInteraction) =>
+    element.shadowRoot?.querySelector('span[part="correct-option"]')?.textContent?.trim() ?? null;
+
+  describe('showing the correct response', () => {
+    it('keeps the candidate response visible when it differs from the correct one', async () => {
+      const element = await setup();
+
+      element.response = 'A';
+      await element.updateComplete;
+      element.toggleInternalCorrectResponse(true);
+      await element.updateComplete;
+
+      expect(triggerText(element)).toBe('Gorbatsjov');
+      expect(correctOptionText(element)).toBe('Kennedy');
+    });
+
+    it('keeps the candidate response visible when it IS the correct one', async () => {
+      const element = await setup();
+
+      element.response = 'B';
+      await element.updateComplete;
+      expect(triggerText(element)).toBe('Kennedy');
+
+      element.toggleInternalCorrectResponse(true);
+      await element.updateComplete;
+
+      // The correct-option marker must render its own copy of the option's nodes:
+      // binding the option's own nodes would move them out of the trigger, leaving
+      // the dropdown blank for every candidate who answered correctly.
+      expect(correctOptionText(element)).toBe('Kennedy');
+      expect(triggerText(element)).toBe('Kennedy');
+    });
+  });
+});

--- a/packages/interactions/inline-choice-interaction/src/qti-inline-choice-interaction.ts
+++ b/packages/interactions/inline-choice-interaction/src/qti-inline-choice-interaction.ts
@@ -244,10 +244,17 @@ export class QtiInlineChoiceInteraction extends Interaction {
       return;
     }
 
+    // Render a copy: a DOM node can only live in one place, so binding the option's
+    // own nodes here would move them out of the trigger's `part="value"` — blanking
+    // the candidate's answer whenever it happens to be the correct option.
+    const content = Array.isArray(correctOptionData.content)
+      ? correctOptionData.content.map(node => node.cloneNode(true))
+      : correctOptionData.content;
+
     this.correctOption = html`<span
       part="correct-option"
       style="border:1px solid var(--qti-correct); border-radius:4px; padding: 2px 4px; margin: 4px; display:inline-block"
-      >${correctOptionData.content}</span
+      >${content}</span
     >`;
   }
 


### PR DESCRIPTION
## The bug

In an inline-choice (dropdown) interaction, turning on the correct response blanks the dropdown — but **only for the candidates who answered correctly**. A correct answer ends up looking unanswered in review.

Reported from a teacher review screen in Cito Test Uit / CheckMate. Out of three two-dropdown history items in one session, the two dropdowns of the fully-correct item both rendered empty, the fully-wrong item rendered both answers fine, and the half-correct item rendered exactly one — the wrong one.

## Cause

`#updateOptions` builds each option's `content` once, as an array of real DOM nodes:

```ts
content: Array.from(choice.childNodes).map(node => node.cloneNode(true)),
```

Two bindings then render that array: the trigger's `<span part="value">${selected?.content}</span>` and, in `toggleInternalCorrectResponse`, the marker `${correctOptionData.content}`.

When the selected option *is* the correct option, both bindings receive the **same node objects**. A DOM node can only live in one place, so lit's insert into the marker (rendered last in the template) removes those nodes from the trigger. The trigger keeps its pre-measured width, so it renders as an empty, full-width dropdown next to the correct-answer marker.

Switching the correct response back off does not restore it: lit dirty-checks the unchanged node reference and never re-inserts it. Verified in Chromium against 7.28.1 — trigger goes `"Kennedy"` → `""` on toggle-on and stays `""` after toggle-off, while a wrong-answer dropdown in the same item keeps showing its value throughout.

Note the response data itself is never affected — `interaction.response` stays correct the whole time. This is purely rendering.

## Fix

The marker renders its own copy of the nodes.

## Tests

New `qti-inline-choice-interaction.spec.ts` covers both cases: candidate answer differing from the correct answer, and candidate answer equal to it. On `main` the second one fails (1 failed / 1 passed); with the fix both pass. Checked in both directions by stashing the source change and rebuilding.