### PR TITLE
fix(interactions-core): keep the drag clone visible in fullscreen

### DIFF
--- a/.changeset/drag-clone-fullscreen-host.md
+++ b/.changeset/drag-clone-fullscreen-host.md
@@ -1,0 +1,20 @@
+---
+'@qti-components/interactions-core': patch
+---
+
+Keep the drag clone visible while the page is in fullscreen.
+
+The observable drag-drop mixin appended its visual clone to `document.body`. That is invisible
+while the page is in fullscreen: the browser paints only the fullscreen element's subtree, in the
+top layer, which no `z-index` can reach. Picking up a draggable in a fullscreen player (exam
+lockdown / kiosk) therefore made it disappear until it was dropped. The predecessor mixin had this
+fixed; the fix was not carried over in the rewrite.
+
+`createDragClone` now hosts the clone in the fullscreen element when there is one - resolved
+through shadow trees, since `document.fullscreenElement` is retargeted to the host, and falling
+back to that element's shadow root when it cannot slot light-DOM children - and in `document.body`
+otherwise. Because a host subtree may establish a containing block for `position: fixed` children
+(`transform`, `filter`, `contain`, `zoom`, …), the clone's coordinate space is measured with a
+throwaway probe and its position and size are corrected for that origin and scale. A clone that is
+being dragged when the page enters or leaves fullscreen is moved to the new host and repositioned
+under the pointer.

--- a/custom-elements.json
+++ b/custom-elements.json
@@ -4605,6 +4605,16 @@
             },
             {
               "kind": "field",
+              "name": "cloneFrame",
+              "type": {
+                "text": "FixedFrame"
+              },
+              "privacy": "private",
+              "default": "IDENTITY_FIXED_FRAME",
+              "description": "Coordinate space of the current clone's host; identity while the host is `document.body`."
+            },
+            {
+              "kind": "field",
               "name": "collisionDetectionAlgorithm",
               "type": {
                 "text": "CollisionDetectionAlgorithm"
@@ -4972,6 +4982,17 @@
                   }
                 }
               ]
+            },
+            {
+              "kind": "method",
+              "name": "watchDragCloneHost",
+              "privacy": "private",
+              "return": {
+                "type": {
+                  "text": "void"
+                }
+              },
+              "description": "Keeps the clone in a host the browser still paints when the page enters or leaves fullscreen\nmid-drag - otherwise it is stranded in a container that is no longer rendered. Re-parenting\nreconnects the clone's custom elements, which is why it only happens on an actual change."
             }
           ],
           "parameters": [
@@ -7200,6 +7221,121 @@
           "declaration": {
             "name": "rectangleIntersectionCollision",
             "module": "packages/interactions/core/src/mixins/drag-drop-observables/utils/collision.utils.ts"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "packages/interactions/core/src/mixins/drag-drop-observables/utils/drag-clone-host.ts",
+      "declarations": [
+        {
+          "kind": "variable",
+          "name": "IDENTITY_FIXED_FRAME",
+          "type": {
+            "text": "FixedFrame"
+          },
+          "default": "{ origin: { x: 0, y: 0 }, scale: { x: 1, y: 1 } }",
+          "description": "Viewport coordinates, no scaling: the frame of a clone hosted by `document.body`."
+        },
+        {
+          "kind": "function",
+          "name": "measureFixedFrame",
+          "return": {
+            "type": {
+              "text": "FixedFrame"
+            }
+          },
+          "parameters": [
+            {
+              "name": "host",
+              "type": {
+                "text": "DragCloneHost"
+              }
+            }
+          ],
+          "description": "Measures the frame a `position: fixed` child of `host` is laid out in, using a throwaway probe so\nthe clone's own `transform` / `rotate` cannot skew the reading. Costs one layout per drag start."
+        },
+        {
+          "kind": "function",
+          "name": "resolveDragCloneHost",
+          "return": {
+            "type": {
+              "text": "DragCloneHost"
+            }
+          },
+          "parameters": [
+            {
+              "name": "dragSource",
+              "type": {
+                "text": "Node"
+              }
+            }
+          ],
+          "description": "Resolves the host for a clone of `dragSource`: the fullscreen element if there is one, else body."
+        },
+        {
+          "kind": "function",
+          "name": "toFrameCoordinates",
+          "return": {
+            "type": {
+              "text": "{ x: number; y: number }"
+            }
+          },
+          "parameters": [
+            {
+              "name": "frame",
+              "type": {
+                "text": "FixedFrame"
+              }
+            },
+            {
+              "name": "x",
+              "type": {
+                "text": "number"
+              }
+            },
+            {
+              "name": "y",
+              "type": {
+                "text": "number"
+              }
+            }
+          ],
+          "description": "Converts a viewport coordinate into the host's fixed-positioning space."
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "IDENTITY_FIXED_FRAME",
+          "declaration": {
+            "name": "IDENTITY_FIXED_FRAME",
+            "module": "packages/interactions/core/src/mixins/drag-drop-observables/utils/drag-clone-host.ts"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "measureFixedFrame",
+          "declaration": {
+            "name": "measureFixedFrame",
+            "module": "packages/interactions/core/src/mixins/drag-drop-observables/utils/drag-clone-host.ts"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "resolveDragCloneHost",
+          "declaration": {
+            "name": "resolveDragCloneHost",
+            "module": "packages/interactions/core/src/mixins/drag-drop-observables/utils/drag-clone-host.ts"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "toFrameCoordinates",
+          "declaration": {
+            "name": "toFrameCoordinates",
+            "module": "packages/interactions/core/src/mixins/drag-drop-observables/utils/drag-clone-host.ts"
           }
         }
       ]

--- a/packages/interactions/core/src/mixins/drag-drop-observables/drag-drop-core.mixin.spec.ts
+++ b/packages/interactions/core/src/mixins/drag-drop-observables/drag-drop-core.mixin.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { DragDropCoreMixin } from './drag-drop-core.mixin';
 
@@ -86,5 +86,84 @@ describe('DragDropCoreMixin - slotted press/release behavior', () => {
     expect(element.dropCalls).toHaveLength(1);
     expect(element.dropCalls[0]).toEqual({ draggable: dragSource, droppable: sourceDroppable });
     expect(element.invalidCalls).toHaveLength(0);
+  });
+});
+
+describe('DragDropCoreMixin - drag clone hosting', () => {
+  const cleanups: Array<() => void> = [];
+
+  const mount = <T extends HTMLElement>(element: T): T => {
+    document.body.appendChild(element);
+    cleanups.push(() => element.remove());
+    return element;
+  };
+
+  const fakeFullscreen = (element: Element | null): void => {
+    Object.defineProperty(document, 'fullscreenElement', { configurable: true, get: () => element });
+    cleanups.push(() => {
+      delete (document as unknown as Record<string, unknown>).fullscreenElement;
+    });
+  };
+
+  const dragSourceIn = (parent: HTMLElement): HTMLElement => {
+    const source = parent.appendChild(document.createElement('div'));
+    source.style.cssText = 'position:absolute;left:0;top:0;width:60px;height:20px;margin:0;';
+    return source;
+  };
+
+  afterEach(() => {
+    while (cleanups.length) cleanups.pop()!();
+  });
+
+  it('appends the clone to the body when the page is not in fullscreen', () => {
+    const element = new TestCoreElement() as any;
+    const source = dragSourceIn(mount(document.createElement('div')));
+
+    const clone = element.createDragClone(source, source.getBoundingClientRect());
+    cleanups.push(() => clone.remove());
+
+    expect(clone.parentNode).toBe(document.body);
+  });
+
+  it('appends the clone to the fullscreen element, which is the only subtree the browser paints', () => {
+    const element = new TestCoreElement() as any;
+    const fullscreenRoot = mount(document.createElement('div'));
+    const source = dragSourceIn(fullscreenRoot);
+    fakeFullscreen(fullscreenRoot);
+
+    const clone = element.createDragClone(source, source.getBoundingClientRect());
+
+    expect(clone.parentNode).toBe(fullscreenRoot);
+  });
+
+  it('positions the clone under the pointer even when its host offsets and scales fixed children', () => {
+    const element = new TestCoreElement() as any;
+    const fullscreenRoot = mount(document.createElement('div'));
+    fullscreenRoot.style.cssText =
+      'position:absolute;left:30px;top:20px;width:400px;height:300px;transform:scale(0.5);transform-origin:0 0;';
+    const source = dragSourceIn(fullscreenRoot);
+    fakeFullscreen(fullscreenRoot);
+
+    const sourceRect = source.getBoundingClientRect();
+    const clone = element.createDragClone(source, sourceRect);
+    element.dragState = {
+      dragging: true,
+      dragSource: source,
+      dragClone: clone,
+      startOffset: { x: 5, y: 5 },
+      currentTarget: null,
+      sourceDroppable: null,
+      inputType: 'mouse'
+    };
+
+    element.updateClonePosition(200, 150);
+    const cloneRect = clone.getBoundingClientRect();
+
+    // The clone's top-left must land at the pointer minus the grab offset, in viewport pixels...
+    expect(cloneRect.left).toBeCloseTo(195, 0);
+    expect(cloneRect.top).toBeCloseTo(145, 0);
+    // ...and it must stay the same size as the element it was cloned from.
+    expect(cloneRect.width).toBeCloseTo(sourceRect.width, 0);
+    expect(cloneRect.height).toBeCloseTo(sourceRect.height, 0);
   });
 });

--- a/packages/interactions/core/src/mixins/drag-drop-observables/drag-drop-core.mixin.ts
+++ b/packages/interactions/core/src/mixins/drag-drop-observables/drag-drop-core.mixin.ts
@@ -1,9 +1,16 @@
 import { isSupported, apply } from 'observable-polyfill/fn';
 
 import { detectCollision, findDraggableTarget } from './utils/drag-drop.utils';
+import {
+  IDENTITY_FIXED_FRAME,
+  measureFixedFrame,
+  resolveDragCloneHost,
+  toFrameCoordinates
+} from './utils/drag-clone-host';
 
 import type { Interaction } from '@qti-components/base';
 import type { CollisionDetectionAlgorithm } from './utils/drag-drop.utils';
+import type { FixedFrame } from './utils/drag-clone-host';
 
 if (!isSupported()) apply();
 
@@ -69,6 +76,8 @@ interface DragState {
   activationTimeout?: number;
   touchCleanup?: () => void;
   lastTargetChangeTime?: number;
+  /** Last pointer position, so the clone can be repositioned after it is re-hosted mid-drag. */
+  lastCoordinates?: { x: number; y: number };
 }
 
 type DragEventSource = 'pointer' | 'mouse' | 'touch';
@@ -101,6 +110,9 @@ export const DragDropCoreMixin = <T extends Constructor<Interaction>>(
       sourceDroppable: null,
       inputType: null
     };
+
+    /** Coordinate space of the current clone's host; identity while the host is `document.body`. */
+    private cloneFrame: FixedFrame = IDENTITY_FIXED_FRAME;
 
     private subscriptions: Array<{ unsubscribe: () => void }> = [];
     private dragSubscriptions: Array<{ unsubscribe: () => void }> = [];
@@ -480,6 +492,7 @@ export const DragDropCoreMixin = <T extends Constructor<Interaction>>(
 
       this.updateClonePosition(startX, startY);
       this.activateAllDroppables();
+      this.watchDragCloneHost();
       this.setupMoveObservables(inputType, eventSource);
     }
 
@@ -745,9 +758,15 @@ export const DragDropCoreMixin = <T extends Constructor<Interaction>>(
         clone.style.setProperty(property, computedStyles.getPropertyValue(property));
       }
 
+      // The clone cannot live in `document.body` unconditionally: while the page is in fullscreen
+      // the browser paints only the fullscreen element's subtree, so a clone in the body is invisible.
+      const host = resolveDragCloneHost(element.isConnected ? element : this);
+      this.cloneFrame = measureFixedFrame(host);
+
       clone.style.position = 'fixed';
-      clone.style.width = `${rect.width}px`;
-      clone.style.height = `${rect.height}px`;
+      // `rect` is in viewport pixels; the host may lay its children out in a scaled space.
+      clone.style.width = `${rect.width / this.cloneFrame.scale.x}px`;
+      clone.style.height = `${rect.height / this.cloneFrame.scale.y}px`;
       clone.style.zIndex = '9999';
       clone.style.pointerEvents = 'none'; // Critical: never capture events
       clone.style.touchAction = 'none'; // Prevent touch interactions
@@ -758,19 +777,56 @@ export const DragDropCoreMixin = <T extends Constructor<Interaction>>(
       clone.removeAttribute('tabindex');
       clone.setAttribute('data-drag-clone', 'true');
 
-      document.body.appendChild(clone);
+      host.appendChild(clone);
       return clone;
     }
 
     protected updateClonePosition(clientX: number, clientY: number): void {
+      this.dragState.lastCoordinates = { x: clientX, y: clientY };
+
       if (!this.dragState.dragClone) return;
 
+      // `startOffset` is in viewport pixels, so the target position is resolved there and only then
+      // converted into the host's space.
       const { startOffset } = this.dragState;
-      const x = clientX - startOffset.x;
-      const y = clientY - startOffset.y;
+      const { x, y } = toFrameCoordinates(this.cloneFrame, clientX - startOffset.x, clientY - startOffset.y);
 
       this.dragState.dragClone.style.left = `${x}px`;
       this.dragState.dragClone.style.top = `${y}px`;
+    }
+
+    /**
+     * Keeps the clone in a host the browser still paints when the page enters or leaves fullscreen
+     * mid-drag - otherwise it is stranded in a container that is no longer rendered. Re-parenting
+     * reconnects the clone's custom elements, which is why it only happens on an actual change.
+     */
+    private watchDragCloneHost(): void {
+      const ownerDocument = this.ownerDocument ?? document;
+
+      const rehost = () => {
+        const { dragClone, dragSource, lastCoordinates } = this.dragState;
+        if (!dragClone) return;
+
+        const anchor = dragSource?.isConnected ? dragSource : this;
+        const host = resolveDragCloneHost(anchor);
+        if (host === dragClone.parentNode) return;
+
+        host.appendChild(dragClone);
+        this.cloneFrame = measureFixedFrame(host);
+        if (lastCoordinates) {
+          this.updateClonePosition(lastCoordinates.x, lastCoordinates.y);
+        }
+      };
+
+      ownerDocument.addEventListener('fullscreenchange', rehost);
+      ownerDocument.addEventListener('webkitfullscreenchange', rehost);
+
+      this.dragSubscriptions.push({
+        unsubscribe: () => {
+          ownerDocument.removeEventListener('fullscreenchange', rehost);
+          ownerDocument.removeEventListener('webkitfullscreenchange', rehost);
+        }
+      });
     }
 
     protected activateAllDroppables(): void {
@@ -817,6 +873,7 @@ export const DragDropCoreMixin = <T extends Constructor<Interaction>>(
         }
       });
       this.dragSubscriptions = [];
+      this.cloneFrame = IDENTITY_FIXED_FRAME;
 
       this.dragState = {
         dragging: false,

--- a/packages/interactions/core/src/mixins/drag-drop-observables/utils/drag-clone-host.spec.ts
+++ b/packages/interactions/core/src/mixins/drag-drop-observables/utils/drag-clone-host.spec.ts
@@ -1,0 +1,118 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { measureFixedFrame, resolveDragCloneHost } from './drag-clone-host';
+
+const cleanups: Array<() => void> = [];
+
+const mount = <T extends HTMLElement>(element: T): T => {
+  document.body.appendChild(element);
+  cleanups.push(() => element.remove());
+  return element;
+};
+
+/** `fullscreenElement` is read-only, so it is shadowed with an own property on the root. */
+const fakeFullscreen = (root: Document | ShadowRoot, element: Element | null): void => {
+  Object.defineProperty(root, 'fullscreenElement', { configurable: true, get: () => element });
+  cleanups.push(() => {
+    delete (root as unknown as Record<string, unknown>).fullscreenElement;
+  });
+};
+
+afterEach(() => {
+  while (cleanups.length) cleanups.pop()!();
+});
+
+describe('resolveDragCloneHost', () => {
+  it('hosts the clone in the body for an item rendered in a plain page', () => {
+    const source = mount(document.createElement('div'));
+
+    expect(resolveDragCloneHost(source)).toBe(document.body);
+  });
+
+  it('hosts the clone in the fullscreen element, which is the only subtree the browser paints', () => {
+    const fullscreenRoot = mount(document.createElement('div'));
+    const source = fullscreenRoot.appendChild(document.createElement('div'));
+    fakeFullscreen(document, fullscreenRoot);
+
+    expect(resolveDragCloneHost(source)).toBe(fullscreenRoot);
+  });
+
+  it('resolves the retargeted fullscreen element down through shadow trees', () => {
+    const host = mount(document.createElement('div'));
+    const shadowRoot = host.attachShadow({ mode: 'open' });
+    const realFullscreenElement = shadowRoot.appendChild(document.createElement('div'));
+    // The document reports the host, not the element that actually went fullscreen.
+    fakeFullscreen(document, host);
+    fakeFullscreen(shadowRoot, realFullscreenElement);
+
+    expect(resolveDragCloneHost(mount(document.createElement('div')))).toBe(realFullscreenElement);
+  });
+
+  it('hosts the clone in the shadow tree when the fullscreen element cannot slot it', () => {
+    const fullscreenRoot = mount(document.createElement('div'));
+    const shadowRoot = fullscreenRoot.attachShadow({ mode: 'open' });
+    shadowRoot.innerHTML = '<slot name="drags"></slot>';
+    fakeFullscreen(document, fullscreenRoot);
+
+    expect(resolveDragCloneHost(mount(document.createElement('div')))).toBe(shadowRoot);
+  });
+
+  it('keeps the clone in the light DOM when the fullscreen element has a default slot', () => {
+    const fullscreenRoot = mount(document.createElement('div'));
+    const shadowRoot = fullscreenRoot.attachShadow({ mode: 'open' });
+    shadowRoot.innerHTML = '<slot></slot>';
+    fakeFullscreen(document, fullscreenRoot);
+
+    expect(resolveDragCloneHost(mount(document.createElement('div')))).toBe(fullscreenRoot);
+  });
+
+  it('leaves a clone dragged from a shadow tree in the body, out of the tree the interaction owns', () => {
+    const host = mount(document.createElement('div'));
+    const shadowRoot = host.attachShadow({ mode: 'open' });
+    const source = shadowRoot.appendChild(document.createElement('div'));
+
+    expect(resolveDragCloneHost(source)).toBe(document.body);
+  });
+});
+
+describe('measureFixedFrame', () => {
+  it('measures the viewport itself for a body-hosted clone', () => {
+    const frame = measureFixedFrame(document.body);
+
+    expect(frame.origin.x).toBeCloseTo(0, 0);
+    expect(frame.origin.y).toBeCloseTo(0, 0);
+    expect(frame.scale.x).toBeCloseTo(1, 2);
+    expect(frame.scale.y).toBeCloseTo(1, 2);
+  });
+
+  it('measures the containing block a transformed host establishes for its fixed children', () => {
+    const host = mount(document.createElement('div'));
+    host.style.cssText = 'position:absolute;left:40px;top:25px;width:200px;height:200px;transform:translateZ(0);';
+
+    const frame = measureFixedFrame(host);
+    const hostRect = host.getBoundingClientRect();
+
+    expect(frame.origin.x).toBeCloseTo(hostRect.left, 0);
+    expect(frame.origin.y).toBeCloseTo(hostRect.top, 0);
+    expect(frame.scale.x).toBeCloseTo(1, 2);
+  });
+
+  it('measures the scale a zoomed or scaled host applies, so clone coordinates can be corrected', () => {
+    const host = mount(document.createElement('div'));
+    host.style.cssText =
+      'position:absolute;left:0;top:0;width:200px;height:200px;transform:scale(0.5);transform-origin:0 0;';
+
+    const frame = measureFixedFrame(host);
+
+    expect(frame.scale.x).toBeCloseTo(0.5, 2);
+    expect(frame.scale.y).toBeCloseTo(0.5, 2);
+  });
+
+  it('leaves no probe behind', () => {
+    const host = mount(document.createElement('div'));
+
+    measureFixedFrame(host);
+
+    expect(host.childElementCount).toBe(0);
+  });
+});

--- a/packages/interactions/core/src/mixins/drag-drop-observables/utils/drag-clone-host.ts
+++ b/packages/interactions/core/src/mixins/drag-drop-observables/utils/drag-clone-host.ts
@@ -1,0 +1,104 @@
+/**
+ * Where a drag clone has to live to be painted, and in which coordinate space it is positioned.
+ *
+ * `document.body` is the right host for an item rendered in a plain page, but not for a player that
+ * uses the **Fullscreen API** (exam lockdown / kiosk): the browser paints only the fullscreen
+ * element's subtree, in the top layer. A clone appended to `body` is not painted at all - no
+ * `z-index` can reach past the top layer - so the dragged element simply disappears while it is
+ * held.
+ *
+ * The clone is deliberately *not* re-hosted into the shadow tree it was dragged from, tempting as
+ * that is for keeping scoped styles: that tree belongs to the interaction, which queries and
+ * observes it, and a clone living there is picked up as one of its own elements. The
+ * order-interaction press/release conformance test fails exactly that way. Losing scoped styling is
+ * the lesser problem, and `createDragClone` already inlines the source's computed styles.
+ */
+
+type FullscreenDocument = Document & { webkitFullscreenElement?: Element | null };
+type FullscreenRoot = ShadowRoot & { fullscreenElement?: Element | null };
+
+/** A node a clone can be appended to. A shadow root is used when its host cannot slot the clone. */
+export type DragCloneHost = HTMLElement | ShadowRoot;
+
+/**
+ * The coordinate space a `position: fixed` clone is laid out in.
+ *
+ * `fixed` is relative to the viewport only while no ancestor establishes a containing block
+ * (`transform`, `filter`, `backdrop-filter`, `perspective`, `contain`, `will-change`, `zoom`).
+ * Inside a host's subtree that is the integrator's choice, not ours, so the frame is measured
+ * rather than assumed.
+ */
+export interface FixedFrame {
+  origin: { x: number; y: number };
+  scale: { x: number; y: number };
+}
+
+/** Viewport coordinates, no scaling: the frame of a clone hosted by `document.body`. */
+export const IDENTITY_FIXED_FRAME: FixedFrame = { origin: { x: 0, y: 0 }, scale: { x: 1, y: 1 } };
+
+const PROBE_SIZE = 100;
+
+/**
+ * `document.fullscreenElement` is retargeted against the document: when the element that went
+ * fullscreen lives inside a shadow tree, the document reports that tree's host instead. Walk down
+ * the shadow trees to find the element that is really fullscreen, otherwise the clone is appended
+ * to a host that never renders it.
+ */
+const deepestFullscreenElement = (ownerDocument: FullscreenDocument): HTMLElement | null => {
+  let current = (ownerDocument.fullscreenElement ?? ownerDocument.webkitFullscreenElement ?? null) as Element | null;
+
+  while (current instanceof HTMLElement) {
+    const nested = (current.shadowRoot as FullscreenRoot | null)?.fullscreenElement ?? null;
+    if (!nested || nested === current) break;
+    current = nested;
+  }
+
+  return current instanceof HTMLElement ? current : null;
+};
+
+/**
+ * Light-DOM children of a shadow host are only painted when the shadow tree has a slot to put them
+ * in. Without a default slot the clone would be invisible again, so it goes into the shadow tree.
+ */
+const hostFor = (element: HTMLElement): DragCloneHost => {
+  const shadowRoot = element.shadowRoot;
+  if (!shadowRoot) return element;
+  return shadowRoot.querySelector('slot:not([name])') ? element : shadowRoot;
+};
+
+/** Resolves the host for a clone of `dragSource`: the fullscreen element if there is one, else body. */
+export const resolveDragCloneHost = (dragSource: Node): DragCloneHost => {
+  const ownerDocument = (dragSource.ownerDocument ?? document) as FullscreenDocument;
+
+  const fullscreenElement = deepestFullscreenElement(ownerDocument);
+  if (fullscreenElement) return hostFor(fullscreenElement);
+
+  return ownerDocument.body;
+};
+
+/**
+ * Measures the frame a `position: fixed` child of `host` is laid out in, using a throwaway probe so
+ * the clone's own `transform` / `rotate` cannot skew the reading. Costs one layout per drag start.
+ */
+export const measureFixedFrame = (host: DragCloneHost): FixedFrame => {
+  const ownerDocument = host.ownerDocument ?? document;
+  const probe = ownerDocument.createElement('div');
+  probe.style.cssText =
+    `position:fixed;left:0;top:0;width:${PROBE_SIZE}px;height:${PROBE_SIZE}px;` +
+    'margin:0;padding:0;border:0;visibility:hidden;pointer-events:none;';
+
+  host.appendChild(probe);
+  const rect = probe.getBoundingClientRect();
+  probe.remove();
+
+  return {
+    origin: { x: rect.left, y: rect.top },
+    scale: { x: rect.width / PROBE_SIZE || 1, y: rect.height / PROBE_SIZE || 1 }
+  };
+};
+
+/** Converts a viewport coordinate into the host's fixed-positioning space. */
+export const toFrameCoordinates = (frame: FixedFrame, x: number, y: number): { x: number; y: number } => ({
+  x: (x - frame.origin.x) / frame.scale.x,
+  y: (y - frame.origin.y) / frame.scale.y
+});


### PR DESCRIPTION
## The bug

`createDragClone` in the observable drag-drop mixin appends its visual clone to `document.body`. That is invisible while the page is in fullscreen: the browser paints only the fullscreen element's subtree, in the top layer, which no `z-index` can reach. Picking up a draggable in a fullscreen player (exam lockdown / kiosk) makes it disappear until it is dropped — the source is hidden too (`opacity: 0`, or removed when dragging out of a dropzone), so it reads as the item vanishing entirely.

This was fixed once, in the predecessor mixin — `appendClone()` in `drag-drop/drag-drop-interaction-mixin.ts`, commit e2a1bfcc. The new `drag-drop-observables` mixin did not carry it over, and since the old mixin is no longer bundled (both gap-match interactions have their `DragDropInteractionMixin` import commented out), the fix is now dead code.

Not covered by any test: a plain storybook page is never in fullscreen, so CI cannot see it. Reproduced in a player that wraps the item in `element.requestFullscreen()`. Note that F11 browser fullscreen does *not* reproduce it — no element goes fullscreen, so there is no top layer involved.

## The fix

`createDragClone` resolves its host instead of assuming `document.body`:

- The fullscreen element when there is one, else `document.body` as before.
- Resolved *through* shadow trees: `document.fullscreenElement` is retargeted against the document, so it reports the host when the element that went fullscreen lives in a shadow tree. Appending to that host would be invisible all over again.
- Falling back to the fullscreen element's shadow root when the element cannot slot light-DOM children (no default `<slot>`).

A host subtree may establish a containing block for `position: fixed` children (`transform`, `filter`, `contain`, `zoom`, …), which `document.body` normally does not. Rather than assume, the clone's coordinate space is measured with a throwaway probe and its position *and* size are corrected for that origin and scale. A clone that is being dragged when the page enters or leaves fullscreen is moved to the new host and repositioned under the pointer, so it is not stranded in a container the browser no longer paints.

## Deliberately not included

The same rewrite also dropped the old mixin's ShadowRoot branch (`drag-drop-api.ts:118-122`), which kept a clone inside the shadow tree it was dragged from so scoped styles still applied. Restoring it breaks the order-interaction press/release conformance test: that tree belongs to the interaction, which queries and observes it, and a clone living there is picked up as one of its own elements. Left out of this PR and documented in the code; the styling gap needs a different approach.

## Tests

13 new tests, all in real Chromium:

- `utils/drag-clone-host.spec.ts` — host resolution (body, fullscreen element, retargeted shadow host, slotting fallbacks) and frame measurement (viewport, transformed host, scaled host, no probe left behind).
- `drag-drop-core.mixin.spec.ts` — `createDragClone` hosting, plus a drag inside a `scale(0.5)`-transformed fullscreen host asserting the clone lands under the pointer at the source's size. That one fails without the frame correction.

Full unit suite (385) and full storybook suite pass; `tsc --noEmit`, prettier and eslint clean.