### PR TITLE
feat(pci): pass the response declaration into the getInstance configuration

### DIFF
--- a/.changeset/pci-response-declaration.md
+++ b/.changeset/pci-response-declaration.md
@@ -1,0 +1,16 @@
+---
+'@qti-components/portable-custom-interaction': minor
+---
+
+Pass the response declaration into the PCI `getInstance` configuration, so a PCI can render the
+correct response itself instead of having it pushed in as a candidate response.
+
+`responseDeclaration` is a camelCased mirror of `qti-response-declaration`, derived from the item
+context unless a host sets it explicitly. `status` carries the item lifecycle status, defaults to
+`interacting`, and is settable through the `data-status` attribute or the `status` property.
+
+`correctResponse` is only sent when `status` is `solution` or `review`. A PCI is third-party code
+in an iframe and has no reason to hold the answer key while the candidate is still working.
+
+Implements the design agreed in
+https://github.com/1EdTech/qti-project-management/issues/210

--- a/custom-elements.json
+++ b/custom-elements.json
@@ -20087,6 +20087,15 @@
               "description": "IFRAME MODE: Process pending messages"
             },
             {
+              "kind": "field",
+              "name": "#responseDeclaration",
+              "privacy": "private",
+              "type": {
+                "text": "PciResponseDeclaration | null"
+              },
+              "default": "null"
+            },
+            {
               "kind": "method",
               "name": "#sendIframeInitData",
               "privacy": "private",
@@ -20658,6 +20667,14 @@
             },
             {
               "kind": "field",
+              "name": "responseDeclaration",
+              "description": "Response declaration passed into the PCI configuration, so a PCI can render\nthe correct response itself instead of having it pushed in as a response.\n\nDerived from the item context, unless a host sets it explicitly - the\ncorrect response viewer does, since it has no response declaration of its own.\n\nSee https://github.com/1EdTech/qti-project-management/issues/210",
+              "type": {
+                "text": "PciResponseDeclaration | null"
+              }
+            },
+            {
+              "kind": "field",
               "name": "responseIdentifier",
               "type": {
                 "text": "string"
@@ -20806,6 +20823,19 @@
               "inheritedFrom": {
                 "name": "Interaction",
                 "module": "packages/qti-base/src/abstract/interaction.ts"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "status",
+              "type": {
+                "text": "PciInteractionStatus"
+              },
+              "default": "'interacting'",
+              "description": "Item lifecycle status handed to the PCI in its `getInstance` configuration.\nA delivery engine sets `solution` to let a PCI render the correct response.",
+              "attribute": "status",
+              "parsedType": {
+                "text": "'interacting' | 'suspended' | 'closed' | 'solution' | 'review'"
               }
             },
             {
@@ -21123,6 +21153,18 @@
               "inheritedFrom": {
                 "name": "Interaction",
                 "module": "packages/qti-base/src/abstract/interaction.ts"
+              }
+            },
+            {
+              "name": "status",
+              "type": {
+                "text": "PciInteractionStatus"
+              },
+              "default": "'interacting'",
+              "description": "Item lifecycle status handed to the PCI in its `getInstance` configuration.\nA delivery engine sets `solution` to let a PCI render the correct response.",
+              "fieldName": "status",
+              "parsedType": {
+                "text": "'interacting' | 'suspended' | 'closed' | 'solution' | 'review'"
               }
             }
           ],
@@ -21552,6 +21594,19 @@
                 "text": "boolean"
               },
               "default": "false"
+            },
+            {
+              "kind": "field",
+              "name": "#responseDeclaration",
+              "privacy": "private",
+              "type": {
+                "text": "PciResponseDeclaration | null"
+              },
+              "default": "null",
+              "inheritedFrom": {
+                "name": "QtiPortableCustomInteraction",
+                "module": "packages/interactions/portable-custom-interaction/src/qti-portable-custom-interaction.ts"
+              }
             },
             {
               "kind": "method",
@@ -22447,6 +22502,18 @@
             },
             {
               "kind": "field",
+              "name": "responseDeclaration",
+              "description": "Response declaration passed into the PCI configuration, so a PCI can render\nthe correct response itself instead of having it pushed in as a response.\n\nDerived from the item context, unless a host sets it explicitly - the\ncorrect response viewer does, since it has no response declaration of its own.\n\nSee https://github.com/1EdTech/qti-project-management/issues/210",
+              "type": {
+                "text": "PciResponseDeclaration | null"
+              },
+              "inheritedFrom": {
+                "name": "QtiPortableCustomInteraction",
+                "module": "packages/interactions/portable-custom-interaction/src/qti-portable-custom-interaction.ts"
+              }
+            },
+            {
+              "kind": "field",
               "name": "responseIdentifier",
               "type": {
                 "text": "string"
@@ -22624,6 +22691,23 @@
               "inheritedFrom": {
                 "name": "Interaction",
                 "module": "packages/qti-base/src/abstract/interaction.ts"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "status",
+              "type": {
+                "text": "PciInteractionStatus"
+              },
+              "default": "'interacting'",
+              "description": "Item lifecycle status handed to the PCI in its `getInstance` configuration.\nA delivery engine sets `solution` to let a PCI render the correct response.",
+              "attribute": "status",
+              "parsedType": {
+                "text": "'interacting' | 'suspended' | 'closed' | 'solution' | 'review'"
+              },
+              "inheritedFrom": {
+                "name": "QtiPortableCustomInteraction",
+                "module": "packages/interactions/portable-custom-interaction/src/qti-portable-custom-interaction.ts"
               }
             },
             {
@@ -22983,6 +23067,22 @@
               "inheritedFrom": {
                 "name": "Interaction",
                 "module": "packages/qti-base/src/abstract/interaction.ts"
+              }
+            },
+            {
+              "name": "status",
+              "type": {
+                "text": "PciInteractionStatus"
+              },
+              "default": "'interacting'",
+              "description": "Item lifecycle status handed to the PCI in its `getInstance` configuration.\nA delivery engine sets `solution` to let a PCI render the correct response.",
+              "fieldName": "status",
+              "parsedType": {
+                "text": "'interacting' | 'suspended' | 'closed' | 'solution' | 'review'"
+              },
+              "inheritedFrom": {
+                "name": "QtiPortableCustomInteraction",
+                "module": "packages/interactions/portable-custom-interaction/src/qti-portable-custom-interaction.ts"
               }
             }
           ],

--- a/custom-elements.json
+++ b/custom-elements.json
@@ -20233,6 +20233,17 @@
             },
             {
               "kind": "method",
+              "name": "#responseDeclarationForStatus",
+              "privacy": "private",
+              "return": {
+                "type": {
+                  "text": "PciResponseDeclaration | null"
+                }
+              },
+              "description": "The declaration as it goes into the PCI configuration.\n\n`correctResponse` is withheld unless the item is actually showing a solution. A PCI is\nthird-party code running in an iframe, and there is no reason for it to hold the answer key\nwhile the candidate is still working - the use case this field exists for only applies once\nthe status says the correct response is being shown.\n\nThe filter sits here rather than in the `responseDeclaration` getter so it also covers a\ndeclaration a host set explicitly, not just the one derived from the item context."
+            },
+            {
+              "kind": "method",
               "name": "#sendIframeInitData",
               "privacy": "private",
               "description": "IFRAME MODE: Send initialization data to iframe"
@@ -20969,7 +20980,7 @@
               },
               "default": "'interacting'",
               "description": "Item lifecycle status handed to the PCI in its `getInstance` configuration.\nA delivery engine sets `solution` to let a PCI render the correct response.",
-              "attribute": "status",
+              "attribute": "data-status",
               "parsedType": {
                 "text": "'interacting' | 'suspended' | 'closed' | 'solution' | 'review'"
               }
@@ -21195,6 +21206,18 @@
               "fieldName": "requireShimJson"
             },
             {
+              "name": "data-status",
+              "type": {
+                "text": "PciInteractionStatus"
+              },
+              "default": "'interacting'",
+              "description": "Item lifecycle status handed to the PCI in its `getInstance` configuration.\nA delivery engine sets `solution` to let a PCI render the correct response.",
+              "fieldName": "status",
+              "parsedType": {
+                "text": "'interacting' | 'suspended' | 'closed' | 'solution' | 'review'"
+              }
+            },
+            {
               "name": "data-use-default-paths",
               "type": {
                 "text": "boolean"
@@ -21289,18 +21312,6 @@
               "inheritedFrom": {
                 "name": "Interaction",
                 "module": "packages/qti-base/src/abstract/interaction.ts"
-              }
-            },
-            {
-              "name": "status",
-              "type": {
-                "text": "PciInteractionStatus"
-              },
-              "default": "'interacting'",
-              "description": "Item lifecycle status handed to the PCI in its `getInstance` configuration.\nA delivery engine sets `solution` to let a PCI render the correct response.",
-              "fieldName": "status",
-              "parsedType": {
-                "text": "'interacting' | 'suspended' | 'closed' | 'solution' | 'review'"
               }
             }
           ],
@@ -21739,6 +21750,21 @@
                 "text": "PciResponseDeclaration | null"
               },
               "default": "null",
+              "inheritedFrom": {
+                "name": "QtiPortableCustomInteraction",
+                "module": "packages/interactions/portable-custom-interaction/src/qti-portable-custom-interaction.ts"
+              }
+            },
+            {
+              "kind": "method",
+              "name": "#responseDeclarationForStatus",
+              "privacy": "private",
+              "return": {
+                "type": {
+                  "text": "PciResponseDeclaration | null"
+                }
+              },
+              "description": "The declaration as it goes into the PCI configuration.\n\n`correctResponse` is withheld unless the item is actually showing a solution. A PCI is\nthird-party code running in an iframe, and there is no reason for it to hold the answer key\nwhile the candidate is still working - the use case this field exists for only applies once\nthe status says the correct response is being shown.\n\nThe filter sits here rather than in the `responseDeclaration` getter so it also covers a\ndeclaration a host set explicitly, not just the one derived from the item context.",
               "inheritedFrom": {
                 "name": "QtiPortableCustomInteraction",
                 "module": "packages/interactions/portable-custom-interaction/src/qti-portable-custom-interaction.ts"
@@ -22837,7 +22863,7 @@
               },
               "default": "'interacting'",
               "description": "Item lifecycle status handed to the PCI in its `getInstance` configuration.\nA delivery engine sets `solution` to let a PCI render the correct response.",
-              "attribute": "status",
+              "attribute": "data-status",
               "parsedType": {
                 "text": "'interacting' | 'suspended' | 'closed' | 'solution' | 'review'"
               },
@@ -23101,6 +23127,22 @@
               }
             },
             {
+              "name": "data-status",
+              "type": {
+                "text": "PciInteractionStatus"
+              },
+              "default": "'interacting'",
+              "description": "Item lifecycle status handed to the PCI in its `getInstance` configuration.\nA delivery engine sets `solution` to let a PCI render the correct response.",
+              "fieldName": "status",
+              "parsedType": {
+                "text": "'interacting' | 'suspended' | 'closed' | 'solution' | 'review'"
+              },
+              "inheritedFrom": {
+                "name": "QtiPortableCustomInteraction",
+                "module": "packages/interactions/portable-custom-interaction/src/qti-portable-custom-interaction.ts"
+              }
+            },
+            {
               "name": "data-use-default-paths",
               "type": {
                 "text": "boolean"
@@ -23203,22 +23245,6 @@
               "inheritedFrom": {
                 "name": "Interaction",
                 "module": "packages/qti-base/src/abstract/interaction.ts"
-              }
-            },
-            {
-              "name": "status",
-              "type": {
-                "text": "PciInteractionStatus"
-              },
-              "default": "'interacting'",
-              "description": "Item lifecycle status handed to the PCI in its `getInstance` configuration.\nA delivery engine sets `solution` to let a PCI render the correct response.",
-              "fieldName": "status",
-              "parsedType": {
-                "text": "'interacting' | 'suspended' | 'closed' | 'solution' | 'review'"
-              },
-              "inheritedFrom": {
-                "name": "QtiPortableCustomInteraction",
-                "module": "packages/interactions/portable-custom-interaction/src/qti-portable-custom-interaction.ts"
               }
             }
           ],

--- a/packages/interactions/portable-custom-interaction/src/interface.ts
+++ b/packages/interactions/portable-custom-interaction/src/interface.ts
@@ -1,9 +1,37 @@
+import type { BaseType, Cardinality } from '@qti-components/base';
+
 /**
  * Shared status values for PCI lifecycle callbacks.
  *
  * Matches the status vocabulary used in IMS QTI 3 PCI documentation.
  */
 export type PciInteractionStatus = 'interacting' | 'suspended' | 'closed' | 'solution' | 'review';
+
+/**
+ * Correct response of a response declaration, mirroring `qti-correct-response`.
+ *
+ * `value` holds the authored `qti-value` content: a single value for `single`
+ * cardinality, an array of values for every other cardinality.
+ */
+export interface PciCorrectResponse {
+  value: string | string[];
+}
+
+/**
+ * Response declaration passed into the `getInstance` configuration so a PCI can
+ * render a correct response itself when the item is in `solution` status.
+ *
+ * Mirrors `qti-response-declaration` with camelCased names. Every field is
+ * optional, a delivery engine passes as much or as little as it has, and
+ * `correctResponse` is absent when the response variable has none.
+ *
+ * See https://github.com/1EdTech/qti-project-management/issues/210
+ */
+export interface PciResponseDeclaration {
+  baseType?: BaseType;
+  cardinality?: Cardinality;
+  correctResponse?: PciCorrectResponse;
+}
 
 /**
  * Payload passed to `onready` once a PCI reports it is ready.
@@ -37,6 +65,7 @@ export interface ConfigProperties<T> {
   contextVariables: Record<string, unknown>; // Follows structure in Appendix C
   boundTo: unknown; // Follows structure in Appendix C
   responseIdentifier: string; // Unique within interaction scope
+  responseDeclaration?: PciResponseDeclaration; // Optional, carries the correct response when the item declares one
 
   onready: (payload: PciReadyPayload) => void; // Callback for when PCI is fully constructed and ready
   ondone?: (payload: PciDonePayload) => void; // Optional callback when candidate finishes interaction

--- a/packages/interactions/portable-custom-interaction/src/interface.ts
+++ b/packages/interactions/portable-custom-interaction/src/interface.ts
@@ -25,6 +25,10 @@ export interface PciCorrectResponse {
  * optional, a delivery engine passes as much or as little as it has, and
  * `correctResponse` is absent when the response variable has none.
  *
+ * `correctResponse` is also withheld while the candidate is still working: it is
+ * only sent when `status` is `solution` or `review`, so a PCI never holds the
+ * answer key during `interacting`.
+ *
  * See https://github.com/1EdTech/qti-project-management/issues/210
  */
 export interface PciResponseDeclaration {
@@ -65,7 +69,7 @@ export interface ConfigProperties<T> {
   contextVariables: Record<string, unknown>; // Follows structure in Appendix C
   boundTo: unknown; // Follows structure in Appendix C
   responseIdentifier: string; // Unique within interaction scope
-  responseDeclaration?: PciResponseDeclaration; // Optional, carries the correct response when the item declares one
+  responseDeclaration?: PciResponseDeclaration; // Optional; carries correctResponse only when status is solution/review
 
   onready: (payload: PciReadyPayload) => void; // Callback for when PCI is fully constructed and ready
   ondone?: (payload: PciDonePayload) => void; // Optional callback when candidate finishes interaction

--- a/packages/interactions/portable-custom-interaction/src/qti-portable-custom-interaction.stories.ts
+++ b/packages/interactions/portable-custom-interaction/src/qti-portable-custom-interaction.stories.ts
@@ -8,6 +8,7 @@ import { qtiTransformItem } from '@qti-components/transformers';
 import type { ItemContainer, QtiItem } from '@qti-components/item';
 import type { ModuleResolutionConfig } from '@qti-components/transformers';
 import type { QtiPortableCustomInteraction } from './qti-portable-custom-interaction';
+import type { QtiPortableCustomInteractionTest } from './qti-portable-custom-test-interaction';
 import type { QtiAssessmentItem } from '@qti-components/elements';
 import type { StoryObj, Meta } from '@storybook/web-components-vite';
 
@@ -751,3 +752,119 @@ export const PciConformance3: Story = createPciConformanceStory('item-3');
 export const PciConformance4: Story = createPciConformanceStory('item-4');
 export const PciConformance5: Story = createPciConformanceStory('item-5');
 export const PciConformance6: Story = createPciConformanceStory('item-6');
+
+/**
+ * The correct response must not reach a PCI while the candidate is still working.
+ *
+ * A PCI is third-party code in an iframe, and `responseDeclaration` exists so it can render the
+ * correct response once the item is *showing* one. Handing it the answer key at `interacting`
+ * would widen a leak that today stays inside our own DOM. `correctResponse` is therefore only
+ * sent when `status` is `solution` or `review`; `baseType` and `cardinality` always go through.
+ *
+ * Also covers an empty `<qti-correct-response>` on a non-single cardinality, which yields `[]`
+ * from the response variable and must read as "no correct response" rather than an empty one.
+ */
+export const CorrectResponseWithheldWhileInteracting: Story = {
+  render: () =>
+    html`<qti-assessment-item
+      xmlns="http://www.imsglobal.org/xsd/imsqtiasi_v3p0"
+      adaptive="false"
+      time-dependent="false"
+      identifier="pci-correct-response-gating"
+      title="PCI correct response gating"
+    >
+      <qti-response-declaration identifier="RESPONSE" cardinality="single" base-type="string">
+        <qti-correct-response>
+          <qti-value>42</qti-value>
+        </qti-correct-response>
+      </qti-response-declaration>
+      <qti-response-declaration identifier="RESPONSE_EMPTY" cardinality="multiple" base-type="identifier">
+        <qti-correct-response></qti-correct-response>
+      </qti-response-declaration>
+      <qti-item-body>
+        <qti-portable-custom-interaction-test
+          response-identifier="RESPONSE"
+          module="pci-getallen"
+          custom-interaction-type-identifier="getallenFormule"
+          data-base-url="/assets/qti-portable-interaction/baking_soda"
+        >
+          <qti-interaction-modules>
+            <qti-interaction-module id="pci-getallen" primary-path="pci-getallen.js"></qti-interaction-module>
+          </qti-interaction-modules>
+          <qti-interaction-markup></qti-interaction-markup>
+        </qti-portable-custom-interaction-test>
+        <qti-portable-custom-interaction-test
+          response-identifier="RESPONSE_EMPTY"
+          module="pci-getallen"
+          custom-interaction-type-identifier="getallenFormule"
+          data-base-url="/assets/qti-portable-interaction/baking_soda"
+        >
+          <qti-interaction-modules>
+            <qti-interaction-module id="pci-getallen" primary-path="pci-getallen.js"></qti-interaction-module>
+          </qti-interaction-modules>
+          <qti-interaction-markup></qti-interaction-markup>
+        </qti-portable-custom-interaction-test>
+      </qti-item-body>
+    </qti-assessment-item>`,
+  play: async ({ canvasElement, step }) => {
+    const [withCorrect, withEmptyCorrect] = Array.from(
+      canvasElement.querySelectorAll('qti-portable-custom-interaction-test')
+    ) as QtiPortableCustomInteractionTest[];
+
+    const configOf = (el: QtiPortableCustomInteractionTest) =>
+      (el.querySelector('iframe')?.contentWindow as any)?.PCIManager?.pciConfig;
+
+    await Promise.all(
+      [withCorrect, withEmptyCorrect].map(
+        el =>
+          new Promise(resolve =>
+            el.addEventListener('qti-portable-custom-interaction-loaded', () => resolve(true), { once: true })
+          )
+      )
+    );
+
+    await step('interacting: declaration goes through, correct response does not', async () => {
+      await waitFor(
+        () => {
+          const config = configOf(withCorrect);
+          expect(config?.status).toBe('interacting');
+          // The shape the PCI needs to interpret responses is still there...
+          expect(config?.responseDeclaration).toEqual({ baseType: 'string', cardinality: 'single' });
+          // ...but the answer key is not.
+          expect(config?.responseDeclaration?.correctResponse).toBeUndefined();
+        },
+        { timeout: 10000, interval: 250 }
+      );
+    });
+
+    await step('an empty qti-correct-response is not reported as a correct response', async () => {
+      // `multiple` cardinality yields [] for an empty element, which must not become
+      // correctResponse: { value: [] }.
+      expect(withEmptyCorrect.responseDeclaration).toEqual({
+        baseType: 'identifier',
+        cardinality: 'multiple'
+      });
+    });
+
+    await step('solution: the correct response is handed over', async () => {
+      withCorrect.status = 'solution';
+      await withCorrect.recreateIframe();
+
+      await waitFor(
+        () => {
+          const config = configOf(withCorrect);
+          expect(config?.status).toBe('solution');
+          expect(config?.responseDeclaration).toEqual({
+            baseType: 'string',
+            cardinality: 'single',
+            correctResponse: { value: '42' }
+          });
+        },
+        { timeout: 10000, interval: 250 }
+      );
+    });
+  },
+  parameters: {
+    chromatic: { disableSnapshot: true }
+  }
+};

--- a/packages/interactions/portable-custom-interaction/src/qti-portable-custom-interaction.stories.ts
+++ b/packages/interactions/portable-custom-interaction/src/qti-portable-custom-interaction.stories.ts
@@ -48,6 +48,18 @@ type Story = StoryObj<QtiPortableCustomInteraction & typeof args>;
  * - `<properties>` element: raw properties markup forwarded to PCI.
  * - `data-*` attributes: forwarded as PCI `properties` values.
  *   advanced RequireJS configuration controls.
+ * - `status`: item lifecycle status handed to the PCI, defaults to `interacting`.
+ *
+ * ### Correct Response
+ * The `getInstance` configuration carries an optional `responseDeclaration` (camelCased
+ * `qti-response-declaration`, with `baseType`, `cardinality` and `correctResponse`), so a PCI
+ * can render the correct response itself when it is constructed with `status: 'solution'`:
+ * ```js
+ * getInstance(dom, { responseIdentifier: 'RESPONSE', status: 'solution',
+ *   responseDeclaration: { baseType: 'identifier', cardinality: 'single', correctResponse: { value: 'A' } }
+ * }, state)
+ * ```
+ * See https://github.com/1EdTech/qti-project-management/issues/210
  *
  * ### Implementation Guide Coverage (this component)
  * - Implemented: host element contract, response/state bridge, `data-*` to properties,
@@ -620,6 +632,19 @@ export const VerhoudingenShowCorrectResponse = {
 
       await waitFor(
         () => {
+          // The PCI is constructed in solution status and gets the correct response
+          // through its configuration: https://github.com/1EdTech/qti-project-management/issues/210
+          const pciConfig = (viewer.querySelector('iframe')?.contentWindow as any)?.PCIManager?.pciConfig;
+          expect(pciConfig?.status).toBe('solution');
+          expect(pciConfig?.responseDeclaration).toEqual({
+            baseType: 'string',
+            cardinality: 'single',
+            correctResponse: {
+              value:
+                '[{"color":"blue","percentage":12.5},{"color":"green","percentage":12.5},{"color":"red","percentage":75}]'
+            }
+          });
+
           const cloneHtml = deepIframeHtml(viewer.querySelector('iframe'));
           // The correct response is 75% red, 12.5% blue and 12.5% green; an
           // unanswered interaction paints every square white instead.

--- a/packages/interactions/portable-custom-interaction/src/qti-portable-custom-interaction.stories.ts
+++ b/packages/interactions/portable-custom-interaction/src/qti-portable-custom-interaction.stories.ts
@@ -514,6 +514,142 @@ export const VerhoudingenRestoreResponse = {
   }
 };
 
+/**
+ * The PCI renders inside an iframe and paints into shadow roots, so collect both
+ * to be able to assert on what a candidate actually sees.
+ */
+const deepIframeHtml = (iframe: HTMLIFrameElement | null): string => {
+  const doc = iframe?.contentDocument;
+  if (!doc) return '';
+  const collectShadowHtml = (root: ParentNode): string[] =>
+    Array.from(root.querySelectorAll('*')).flatMap(node =>
+      node.shadowRoot ? [node.shadowRoot.innerHTML, ...collectShadowHtml(node.shadowRoot)] : []
+    );
+  return [doc.body.innerHTML, ...collectShadowHtml(doc)].join('\n');
+};
+
+export const VerhoudingenShowCorrectResponse = {
+  render: () => {
+    const qti = `<qti-assessment-item
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns="http://www.imsglobal.org/xsd/imsqtiasi_v3p0"
+      xsi:schemaLocation="http://www.imsglobal.org/xsd/imsqtiasi_v3p0 https://purl.imsglobal.org/spec/qti/v3p0/schema/xsd/imsqti_asiv3p0_v1p0.xsd"
+      identifier="i67a0dfca446508820f6286cf78feea"
+      title="verhoudingen"
+      label="verhoudingen"
+      xml:lang="en-US"
+      adaptive="false"
+      time-dependent="false"
+      tool-name="TAO"
+      tool-version="3.4.0-sprint121"
+    >
+      <qti-response-declaration identifier="RESPONSE" cardinality="single" base-type="string">
+        <qti-correct-response>
+          <qti-value>[{&quot;color&quot;:&quot;blue&quot;,&quot;percentage&quot;:12.5},{&quot;color&quot;:&quot;green&quot;,&quot;percentage&quot;:12.5},{&quot;color&quot;:&quot;red&quot;,&quot;percentage&quot;:75}]</qti-value>
+        </qti-correct-response>
+      </qti-response-declaration>
+      <qti-outcome-declaration identifier="SCORE" cardinality="single" base-type="float"></qti-outcome-declaration>
+      <qti-item-body>
+        <div class="grid-row">
+          <div class="col-12">
+            <qti-portable-custom-interaction-test
+              custom-interaction-type-identifier="colorProportions"
+              data-version="1.0.1"
+              data-colors="red, blue, green"
+              data-width="400"
+              data-height="400"
+              data-base-url="/assets/qti-portable-interaction/verhoudingen/"
+              module="colorProportions"
+              response-identifier="RESPONSE"
+            >
+              <qti-interaction-modules>
+                <qti-interaction-module
+                  id="colorProportions"
+                  primary-path="/interaction/runtime/js/index.js"
+                ></qti-interaction-module>
+              </qti-interaction-modules>
+              <qti-interaction-markup>
+                <div class="pciInteraction">
+                  <div class="prompt"></div>
+                  <ul class="pci"></ul>
+                </div>
+              </qti-interaction-markup>
+            </qti-portable-custom-interaction-test>
+          </div>
+        </div>
+      </qti-item-body>
+    </qti-assessment-item>`;
+    return html`
+      <qti-item>
+        <item-container .itemXML=${qti}></item-container>
+      </qti-item>
+    `;
+  },
+  play: async ({ canvasElement, step }) => {
+    const qtiItem = canvasElement.querySelector('qti-item') as QtiItem;
+
+    const assessmentItem = await waitFor(
+      () => {
+        if (!qtiItem?.children.length) throw new Error('qtiItem has no children');
+        const item = qtiItem.children[0].shadowRoot.querySelector('qti-assessment-item') as QtiAssessmentItem;
+        if (!item) throw new Error('assessmentItem is not defined');
+        if (!item.querySelector('qti-portable-custom-interaction-test')) throw new Error('interaction not rendered');
+        return item;
+      },
+      { timeout: 10000, interval: 500 }
+    );
+
+    await step('show the correct response', async () => {
+      assessmentItem.showCorrectResponse(true);
+
+      const viewer = await waitFor(
+        () => {
+          const container = assessmentItem.querySelector('[id^="correct-response-container-"]');
+          if (!container) throw new Error('correct response container not found');
+          const el = container.querySelector('qti-portable-custom-interaction');
+          if (!el) throw new Error('correct response viewer not found');
+          return el as QtiPortableCustomInteraction;
+        },
+        { timeout: 10000, interval: 500 }
+      );
+
+      // Only the viewer's own iframe: the runtime generated children of the original
+      // interaction - its iframe and the review overlay - must not be cloned along.
+      expect(viewer.querySelectorAll('iframe')).toHaveLength(1);
+      expect(viewer.querySelector('.pci-interaction-overlay')).toBeNull();
+
+      await waitFor(
+        () => {
+          const cloneHtml = deepIframeHtml(viewer.querySelector('iframe'));
+          // The correct response is 75% red, 12.5% blue and 12.5% green; an
+          // unanswered interaction paints every square white instead.
+          expect(cloneHtml).toContain('fill="red"');
+          expect(cloneHtml).toContain('fill="blue"');
+          expect(cloneHtml).toContain('fill="green"');
+        },
+        { timeout: 10000, interval: 500 }
+      );
+    });
+
+    await step('hide the correct response', async () => {
+      // The viewer used to register itself as a real interaction on the item, which
+      // made this throw: Cannot read properties of undefined (reading 'cardinality')
+      assessmentItem.showCorrectResponse(false);
+
+      await waitFor(
+        () => {
+          expect(assessmentItem.querySelector('[id^="correct-response-container-"]')).toBeNull();
+          expect(assessmentItem.querySelector('.pci-interaction-overlay')).toBeNull();
+        },
+        { timeout: 10000, interval: 500 }
+      );
+    });
+  },
+  parameters: {
+    chromatic: { disableSnapshot: true }
+  }
+};
+
 // Base story function that accepts itemName as parameter
 const createPciConformanceStory = (itemName: string): Story => ({
   args: {

--- a/packages/interactions/portable-custom-interaction/src/qti-portable-custom-interaction.ts
+++ b/packages/interactions/portable-custom-interaction/src/qti-portable-custom-interaction.ts
@@ -8,7 +8,13 @@ import styles from './qti-portable-custom-interaction.styles';
 
 import type { CSSResultGroup } from 'lit';
 import type { BaseType, Cardinality, ItemContext, QtiContext } from '@qti-components/base';
-import type { QtiRecordItem, QtiVariableJSON, ResponseVariableType } from './interface';
+import type {
+  PciInteractionStatus,
+  PciResponseDeclaration,
+  QtiRecordItem,
+  QtiVariableJSON,
+  ResponseVariableType
+} from './interface';
 
 export class QtiPortableCustomInteraction extends Interaction {
   #value: string | string[];
@@ -51,6 +57,51 @@ export class QtiPortableCustomInteraction extends Interaction {
 
   @property({ type: Boolean, attribute: 'data-use-default-paths' })
   useDefaultPaths = false;
+
+  /**
+   * Item lifecycle status handed to the PCI in its `getInstance` configuration.
+   * A delivery engine sets `solution` to let a PCI render the correct response.
+   */
+  @property({ type: String, attribute: 'status' })
+  status: PciInteractionStatus = 'interacting';
+
+  #responseDeclaration: PciResponseDeclaration | null = null;
+
+  /**
+   * Response declaration passed into the PCI configuration, so a PCI can render
+   * the correct response itself instead of having it pushed in as a response.
+   *
+   * Derived from the item context, unless a host sets it explicitly - the
+   * correct response viewer does, since it has no response declaration of its own.
+   *
+   * See https://github.com/1EdTech/qti-project-management/issues/210
+   */
+  set responseDeclaration(declaration: PciResponseDeclaration | null) {
+    this.#responseDeclaration = declaration;
+  }
+
+  get responseDeclaration(): PciResponseDeclaration | null {
+    if (this.#responseDeclaration) {
+      return this.#responseDeclaration;
+    }
+
+    const variable = this.responseVariable;
+    if (!variable) {
+      return null;
+    }
+
+    const declaration: PciResponseDeclaration = {
+      baseType: variable.baseType,
+      cardinality: variable.cardinality
+    };
+
+    const correctResponse = variable.correctResponse;
+    if (correctResponse !== null && correctResponse !== undefined && correctResponse !== '') {
+      declaration.correctResponse = { value: correctResponse };
+    }
+
+    return declaration;
+  }
 
   @state()
   private _errorMessage: string = null;
@@ -764,6 +815,8 @@ export class QtiPortableCustomInteraction extends Interaction {
       dataAttributes: { ...this.dataset },
       interactionModules: this.#getInteractionModules(),
       boundTo: storedState ? null : this.boundTo,
+      responseDeclaration: this.responseDeclaration,
+      status: this.status,
       state: storedState
     };
 
@@ -993,6 +1046,7 @@ export class QtiPortableCustomInteraction extends Interaction {
             // PCI Manager for iframe implementation
             window.PCIManager = {
               pciInstance: null,
+              pciConfig: null,
               container: null,
               markupEl: null,
               propertiesEl: null,
@@ -1218,7 +1272,9 @@ export class QtiPortableCustomInteraction extends Interaction {
                           );
                         },
                         responseIdentifier: config.responseIdentifier,
-                        boundTo: config.boundTo
+                        boundTo: config.boundTo,
+                        responseDeclaration: config.responseDeclaration || undefined,
+                        status: config.status || 'interacting'
                       };
 
                       if (pciInstance.getInstance) {
@@ -1234,6 +1290,9 @@ export class QtiPortableCustomInteraction extends Interaction {
                             restoredState = config.state;
                           }
                         }
+                        // Keep the configuration around next to the instance, it carries the
+                        // status and response declaration this PCI was constructed with.
+                        this.pciConfig = pciConfig;
                         pciInstance.getInstance(dom, pciConfig, restoredState || undefined);
                       } else {
                         this.notifyError('Loaded PCI module has no getInstance().');
@@ -1851,7 +1910,19 @@ export class QtiPortableCustomInteraction extends Interaction {
     // Store the correct response value
     const correctResponseValue = responseVariable.correctResponse;
 
+    // Hand the correct response to the viewer the standard way as well: a PCI that
+    // implements the solution use case reads it from its getInstance configuration.
+    // See https://github.com/1EdTech/qti-project-management/issues/210
+    correctResponseViewer.status = 'solution';
+    correctResponseViewer.responseDeclaration = {
+      baseType: responseVariable.baseType,
+      cardinality: responseVariable.cardinality,
+      correctResponse: { value: correctResponseValue }
+    };
+
     // Push the correct response into the viewer's iframe as soon as it is ready.
+    // Kept next to the responseDeclaration above for PCIs that do not implement
+    // the solution use case: they only know how to render a bound response.
     // Note: overriding connectedCallback on the instance has no effect, custom
     // element reactions are looked up on the prototype when the element is defined.
     const applyCorrectResponse = () => {

--- a/packages/interactions/portable-custom-interaction/src/qti-portable-custom-interaction.ts
+++ b/packages/interactions/portable-custom-interaction/src/qti-portable-custom-interaction.ts
@@ -16,6 +16,20 @@ import type {
   ResponseVariableType
 } from './interface';
 
+/** Statuses in which the item is showing the correct response, so a PCI may legitimately see it. */
+const STATUSES_SHOWING_CORRECT_RESPONSE: PciInteractionStatus[] = ['solution', 'review'];
+
+/**
+ * Whether a response variable actually declares a correct response.
+ *
+ * Non-single cardinality yields `[]` for an empty `<qti-correct-response>`, which is "no correct
+ * response" and must not be reported as one.
+ */
+function hasCorrectResponseValue(value: string | string[] | null | undefined): boolean {
+  if (value === null || value === undefined) return false;
+  return Array.isArray(value) ? value.length > 0 : value !== '';
+}
+
 export class QtiPortableCustomInteraction extends Interaction {
   #value: string | string[];
 
@@ -62,7 +76,7 @@ export class QtiPortableCustomInteraction extends Interaction {
    * Item lifecycle status handed to the PCI in its `getInstance` configuration.
    * A delivery engine sets `solution` to let a PCI render the correct response.
    */
-  @property({ type: String, attribute: 'status' })
+  @property({ type: String, attribute: 'data-status' })
   status: PciInteractionStatus = 'interacting';
 
   #responseDeclaration: PciResponseDeclaration | null = null;
@@ -96,11 +110,35 @@ export class QtiPortableCustomInteraction extends Interaction {
     };
 
     const correctResponse = variable.correctResponse;
-    if (correctResponse !== null && correctResponse !== undefined && correctResponse !== '') {
+    if (hasCorrectResponseValue(correctResponse)) {
       declaration.correctResponse = { value: correctResponse };
     }
 
     return declaration;
+  }
+
+  /**
+   * The declaration as it goes into the PCI configuration.
+   *
+   * `correctResponse` is withheld unless the item is actually showing a solution. A PCI is
+   * third-party code running in an iframe, and there is no reason for it to hold the answer key
+   * while the candidate is still working - the use case this field exists for only applies once
+   * the status says the correct response is being shown.
+   *
+   * The filter sits here rather than in the `responseDeclaration` getter so it also covers a
+   * declaration a host set explicitly, not just the one derived from the item context.
+   */
+  #responseDeclarationForStatus(): PciResponseDeclaration | null {
+    const declaration = this.responseDeclaration;
+    if (!declaration?.correctResponse) {
+      return declaration;
+    }
+    if (STATUSES_SHOWING_CORRECT_RESPONSE.includes(this.status)) {
+      return declaration;
+    }
+
+    const { correctResponse: _withheld, ...rest } = declaration;
+    return rest;
   }
 
   @state()
@@ -815,7 +853,7 @@ export class QtiPortableCustomInteraction extends Interaction {
       dataAttributes: { ...this.dataset },
       interactionModules: this.#getInteractionModules(),
       boundTo: storedState ? null : this.boundTo,
-      responseDeclaration: this.responseDeclaration,
+      responseDeclaration: this.#responseDeclarationForStatus(),
       status: this.status,
       state: storedState
     };

--- a/packages/interactions/portable-custom-interaction/src/qti-portable-custom-interaction.ts
+++ b/packages/interactions/portable-custom-interaction/src/qti-portable-custom-interaction.ts
@@ -1759,7 +1759,7 @@ export class QtiPortableCustomInteraction extends Interaction {
     // Store the correct response or clear it based on the show parameter
     this.correctResponse = show
       ? responseVariable?.correctResponse
-      : responseVariable.cardinality === 'single'
+      : responseVariable?.cardinality === 'single'
         ? ''
         : [];
 
@@ -1813,9 +1813,17 @@ export class QtiPortableCustomInteraction extends Interaction {
       'qti-portable-custom-interaction'
     ) as QtiPortableCustomInteraction;
 
-    // Copy all attributes from the original PCI
+    // Copy all attributes from the original PCI, except the ones that identify it
+    // or would make the clone show its own correct response / correction states
+    const skippedAttributes = [
+      'id',
+      'response-identifier',
+      'show-correct-response',
+      'show-full-correct-response',
+      'show-candidate-correction'
+    ];
     Array.from(this.attributes).forEach(attr => {
-      if (attr.name !== 'id' && attr.name !== 'response-identifier') {
+      if (!skippedAttributes.includes(attr.name)) {
         correctResponseViewer.setAttribute(attr.name, attr.value);
       }
     });
@@ -1824,40 +1832,44 @@ export class QtiPortableCustomInteraction extends Interaction {
     const originalResponseId = this.responseIdentifier;
     correctResponseViewer.responseIdentifier = `${originalResponseId}-correct`;
 
-    // Copy any light DOM content from the original PCI
-    // This includes markup and properties
-    Array.from(this.children).forEach(child => {
-      const clonedChild = child.cloneNode(true);
-      correctResponseViewer.appendChild(clonedChild);
-    });
+    // Mark as a correct-response clone so it does not register itself as a real
+    // interaction on the assessment item (it has no response declaration of its own).
+    // Must be set after the response identifier, since the setter derives from it.
+    correctResponseViewer.isFullCorrectResponse = true;
+
+    // Copy the authored light DOM content from the original PCI (modules, markup,
+    // properties and stylesheets). Runtime generated children - the iframe, its
+    // styles and the disabled overlay - must not be copied: a cloned iframe never
+    // loads and would render as a broken frame above the actual interaction.
+    Array.from(this.children)
+      .filter(child => child.tagName.startsWith('QTI-'))
+      .forEach(child => {
+        const clonedChild = child.cloneNode(true);
+        correctResponseViewer.appendChild(clonedChild);
+      });
 
     // Store the correct response value
     const correctResponseValue = responseVariable.correctResponse;
 
-    // Ensure the correct-response viewer is initialized and then configured in the iframe
-    const originalConnectedCallback = correctResponseViewer.connectedCallback;
-    correctResponseViewer.connectedCallback = function () {
-      originalConnectedCallback.call(this);
+    // Push the correct response into the viewer's iframe as soon as it is ready.
+    // Note: overriding connectedCallback on the instance has no effect, custom
+    // element reactions are looked up on the prototype when the element is defined.
+    const applyCorrectResponse = () => {
+      const qtiVariableJSON = correctResponseViewer.responseVariablesToQtiVariableJSON(
+        correctResponseValue,
+        responseVariable.cardinality,
+        responseVariable.baseType
+      );
 
-      const applyCorrectResponse = () => {
-        const qtiVariableJSON = this.responseVariablesToQtiVariableJSON(
-          correctResponseValue,
-          responseVariable.cardinality,
-          responseVariable.baseType
-        );
-
-        this.sendMessageToIframe('setBoundTo', {
-          [originalResponseId]: qtiVariableJSON
-        });
-        this.sendMessageToIframe('setState', { state: 'review' });
-      };
-
-      if (this._iframeLoaded) {
-        applyCorrectResponse();
-      } else {
-        this.addEventListener('qti-portable-custom-interaction-loaded', applyCorrectResponse, { once: true });
-      }
+      correctResponseViewer.sendMessageToIframe('setBoundTo', {
+        [originalResponseId]: qtiVariableJSON
+      });
+      correctResponseViewer.sendMessageToIframe('setState', { state: 'review' });
     };
+
+    correctResponseViewer.addEventListener('qti-portable-custom-interaction-loaded', applyCorrectResponse, {
+      once: true
+    });
 
     // Make sure the viewer is not interactive
     correctResponseViewer.style.pointerEvents = 'none';

--- a/packages/qti-components/custom-elements.json
+++ b/packages/qti-components/custom-elements.json
@@ -20087,6 +20087,15 @@
               "description": "IFRAME MODE: Process pending messages"
             },
             {
+              "kind": "field",
+              "name": "#responseDeclaration",
+              "privacy": "private",
+              "type": {
+                "text": "PciResponseDeclaration | null"
+              },
+              "default": "null"
+            },
+            {
               "kind": "method",
               "name": "#sendIframeInitData",
               "privacy": "private",
@@ -20658,6 +20667,14 @@
             },
             {
               "kind": "field",
+              "name": "responseDeclaration",
+              "description": "Response declaration passed into the PCI configuration, so a PCI can render\nthe correct response itself instead of having it pushed in as a response.\n\nDerived from the item context, unless a host sets it explicitly - the\ncorrect response viewer does, since it has no response declaration of its own.\n\nSee https://github.com/1EdTech/qti-project-management/issues/210",
+              "type": {
+                "text": "PciResponseDeclaration | null"
+              }
+            },
+            {
+              "kind": "field",
               "name": "responseIdentifier",
               "type": {
                 "text": "string"
@@ -20806,6 +20823,19 @@
               "inheritedFrom": {
                 "name": "Interaction",
                 "module": "packages/qti-base/src/abstract/interaction.ts"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "status",
+              "type": {
+                "text": "PciInteractionStatus"
+              },
+              "default": "'interacting'",
+              "description": "Item lifecycle status handed to the PCI in its `getInstance` configuration.\nA delivery engine sets `solution` to let a PCI render the correct response.",
+              "attribute": "status",
+              "parsedType": {
+                "text": "'interacting' | 'suspended' | 'closed' | 'solution' | 'review'"
               }
             },
             {
@@ -21123,6 +21153,18 @@
               "inheritedFrom": {
                 "name": "Interaction",
                 "module": "packages/qti-base/src/abstract/interaction.ts"
+              }
+            },
+            {
+              "name": "status",
+              "type": {
+                "text": "PciInteractionStatus"
+              },
+              "default": "'interacting'",
+              "description": "Item lifecycle status handed to the PCI in its `getInstance` configuration.\nA delivery engine sets `solution` to let a PCI render the correct response.",
+              "fieldName": "status",
+              "parsedType": {
+                "text": "'interacting' | 'suspended' | 'closed' | 'solution' | 'review'"
               }
             }
           ],
@@ -21552,6 +21594,19 @@
                 "text": "boolean"
               },
               "default": "false"
+            },
+            {
+              "kind": "field",
+              "name": "#responseDeclaration",
+              "privacy": "private",
+              "type": {
+                "text": "PciResponseDeclaration | null"
+              },
+              "default": "null",
+              "inheritedFrom": {
+                "name": "QtiPortableCustomInteraction",
+                "module": "packages/interactions/portable-custom-interaction/src/qti-portable-custom-interaction.ts"
+              }
             },
             {
               "kind": "method",
@@ -22447,6 +22502,18 @@
             },
             {
               "kind": "field",
+              "name": "responseDeclaration",
+              "description": "Response declaration passed into the PCI configuration, so a PCI can render\nthe correct response itself instead of having it pushed in as a response.\n\nDerived from the item context, unless a host sets it explicitly - the\ncorrect response viewer does, since it has no response declaration of its own.\n\nSee https://github.com/1EdTech/qti-project-management/issues/210",
+              "type": {
+                "text": "PciResponseDeclaration | null"
+              },
+              "inheritedFrom": {
+                "name": "QtiPortableCustomInteraction",
+                "module": "packages/interactions/portable-custom-interaction/src/qti-portable-custom-interaction.ts"
+              }
+            },
+            {
+              "kind": "field",
               "name": "responseIdentifier",
               "type": {
                 "text": "string"
@@ -22624,6 +22691,23 @@
               "inheritedFrom": {
                 "name": "Interaction",
                 "module": "packages/qti-base/src/abstract/interaction.ts"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "status",
+              "type": {
+                "text": "PciInteractionStatus"
+              },
+              "default": "'interacting'",
+              "description": "Item lifecycle status handed to the PCI in its `getInstance` configuration.\nA delivery engine sets `solution` to let a PCI render the correct response.",
+              "attribute": "status",
+              "parsedType": {
+                "text": "'interacting' | 'suspended' | 'closed' | 'solution' | 'review'"
+              },
+              "inheritedFrom": {
+                "name": "QtiPortableCustomInteraction",
+                "module": "packages/interactions/portable-custom-interaction/src/qti-portable-custom-interaction.ts"
               }
             },
             {
@@ -22983,6 +23067,22 @@
               "inheritedFrom": {
                 "name": "Interaction",
                 "module": "packages/qti-base/src/abstract/interaction.ts"
+              }
+            },
+            {
+              "name": "status",
+              "type": {
+                "text": "PciInteractionStatus"
+              },
+              "default": "'interacting'",
+              "description": "Item lifecycle status handed to the PCI in its `getInstance` configuration.\nA delivery engine sets `solution` to let a PCI render the correct response.",
+              "fieldName": "status",
+              "parsedType": {
+                "text": "'interacting' | 'suspended' | 'closed' | 'solution' | 'review'"
+              },
+              "inheritedFrom": {
+                "name": "QtiPortableCustomInteraction",
+                "module": "packages/interactions/portable-custom-interaction/src/qti-portable-custom-interaction.ts"
               }
             }
           ],


### PR DESCRIPTION
Implements the design agreed in [1EdTech/qti-project-management#210 — *New PCI Use-Case: Passing a correct response into a PCI*](https://github.com/1EdTech/qti-project-management/issues/210).

## Why

When an item is in `solution` status a delivery or reporting platform may want to show the correct response, but there is no standard way to hand a PCI the correct response of its response declaration — a capability every built-in interaction has. Today the only option is to push the correct response in as if it were a candidate response (`boundTo`), which a PCI cannot tell apart from real candidate input, and which rules out showing a candidate response and a correct response side by side.

## What

Per the design agreed in the thread, the `getInstance` configuration gains an optional `responseDeclaration`, alongside the already-specified `status`:

```js
item.getInstance(dom, {
  properties: { maxChoicesMessage: 'Too Many' },
  boundTo: { base: { integer: 5 } },
  responseIdentifier: 'RESPONSE',
  responseDeclaration: {
    baseType: 'identifier',
    cardinality: 'single',
    correctResponse: { value: 5 }
  },
  onReady: 'itemIsReady',
  status: 'solution'
}, state);
```

- **`responseDeclaration`** — camelCased mirror of `qti-response-declaration`, derived from the item context. Every field is optional, as agreed, so a platform passes as much or as little as it has. `identifier` is left out as redundant with `responseIdentifier`, and `correctResponse` is absent when the response variable declares none. A host can also set it explicitly: `element.responseDeclaration = { ... }`.
- **`status`** — item lifecycle status handed to the PCI, `interacting` by default, settable through the `status` attribute or property. The PCI decides for itself whether to render the correct response, e.g. by bailing out when `status !== 'solution'`.

The correct-response viewer now constructs its PCI with `status: 'solution'` and the declaration of the interaction it mirrors. It keeps sending the correct response as `boundTo` too, so PCIs that do not implement the use case render exactly as before.

## Notes

- Optional and additive: existing PCIs are unaffected, and both fields are absent when there is nothing to pass. As agreed in the workgroup meeting of 9/9/25, this is optional and not part of Conformance & Certification.
- `ConfigProperties` in `interface.ts` documents both fields for PCI authors, and the PCI storybook docs carry the example above.
- Companion change for PCI authors: the same `responseDeclaration` type is being added to `@citolab/tspci`.

## Verification

The `VerhoudingenShowCorrectResponse` story asserts the configuration that actually reaches `getInstance` — `status: 'solution'` plus the full declaration — not merely the host-side property. Full storybook suite: 534 passed.

## Base branch

Stacked on `fix/pci-show-correct-response` (#180), since it builds on the correct-response viewer fixed there. GitHub retargets this to `main` once #180 merges.
