### PR TITLE
fix(pci): repair show correct response for portable custom interactions

### DIFF
--- a/packages/interactions/portable-custom-interaction/src/qti-portable-custom-interaction.stories.ts
+++ b/packages/interactions/portable-custom-interaction/src/qti-portable-custom-interaction.stories.ts
@@ -514,6 +514,142 @@ export const VerhoudingenRestoreResponse = {
   }
 };
 
+/**
+ * The PCI renders inside an iframe and paints into shadow roots, so collect both
+ * to be able to assert on what a candidate actually sees.
+ */
+const deepIframeHtml = (iframe: HTMLIFrameElement | null): string => {
+  const doc = iframe?.contentDocument;
+  if (!doc) return '';
+  const collectShadowHtml = (root: ParentNode): string[] =>
+    Array.from(root.querySelectorAll('*')).flatMap(node =>
+      node.shadowRoot ? [node.shadowRoot.innerHTML, ...collectShadowHtml(node.shadowRoot)] : []
+    );
+  return [doc.body.innerHTML, ...collectShadowHtml(doc)].join('\n');
+};
+
+export const VerhoudingenShowCorrectResponse = {
+  render: () => {
+    const qti = `<qti-assessment-item
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns="http://www.imsglobal.org/xsd/imsqtiasi_v3p0"
+      xsi:schemaLocation="http://www.imsglobal.org/xsd/imsqtiasi_v3p0 https://purl.imsglobal.org/spec/qti/v3p0/schema/xsd/imsqti_asiv3p0_v1p0.xsd"
+      identifier="i67a0dfca446508820f6286cf78feea"
+      title="verhoudingen"
+      label="verhoudingen"
+      xml:lang="en-US"
+      adaptive="false"
+      time-dependent="false"
+      tool-name="TAO"
+      tool-version="3.4.0-sprint121"
+    >
+      <qti-response-declaration identifier="RESPONSE" cardinality="single" base-type="string">
+        <qti-correct-response>
+          <qti-value>[{&quot;color&quot;:&quot;blue&quot;,&quot;percentage&quot;:12.5},{&quot;color&quot;:&quot;green&quot;,&quot;percentage&quot;:12.5},{&quot;color&quot;:&quot;red&quot;,&quot;percentage&quot;:75}]</qti-value>
+        </qti-correct-response>
+      </qti-response-declaration>
+      <qti-outcome-declaration identifier="SCORE" cardinality="single" base-type="float"></qti-outcome-declaration>
+      <qti-item-body>
+        <div class="grid-row">
+          <div class="col-12">
+            <qti-portable-custom-interaction-test
+              custom-interaction-type-identifier="colorProportions"
+              data-version="1.0.1"
+              data-colors="red, blue, green"
+              data-width="400"
+              data-height="400"
+              data-base-url="/assets/qti-portable-interaction/verhoudingen/"
+              module="colorProportions"
+              response-identifier="RESPONSE"
+            >
+              <qti-interaction-modules>
+                <qti-interaction-module
+                  id="colorProportions"
+                  primary-path="/interaction/runtime/js/index.js"
+                ></qti-interaction-module>
+              </qti-interaction-modules>
+              <qti-interaction-markup>
+                <div class="pciInteraction">
+                  <div class="prompt"></div>
+                  <ul class="pci"></ul>
+                </div>
+              </qti-interaction-markup>
+            </qti-portable-custom-interaction-test>
+          </div>
+        </div>
+      </qti-item-body>
+    </qti-assessment-item>`;
+    return html`
+      <qti-item>
+        <item-container .itemXML=${qti}></item-container>
+      </qti-item>
+    `;
+  },
+  play: async ({ canvasElement, step }) => {
+    const qtiItem = canvasElement.querySelector('qti-item') as QtiItem;
+
+    const assessmentItem = await waitFor(
+      () => {
+        if (!qtiItem?.children.length) throw new Error('qtiItem has no children');
+        const item = qtiItem.children[0].shadowRoot.querySelector('qti-assessment-item') as QtiAssessmentItem;
+        if (!item) throw new Error('assessmentItem is not defined');
+        if (!item.querySelector('qti-portable-custom-interaction-test')) throw new Error('interaction not rendered');
+        return item;
+      },
+      { timeout: 10000, interval: 500 }
+    );
+
+    await step('show the correct response', async () => {
+      assessmentItem.showCorrectResponse(true);
+
+      const viewer = await waitFor(
+        () => {
+          const container = assessmentItem.querySelector('[id^="correct-response-container-"]');
+          if (!container) throw new Error('correct response container not found');
+          const el = container.querySelector('qti-portable-custom-interaction');
+          if (!el) throw new Error('correct response viewer not found');
+          return el as QtiPortableCustomInteraction;
+        },
+        { timeout: 10000, interval: 500 }
+      );
+
+      // Only the viewer's own iframe: the runtime generated children of the original
+      // interaction - its iframe and the review overlay - must not be cloned along.
+      expect(viewer.querySelectorAll('iframe')).toHaveLength(1);
+      expect(viewer.querySelector('.pci-interaction-overlay')).toBeNull();
+
+      await waitFor(
+        () => {
+          const cloneHtml = deepIframeHtml(viewer.querySelector('iframe'));
+          // The correct response is 75% red, 12.5% blue and 12.5% green; an
+          // unanswered interaction paints every square white instead.
+          expect(cloneHtml).toContain('fill="red"');
+          expect(cloneHtml).toContain('fill="blue"');
+          expect(cloneHtml).toContain('fill="green"');
+        },
+        { timeout: 10000, interval: 500 }
+      );
+    });
+
+    await step('hide the correct response', async () => {
+      // The viewer used to register itself as a real interaction on the item, which
+      // made this throw: Cannot read properties of undefined (reading 'cardinality')
+      assessmentItem.showCorrectResponse(false);
+
+      await waitFor(
+        () => {
+          expect(assessmentItem.querySelector('[id^="correct-response-container-"]')).toBeNull();
+          expect(assessmentItem.querySelector('.pci-interaction-overlay')).toBeNull();
+        },
+        { timeout: 10000, interval: 500 }
+      );
+    });
+  },
+  parameters: {
+    chromatic: { disableSnapshot: true }
+  }
+};
+
 // Base story function that accepts itemName as parameter
 const createPciConformanceStory = (itemName: string): Story => ({
   args: {

--- a/packages/interactions/portable-custom-interaction/src/qti-portable-custom-interaction.ts
+++ b/packages/interactions/portable-custom-interaction/src/qti-portable-custom-interaction.ts
@@ -1759,7 +1759,7 @@ export class QtiPortableCustomInteraction extends Interaction {
     // Store the correct response or clear it based on the show parameter
     this.correctResponse = show
       ? responseVariable?.correctResponse
-      : responseVariable.cardinality === 'single'
+      : responseVariable?.cardinality === 'single'
         ? ''
         : [];
 
@@ -1813,9 +1813,17 @@ export class QtiPortableCustomInteraction extends Interaction {
       'qti-portable-custom-interaction'
     ) as QtiPortableCustomInteraction;
 
-    // Copy all attributes from the original PCI
+    // Copy all attributes from the original PCI, except the ones that identify it
+    // or would make the clone show its own correct response / correction states
+    const skippedAttributes = [
+      'id',
+      'response-identifier',
+      'show-correct-response',
+      'show-full-correct-response',
+      'show-candidate-correction'
+    ];
     Array.from(this.attributes).forEach(attr => {
-      if (attr.name !== 'id' && attr.name !== 'response-identifier') {
+      if (!skippedAttributes.includes(attr.name)) {
         correctResponseViewer.setAttribute(attr.name, attr.value);
       }
     });
@@ -1824,40 +1832,44 @@ export class QtiPortableCustomInteraction extends Interaction {
     const originalResponseId = this.responseIdentifier;
     correctResponseViewer.responseIdentifier = `${originalResponseId}-correct`;
 
-    // Copy any light DOM content from the original PCI
-    // This includes markup and properties
-    Array.from(this.children).forEach(child => {
-      const clonedChild = child.cloneNode(true);
-      correctResponseViewer.appendChild(clonedChild);
-    });
+    // Mark as a correct-response clone so it does not register itself as a real
+    // interaction on the assessment item (it has no response declaration of its own).
+    // Must be set after the response identifier, since the setter derives from it.
+    correctResponseViewer.isFullCorrectResponse = true;
+
+    // Copy the authored light DOM content from the original PCI (modules, markup,
+    // properties and stylesheets). Runtime generated children - the iframe, its
+    // styles and the disabled overlay - must not be copied: a cloned iframe never
+    // loads and would render as a broken frame above the actual interaction.
+    Array.from(this.children)
+      .filter(child => child.tagName.startsWith('QTI-'))
+      .forEach(child => {
+        const clonedChild = child.cloneNode(true);
+        correctResponseViewer.appendChild(clonedChild);
+      });
 
     // Store the correct response value
     const correctResponseValue = responseVariable.correctResponse;
 
-    // Ensure the correct-response viewer is initialized and then configured in the iframe
-    const originalConnectedCallback = correctResponseViewer.connectedCallback;
-    correctResponseViewer.connectedCallback = function () {
-      originalConnectedCallback.call(this);
+    // Push the correct response into the viewer's iframe as soon as it is ready.
+    // Note: overriding connectedCallback on the instance has no effect, custom
+    // element reactions are looked up on the prototype when the element is defined.
+    const applyCorrectResponse = () => {
+      const qtiVariableJSON = correctResponseViewer.responseVariablesToQtiVariableJSON(
+        correctResponseValue,
+        responseVariable.cardinality,
+        responseVariable.baseType
+      );
 
-      const applyCorrectResponse = () => {
-        const qtiVariableJSON = this.responseVariablesToQtiVariableJSON(
-          correctResponseValue,
-          responseVariable.cardinality,
-          responseVariable.baseType
-        );
-
-        this.sendMessageToIframe('setBoundTo', {
-          [originalResponseId]: qtiVariableJSON
-        });
-        this.sendMessageToIframe('setState', { state: 'review' });
-      };
-
-      if (this._iframeLoaded) {
-        applyCorrectResponse();
-      } else {
-        this.addEventListener('qti-portable-custom-interaction-loaded', applyCorrectResponse, { once: true });
-      }
+      correctResponseViewer.sendMessageToIframe('setBoundTo', {
+        [originalResponseId]: qtiVariableJSON
+      });
+      correctResponseViewer.sendMessageToIframe('setState', { state: 'review' });
     };
+
+    correctResponseViewer.addEventListener('qti-portable-custom-interaction-loaded', applyCorrectResponse, {
+      once: true
+    });
 
     // Make sure the viewer is not interactive
     correctResponseViewer.style.pointerEvents = 'none';


### PR DESCRIPTION
## Problem

Showing the correct response of a portable custom interaction threw, and the viewer it rendered was unusable:

```
Uncaught TypeError: Cannot read properties of undefined (reading 'cardinality')
    at toggleInternalCorrectResponse
    at toggleCorrectResponse
    at QtiAssessmentItem.showCorrectResponse
    at _updateElementView   (test-view.mixin)
```

Reproduced with a TAO 2.2 package containing a `colorProportions` PCI (`customInteraction` / `portableCustomInteraction`, `RESPONSE` = single/string), toggling Candidate ⇄ Review Mode.

## Root cause

`toggleInternalCorrectResponse` builds a second `<qti-portable-custom-interaction>` as the correct-response viewer, but never marks it as a clone the way the base class does (`clone.isFullCorrectResponse = true` in `qti-base/src/abstract/interaction.ts`). So the viewer passed the guard in `#registerInteraction` and dispatched `qti-register-interaction`, landing in the assessment item's `#interactionElements`.

That gave the item an interaction whose response identifier has no response declaration, so its `responseVariable` getter returns `undefined`. The next `showCorrectResponse(false)` looped over every registered interaction including the ghost, and the hide branch dereferenced `responseVariable` without optional chaining.

## Changes

- Guard the hide branch with `responseVariable?.cardinality`.
- Set `isFullCorrectResponse = true` on the viewer so it never registers as a real interaction — after assigning the response identifier, since the setter derives the attribute from it.
- Skip `show-correct-response` / `show-full-correct-response` / `show-candidate-correction` when copying attributes (same exclusions the base clone makes). Previously the viewer inherited `show-correct-response`, called `disable()` on itself in `firstUpdated`, and covered itself with the review overlay.
- Copy only authored `QTI-*` light DOM children. The old loop copied every child, including the runtime-generated `<iframe>`, its styles and the disable overlay; a cloned iframe never loads and rendered as a dead grey frame above the real interaction.
- Apply the correct response from a `qti-portable-custom-interaction-loaded` listener instead of overriding `connectedCallback` on the instance. That override never ran — custom element reactions are looked up on the prototype when the element is defined — so `setBoundTo` was never sent and the viewer stayed blank.

## Verification

`tsc --noEmit` and `eslint` pass. Manually verified in qti-playground against the reporting package (yalc link):

- Toggle to Review Mode: correct response renders as specified (red 75%, blue 12.5%, green 12.5%), no dead frame, no overlay.
- Toggle back: container, clone and overlay removed; the interaction is interactive again.
- Repeated toggles: no `cardinality` TypeError in either direction, exactly one clone/container/overlay in review and zero in candidate — no leaks.



---

## Added since: regression test

`VerhoudingenShowCorrectResponse` in the PCI stories shows the correct response of a `colorProportions` PCI and hides it again. There was no PCI coverage for this before — the correct-response stories only exist for choice, inline-choice, order and text-entry, and `VerhoudingenRestoreResponse` only restores a *candidate* response — which is why nothing caught this.

It asserts the viewer holds exactly one iframe, carries no `.pci-interaction-overlay`, paints `fill="red"`/`"blue"`/`"green"` (an unanswered interaction paints `fill="#fff"`), and that hiding does not throw and removes the container. Verified to fail on `main` (`expected <iframe> to have a length of 1 but got 2`) and to fail again when only the `isFullCorrectResponse` guard is dropped (the viewer then gets disabled by the item's own loop).
