### PR TITLE
fix(pci): build the iframe with srcdoc and base it on data-base-url

### DIFF
--- a/.changeset/pci-iframe-srcdoc-service-worker.md
+++ b/.changeset/pci-iframe-srcdoc-service-worker.md
@@ -1,0 +1,19 @@
+---
+'@qti-components/portable-custom-interaction': patch
+---
+
+Build the PCI iframe with `srcdoc` instead of a `blob:` object URL, and point
+`<base href>` at `data-base-url` instead of the site origin.
+
+A blob URL document is out of scope for any http(s) Service Worker
+registration, so a player that serves package resources through a Service
+Worker never saw the requests made from inside the interaction - module
+scripts, images, media, stylesheets and the PCI's own fetches all bypassed it
+and hit the network, where they 404 or land on an SPA fallback. An `srcdoc`
+frame inherits the embedding document's URL and stays controlled by the same
+Service Worker. It is same-origin either way, and messages already post with a
+`'*'` target origin, so postMessage is unaffected.
+
+The `<base href>` change makes relative URLs in the interaction markup resolve
+against the item's directory the way the package author wrote them, rather
+than against the site root.

--- a/custom-elements.json
+++ b/custom-elements.json
@@ -20021,15 +20021,6 @@
             },
             {
               "kind": "field",
-              "name": "_iframeObjectUrl",
-              "type": {
-                "text": "string | null"
-              },
-              "privacy": "private",
-              "default": "null"
-            },
-            {
-              "kind": "field",
               "name": "_internals",
               "type": {
                 "text": "ElementInternals"
@@ -21399,19 +21390,6 @@
                 "text": "string | null"
               },
               "privacy": "protected",
-              "default": "null",
-              "inheritedFrom": {
-                "name": "QtiPortableCustomInteraction",
-                "module": "packages/interactions/portable-custom-interaction/src/qti-portable-custom-interaction.ts"
-              }
-            },
-            {
-              "kind": "field",
-              "name": "_iframeObjectUrl",
-              "type": {
-                "text": "string | null"
-              },
-              "privacy": "private",
               "default": "null",
               "inheritedFrom": {
                 "name": "QtiPortableCustomInteraction",

--- a/packages/interactions/portable-custom-interaction/src/qti-portable-custom-interaction.stories.ts
+++ b/packages/interactions/portable-custom-interaction/src/qti-portable-custom-interaction.stories.ts
@@ -727,3 +727,71 @@ export const PciConformance3: Story = createPciConformanceStory('item-3');
 export const PciConformance4: Story = createPciConformanceStory('item-4');
 export const PciConformance5: Story = createPciConformanceStory('item-5');
 export const PciConformance6: Story = createPciConformanceStory('item-6');
+
+/**
+ * Regression guard for how the PCI iframe document is created.
+ *
+ * The iframe must be built with `srcdoc`, never a `blob:` or `data:` URL. Those give the frame a
+ * document URL that is out of scope for any http(s) Service Worker registration, so a player that
+ * serves package resources through a Service Worker (CacheStorage, virtual paths) silently loses
+ * every request made from inside the interaction - module scripts, images, media, stylesheets.
+ *
+ * `<base href>` must point at `data-base-url`, so relative URLs in the interaction markup resolve
+ * against the item's directory rather than the site root. Both are invisible until a real package
+ * is loaded, which is why they are asserted here directly.
+ */
+export const IframeIsServiceWorkerReachable: Story = {
+  render: () =>
+    html` <qti-portable-custom-interaction-test
+      response-identifier="RESPONSE"
+      module="pci-getallen"
+      custom-interaction-type-identifier="getallenFormule"
+      data-base-url="/assets/qti-portable-interaction/baking_soda"
+    >
+      <qti-interaction-modules>
+        <qti-interaction-module id="pci-getallen" primary-path="pci-getallen.js"></qti-interaction-module>
+      </qti-interaction-modules>
+      <qti-interaction-markup></qti-interaction-markup>
+    </qti-portable-custom-interaction-test>`,
+  play: async ({ canvasElement, step }) => {
+    const pciElement = canvasElement.querySelector('qti-portable-custom-interaction-test');
+    await new Promise(resolve => {
+      pciElement?.addEventListener('qti-portable-custom-interaction-loaded', () => resolve(true));
+    });
+
+    const iframe = pciElement.querySelector('iframe');
+    const itemBase = `${window.location.origin}/assets/qti-portable-interaction/baking_soda/`;
+
+    await step('iframe uses srcdoc, not an opaque blob:/data: document', async () => {
+      expect(iframe.getAttribute('srcdoc')).toBeTruthy();
+      // An empty `src` is what keeps the frame inside the page's Service Worker scope.
+      expect(iframe.getAttribute('src')).toBeNull();
+      await waitFor(() => expect(iframe.contentWindow.location.href).not.toMatch(/^(blob:|data:)/));
+    });
+
+    await step('document stays same-origin, so the page can reach into it', async () => {
+      // A blob:/data: document would make `contentDocument` unreachable or same-origin-by-accident;
+      // reading it at all is part of what the fix guarantees.
+      expect(iframe.contentDocument).toBeTruthy();
+      expect(iframe.contentWindow.origin).toBe(window.location.origin);
+    });
+
+    await step('<base href> is the item directory, not the site root', async () => {
+      await waitFor(() => expect(iframe.contentDocument.baseURI).toBe(itemBase));
+      // `data-base-url` has no trailing slash here: without normalising it, the last segment counts
+      // as a filename and `baking_soda.svg` would resolve one directory too high.
+      expect(new URL('baking_soda.svg', iframe.contentDocument.baseURI).href).toBe(`${itemBase}baking_soda.svg`);
+    });
+
+    await step('a relative request from inside the iframe reaches the item directory', async () => {
+      // The end-to-end check: same-origin frame + correct base means a bare relative URL resolves
+      // and actually fetches. Under a blob: URL this throws, and under the old base it 404s.
+      const response = await iframe.contentWindow.fetch('baking_soda.svg');
+      expect(response.ok).toBe(true);
+      expect(new URL(response.url).pathname).toBe('/assets/qti-portable-interaction/baking_soda/baking_soda.svg');
+    });
+  },
+  parameters: {
+    chromatic: { disableSnapshot: true }
+  }
+};

--- a/packages/interactions/portable-custom-interaction/src/qti-portable-custom-interaction.ts
+++ b/packages/interactions/portable-custom-interaction/src/qti-portable-custom-interaction.ts
@@ -17,7 +17,6 @@ export class QtiPortableCustomInteraction extends Interaction {
   protected _pendingMessages: Array<{ method: string; params: any }> = [];
   protected iframe: HTMLIFrameElement;
   protected _iframeMessageOrigin: string | null = null;
-  private _iframeObjectUrl: string | null = null;
 
   // This implementation always renders inside an iframe.
   static override styles: CSSResultGroup = [
@@ -543,10 +542,6 @@ export class QtiPortableCustomInteraction extends Interaction {
   override disconnectedCallback(): void {
     super.disconnectedCallback();
     window.removeEventListener('message', this.handleIframeMessage);
-    if (this._iframeObjectUrl) {
-      URL.revokeObjectURL(this._iframeObjectUrl);
-      this._iframeObjectUrl = null;
-    }
   }
 
   /**
@@ -692,10 +687,6 @@ export class QtiPortableCustomInteraction extends Interaction {
    * IFRAME MODE: Create iframe element
    */
   protected createIframe() {
-    if (this._iframeObjectUrl) {
-      URL.revokeObjectURL(this._iframeObjectUrl);
-      this._iframeObjectUrl = null;
-    }
     this.iframe = document.createElement('iframe');
     this.iframe.id = `pci-iframe-${this.responseIdentifier}`;
     this.iframe.setAttribute('title', 'QTI PCI Iframe');
@@ -709,10 +700,6 @@ export class QtiPortableCustomInteraction extends Interaction {
     // Handle iframe load event
     this.iframe.onload = () => {
       this._iframeLoaded = true;
-      if (this._iframeObjectUrl) {
-        URL.revokeObjectURL(this._iframeObjectUrl);
-        this._iframeObjectUrl = null;
-      }
       this.#addMarkupToIframe();
       // Send initialization data to iframe
       this.#sendIframeInitData();
@@ -725,15 +712,14 @@ export class QtiPortableCustomInteraction extends Interaction {
     // Generate iframe HTML content with all required scripts
     const iframeContent = this.generateIframeContent();
 
-    // Prefer a same-origin blob URL to avoid postMessage target-origin mismatches (e.g. in Storybook).
-    try {
-      const blob = new Blob([iframeContent], { type: 'text/html' });
-      this._iframeObjectUrl = URL.createObjectURL(blob);
-      this.iframe.src = this._iframeObjectUrl;
-    } catch {
-      const encodedContent = encodeURIComponent(iframeContent);
-      this.iframe.src = `data:text/html;charset=utf-8,${encodedContent}`;
-    }
+    // Use `srcdoc` rather than a `blob:` (or `data:`) URL. Both of those give the iframe document
+    // a URL that is out of scope for any http(s) Service Worker registration, so a player that
+    // serves package resources through a Service Worker (CacheStorage, virtual paths) would see
+    // every request made from inside the PCI - module scripts, images, media, stylesheets, fetches -
+    // bypass it and hit the network instead. An `srcdoc` frame inherits this document's URL and
+    // stays controlled by the same Service Worker. It is same-origin either way, and messages are
+    // posted with a `'*'` target origin, so nothing about postMessage changes.
+    this.iframe.srcdoc = iframeContent;
 
     // Append iframe to component
     this.appendChild(this.iframe);
@@ -846,6 +832,16 @@ export class QtiPortableCustomInteraction extends Interaction {
         ? `${window.location.origin}${this.dataset.baseUrl}`
         : this.dataset.baseUrl
       : '';
+    // `data-base-url` names the directory the item was loaded from, so it is also the base every
+    // relative URL inside the interaction should resolve against - the markup's `src`/`href`, the
+    // stylesheets, and whatever the PCI module resolves itself. Anchoring `<base>` at the site
+    // origin instead would send `../assets/x.png` to `/assets/x.png`. Normalise to a trailing
+    // slash: without one the last segment counts as a filename and gets dropped.
+    const iframeBaseHref = iframeBaseUrl
+      ? iframeBaseUrl.endsWith('/')
+        ? iframeBaseUrl
+        : `${iframeBaseUrl}/`
+      : `${window.location.origin}/`;
     const forwardConsole = this.dataset.forwardConsole === 'true';
     const isLocalhost = window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1';
     const defaultComponentsCdnUrl = isLocalhost
@@ -871,7 +867,7 @@ export class QtiPortableCustomInteraction extends Interaction {
         <head>
           <meta charset="utf-8" />
           <title>QTI PCI Container</title>
-          <base href="${window.location.origin}" />
+          <base href="${iframeBaseHref}" />
           <script type="module">
             import '${componentsCdnUrl}';
           </script>


### PR DESCRIPTION
## Problem

The PCI iframe was created from a `blob:` object URL. A blob URL document is out of scope for any http(s) Service Worker registration, so a player that serves package resources through a Service Worker never sees requests made from inside the interaction — module scripts, images, media, stylesheets and the PCI's own fetches all bypassed it and hit the network, where they 404 or land on an SPA fallback.

Separately, `<base href>` pointed at the site origin, so every relative URL in the interaction markup resolved against the root instead of the item's directory. `../assets/x.png` became `/assets/x.png`.

Demonstrated in qti-playground, which serves packages from CacheStorage via a Service Worker under `/__qti_pkg__/…`. A PCI item's image, video, `theme.css` and `content.json` all failed, and the module itself only loaded when the browser HTTP cache happened to be warm from another page.

## Fix

- Build the iframe with `srcdoc`. The frame inherits the embedding document's URL and stays controlled by the same Service Worker. It is same-origin either way, and messages already post with a `'*'` target origin, so postMessage is unaffected. Drops the `_iframeObjectUrl` bookkeeping the blob URL needed.
- Point `<base href>` at `data-base-url`, normalising the trailing slash — without one the last segment counts as a filename and gets dropped.

Measured in a browser, blob vs srcdoc iframe on a page with a Service Worker:

| iframe | `serviceWorker.controller` | `GET /__qti_pkg__/…/content.json` |
| --- | --- | --- |
| `blob:` | `null` | `200 text/html` (SPA fallback) |
| `srcdoc` | set | `200 application/json` |

## Test

Adds `IframeIsServiceWorkerReachable`, asserting the frame is not a `blob:`/`data:` document, that `<base href>` is the item directory, and that a bare relative request from inside the frame actually reaches it.

Verified it fails when **either** change is reverted individually, not only when both are:

- reverting `srcdoc` → fails on `expect(iframe.getAttribute('srcdoc')).toBeTruthy()`
- reverting only `<base href>` → fails with `expected 'http://localhost:63315/' to be 'http://localhost:63315/assets/qti-por…'`

All 13 PCI stories pass; full Storybook suite 535 passed; `tests` project 387 passed, identical with and without this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)