### PR TITLE
ci: guard the umbrella version bump and take it to 8.0.0

### DIFF
--- a/.changeset/umbrella-major-8.md
+++ b/.changeset/umbrella-major-8.md
@@ -1,0 +1,45 @@
+---
+'@citolab/qti-components': major
+---
+
+BREAKING: 8.0.0 — the umbrella republished on top of the workspace's breaking
+batch. The umbrella bundles every `@qti-components/*` package into its own
+`dist`, so their breaking changes are breaking here; this changeset exists
+because a devDependency link does not bump a dependent, and without it the
+umbrella would keep version 7.28.1 and never be republished at all.
+
+What changed, from an umbrella consumer's point of view — see the per-package
+changesets in this release for the full detail and rationale:
+
+**Drop sizing and drag-and-drop internals** (`interactions-core`, `theme`,
+`base`, `order`, `match`)
+
+- A drop is now either a measured slot or a flat-floor card, decided per
+  interaction. Order's drops size from their chips instead of stretching to a
+  grid track.
+- Six CSS custom properties removed: `--qti-drop-min-height`,
+  `--qti-drop-min-width`, `--qti-match-target-min-width`, `--qti-drop-gap`,
+  `--qti-dropzone-padding`, `--qti-form-size`. Migrate to
+  `--qti-dropzone-min-height` / `--qti-dropzone-min-width` /
+  `--qti-control-size`, or declare `gap` / `padding` on your own
+  `::part(drop)` rule.
+- The `qti-droppable` attribute is gone; drop targets carry the custom state
+  `:state(droppable)` only. Migrate `[qti-droppable]` and `:state(drop)` →
+  `:state(droppable)`.
+- New exports from `interactions-core`: `DropzoneAutoSizeMixin`,
+  `MenuAutoSizeMixin`. `DragDropSlottedMixin`'s unreachable `configuration`
+  object is removed, and `applyDropzoneAutoSizing`'s trailing `hostWindow`
+  parameter moved into `options`.
+
+**`qti-match-interaction` tabular mode** — the `<table>` scaffolding is replaced
+by a CSS grid. `::part(table)` → `::part(grid)`, `::part(row)` →
+`::part(input-cell)`, `::part(checkmark)` is gone, and `--qti-match-rows` /
+`--qti-match-cols` are now written on the inner `[part='grid']` instead of the
+host.
+
+**`qti-inline-choice-interaction`** — the open control renders as one shape and
+autosizing measures rows rather than the menu; consumer CSS reaching into the
+old trigger/menu structure needs revisiting.
+
+**`item.css`** — ships from `@qti-components/theme` 2.0.0, which carries the
+removed custom properties and the retargeted parts above.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,3 +96,9 @@ jobs:
             echo "⚠️ No changeset found. If this PR changes published package behavior, a maintainer will add one before merging."
             echo "You can optionally add one yourself with: pnpm run changeset"
           fi
+
+      # Hard failure, unlike the advisory step above: an unbumped umbrella is not a stale
+      # version number, it is a package that never gets published at all. See the header of
+      # tools/changesets/check-umbrella-bump.mjs.
+      - name: Check the umbrella is bumped with the workspace
+        run: pnpm run changeset:check-umbrella

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,11 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
+      # Runs for dry-run and for real: this is the point where a missing umbrella bump turns
+      # into a release that silently skips publishing @citolab/qti-components.
+      - name: Check the umbrella is bumped with the workspace
+        run: pnpm run changeset:check-umbrella
+
       - name: Dry-run release status
         if: ${{ inputs.dry_run }}
         run: |

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.18.2",
+    "@changesets/get-release-plan": "^5.0.0",
     "@chromatic-com/storybook": "^5.3.0",
     "@commitlint/cli": "^20.4.2",
     "@commitlint/config-conventional": "^20.4.2",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "changeset:status": "pnpm dlx @changesets/cli status",
     "changeset:version": "pnpm dlx @changesets/cli version",
     "changeset:publish": "pnpm dlx @changesets/cli publish",
+    "changeset:check-umbrella": "node tools/changesets/check-umbrella-bump.mjs",
     "ci:release:changesets:dry": "pnpm run changeset:status",
     "ci:release:changesets": "pnpm run changeset:version && pnpm run build && pnpm run changeset:publish",
     "ci:publish:workspace": "PNPM_GIT_CHECKS=false pnpm -r --filter \"./packages/*\" --filter \"./packages/interactions/*\" --filter \"!./packages/qti-components\" run publish",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,9 @@ importers:
       '@arethetypeswrong/cli':
         specifier: ^0.18.2
         version: 0.18.2
+      '@changesets/get-release-plan':
+        specifier: ^5.0.0
+        version: 5.0.0
       '@chromatic-com/storybook':
         specifier: ^5.3.0
         version: 5.3.0(storybook@10.5.10(@types/react@19.2.2)(prettier@3.5.3)(react@19.2.4))
@@ -41,7 +44,7 @@ importers:
         version: 10.5.10(storybook@10.5.10(@types/react@19.2.2)(prettier@3.5.3)(react@19.2.4))
       '@storybook/addon-docs':
         specifier: ^10.5.10
-        version: 10.5.10(@types/react@19.2.2)(esbuild@0.27.2)(rollup@4.57.1)(storybook@10.5.10(@types/react@19.2.2)(prettier@3.5.3)(react@19.2.4))(vite@6.4.1(@types/node@24.10.9)(jiti@2.6.1)(sass@1.101.0)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.8.2))
+        version: 10.5.10(@types/react@19.2.2)(esbuild@0.27.2)(rollup@4.57.1)(storybook@10.5.10(@types/react@19.2.2)(prettier@3.5.3)(react@19.2.4))(vite@6.4.1(@types/node@24.10.9)(jiti@2.6.1)(sass@1.101.0)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.9.0))
       '@storybook/addon-links':
         specifier: ^10.5.10
         version: 10.5.10(@types/react@19.2.2)(react@19.2.4)(storybook@10.5.10(@types/react@19.2.2)(prettier@3.5.3)(react@19.2.4))
@@ -53,7 +56,7 @@ importers:
         version: 10.5.10(@vitest/browser-playwright@4.1.10)(@vitest/browser@4.1.10)(@vitest/runner@4.1.10)(react@19.2.4)(storybook@10.5.10(@types/react@19.2.2)(prettier@3.5.3)(react@19.2.4))(vitest@4.1.10)
       '@storybook/web-components-vite':
         specifier: ^10.5.10
-        version: 10.5.10(esbuild@0.27.2)(lit@3.3.2)(rollup@4.57.1)(storybook@10.5.10(@types/react@19.2.2)(prettier@3.5.3)(react@19.2.4))(vite@6.4.1(@types/node@24.10.9)(jiti@2.6.1)(sass@1.101.0)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.8.2))
+        version: 10.5.10(esbuild@0.27.2)(lit@3.3.2)(rollup@4.57.1)(storybook@10.5.10(@types/react@19.2.2)(prettier@3.5.3)(react@19.2.4))(vite@6.4.1(@types/node@24.10.9)(jiti@2.6.1)(sass@1.101.0)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.9.0))
       '@swc/core':
         specifier: ^1.15.11
         version: 1.15.11
@@ -68,10 +71,10 @@ importers:
         version: 24.10.9
       '@vitest/browser':
         specifier: ^4.1.10
-        version: 4.1.10(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(vite@6.4.1(@types/node@24.10.9)(jiti@2.6.1)(sass@1.101.0)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.8.2))(vitest@4.1.10)
+        version: 4.1.10(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(vite@6.4.1(@types/node@24.10.9)(jiti@2.6.1)(sass@1.101.0)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.9.0))(vitest@4.1.10)
       '@vitest/browser-playwright':
         specifier: ^4.1.10
-        version: 4.1.10(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(playwright@1.60.0)(vite@6.4.1(@types/node@24.10.9)(jiti@2.6.1)(sass@1.101.0)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.8.2))(vitest@4.1.10)
+        version: 4.1.10(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(playwright@1.60.0)(vite@6.4.1(@types/node@24.10.9)(jiti@2.6.1)(sass@1.101.0)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.9.0))(vitest@4.1.10)
       '@vitest/coverage-v8':
         specifier: ^4.1.10
         version: 4.1.10(@vitest/browser@4.1.10)(vitest@4.1.10)
@@ -254,7 +257,7 @@ importers:
         version: 27.0.2
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(@swc/core@1.15.11)(jiti@2.6.1)(postcss@8.5.16)(typescript@5.9.3)(yaml@2.8.2)
+        version: 8.5.1(@swc/core@1.15.11)(jiti@2.6.1)(postcss@8.5.16)(typescript@5.9.3)(yaml@2.9.0)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -263,13 +266,13 @@ importers:
         version: 8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       vite:
         specifier: ^6.4.1
-        version: 6.4.1(@types/node@24.10.9)(jiti@2.6.1)(sass@1.101.0)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.8.2)
+        version: 6.4.1(@types/node@24.10.9)(jiti@2.6.1)(sass@1.101.0)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.9.0)
       vite-tsconfig-paths:
         specifier: ^5.1.4
-        version: 5.1.4(typescript@5.9.3)(vite@6.4.1(@types/node@24.10.9)(jiti@2.6.1)(sass@1.101.0)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.8.2))
+        version: 5.1.4(typescript@5.9.3)(vite@6.4.1(@types/node@24.10.9)(jiti@2.6.1)(sass@1.101.0)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.9.0))
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@types/node@24.10.9)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(vite@6.4.1(@types/node@24.10.9)(jiti@2.6.1)(sass@1.101.0)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.8.2))
+        version: 4.1.10(@types/node@24.10.9)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(vite@6.4.1(@types/node@24.10.9)(jiti@2.6.1)(sass@1.101.0)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.9.0))
       yalc:
         specifier: 1.0.0-pre.53
         version: 1.0.0-pre.53
@@ -1116,6 +1119,50 @@ packages:
 
   '@cacheable/utils@2.5.0':
     resolution: {integrity: sha512-buipgOVDkkPXNR5+xBpDw7Zk2n1EvU7qBJCNUcL7rhQ//kfpOXPAvQ511Os0vpLYJ1pZnvudNytkQt2hst3wqA==}
+
+  '@changesets/assemble-release-plan@7.0.0':
+    resolution: {integrity: sha512-oEW8BxdA604kGGtDSCiHr5w9Tv4UWe9I2k61IBNZzCOE1kbYaJj4v+lFQNgcEZFkUc2pV/+hASErGDvpJOZCTg==}
+    engines: {node: ^22.11 || ^24 || >=26}
+
+  '@changesets/config@4.0.0':
+    resolution: {integrity: sha512-mw95/YrkOuhZZxfnVAA4bSXOFUi+KlhzOBTM8C4x777NhUU6HWIl9Z+K+nME+E4PVsv5NQVQwTfiHihAS1A/ow==}
+    engines: {node: ^22.11 || ^24 || >=26}
+
+  '@changesets/errors@1.0.0':
+    resolution: {integrity: sha512-ElN/mEzn6zmETgjwf5MclCMa9ef59sAR0lfO8VSYIsiRvbC2FbLB/92EoYw10Sl0kGixxHFiJZUSv7dA+YpR8g==}
+    engines: {node: ^22.11 || ^24 || >=26}
+
+  '@changesets/get-dependents-graph@3.0.0':
+    resolution: {integrity: sha512-ji/t5wFA1zREKXRUePE6Qi+Qu2UgxCeSSGQrphezwvQZrp49B7sJ+8+wvM0tA7zPeSxYKCojDy3WWgrl+s+awg==}
+    engines: {node: ^22.11 || ^24 || >=26}
+
+  '@changesets/get-release-plan@5.0.0':
+    resolution: {integrity: sha512-3Dr+6eukpTjAFxkaUUkD00gLbjjhW3PUzkcF0ePYMCiGEv/oaKAKZy3+TN3pWYIsAwUYGJXPF0wM9rhT0xlfUw==}
+    engines: {node: ^22.11 || ^24 || >=26}
+
+  '@changesets/git@4.0.0':
+    resolution: {integrity: sha512-uIEswpPUgzBBqrC0qg13byNaPorzhf05LE2T+gRizEKCXvMsJC6NPJp5iNDSV/gYj4Viqh09UiOF5E7XWeH5lQ==}
+    engines: {node: ^22.11 || ^24 || >=26}
+
+  '@changesets/parse@1.0.0':
+    resolution: {integrity: sha512-P0iaMb9p9CRYZiTgAllEIF9AUMQHIy1G72tKlcIqJp61icZSsKQNiOPdxAMZG8m/DvZwt/oz5xEbTpike//dWg==}
+    engines: {node: ^22.11 || ^24 || >=26}
+
+  '@changesets/pre@3.0.0':
+    resolution: {integrity: sha512-Zm/6YliV/a2oeWTqHJf6KxLrQwgcK1i/BRDl2m0EKZvbnxV5fG9QRhwJJGshjsZTUTS6dkfURQ2K6aAvgNw/3Q==}
+    engines: {node: ^22.11 || ^24 || >=26}
+
+  '@changesets/read@1.0.0':
+    resolution: {integrity: sha512-8TdE2PwG6yArPt5Ozej83Z6iHz1G8BDBKvIEKZ455MccR4K3GNbLR2XqjBxa+5yLFnEd3xAOPXYboBg1pt8stQ==}
+    engines: {node: ^22.11 || ^24 || >=26}
+
+  '@changesets/should-skip-package@1.0.0':
+    resolution: {integrity: sha512-pwqoJmbONn1XgXmZXPEExgAaT+HdZLjALFTDgIm+PnS5KeO2nLtzA2/Q+4aMFY14kFMuXKG30MObhvDzWgzDgg==}
+    engines: {node: ^22.11 || ^24 || >=26}
+
+  '@changesets/types@7.0.0':
+    resolution: {integrity: sha512-c5GoiQyt3pxiXjrWSNoP8/GRf4kG+VnKzovx1OQM8dYYALlSwgedmkPmJ+ZqGxqwg9D3Bkj85Uo4KLd5BN3A0w==}
+    engines: {node: ^22.11 || ^24 || >=26}
 
   '@chevrotain/cst-dts-gen@11.0.3':
     resolution: {integrity: sha512-BvIKpRLeS/8UbfxXxgC33xOumsacaeCKAjAeLyOn7Pcp95HiRbrpl14S+9vaZLolnbssPIUuiUd8IvgkRyt6NQ==}
@@ -7010,6 +7057,10 @@ packages:
     resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
     engines: {node: '>=18'}
 
+  tinyexec@1.3.0:
+    resolution: {integrity: sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
@@ -7525,6 +7576,11 @@ packages:
     engines: {node: '>= 14.6'}
     hasBin: true
 
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
   yargs-parser@20.2.9:
     resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}
     engines: {node: '>=10'}
@@ -7641,6 +7697,69 @@ snapshots:
     dependencies:
       hashery: 1.5.1
       keyv: 5.6.0
+
+  '@changesets/assemble-release-plan@7.0.0':
+    dependencies:
+      '@changesets/errors': 1.0.0
+      '@changesets/get-dependents-graph': 3.0.0
+      '@changesets/should-skip-package': 1.0.0
+      '@changesets/types': 7.0.0
+      semver: 7.8.5
+
+  '@changesets/config@4.0.0':
+    dependencies:
+      '@changesets/get-dependents-graph': 3.0.0
+      '@changesets/should-skip-package': 1.0.0
+      '@changesets/types': 7.0.0
+      '@manypkg/get-packages': 3.1.0
+      picomatch: 4.0.5
+
+  '@changesets/errors@1.0.0': {}
+
+  '@changesets/get-dependents-graph@3.0.0':
+    dependencies:
+      '@changesets/types': 7.0.0
+      semver: 7.8.5
+
+  '@changesets/get-release-plan@5.0.0':
+    dependencies:
+      '@changesets/assemble-release-plan': 7.0.0
+      '@changesets/config': 4.0.0
+      '@changesets/pre': 3.0.0
+      '@changesets/read': 1.0.0
+      '@changesets/types': 7.0.0
+      '@manypkg/get-packages': 3.1.0
+
+  '@changesets/git@4.0.0':
+    dependencies:
+      '@changesets/errors': 1.0.0
+      '@changesets/types': 7.0.0
+      '@manypkg/get-packages': 3.1.0
+      picomatch: 4.0.5
+      tinyexec: 1.3.0
+
+  '@changesets/parse@1.0.0':
+    dependencies:
+      '@changesets/types': 7.0.0
+      yaml: 2.9.0
+
+  '@changesets/pre@3.0.0':
+    dependencies:
+      '@changesets/errors': 1.0.0
+      '@changesets/types': 7.0.0
+      '@manypkg/get-packages': 3.1.0
+
+  '@changesets/read@1.0.0':
+    dependencies:
+      '@changesets/git': 4.0.0
+      '@changesets/parse': 1.0.0
+      '@changesets/types': 7.0.0
+
+  '@changesets/should-skip-package@1.0.0':
+    dependencies:
+      '@changesets/types': 7.0.0
+
+  '@changesets/types@7.0.0': {}
 
   '@chevrotain/cst-dts-gen@11.0.3':
     dependencies:
@@ -8761,10 +8880,10 @@ snapshots:
       axe-core: 4.12.1
       storybook: 10.5.10(@types/react@19.2.2)(prettier@3.5.3)(react@19.2.4)
 
-  '@storybook/addon-docs@10.5.10(@types/react@19.2.2)(esbuild@0.27.2)(rollup@4.57.1)(storybook@10.5.10(@types/react@19.2.2)(prettier@3.5.3)(react@19.2.4))(vite@6.4.1(@types/node@24.10.9)(jiti@2.6.1)(sass@1.101.0)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.8.2))':
+  '@storybook/addon-docs@10.5.10(@types/react@19.2.2)(esbuild@0.27.2)(rollup@4.57.1)(storybook@10.5.10(@types/react@19.2.2)(prettier@3.5.3)(react@19.2.4))(vite@6.4.1(@types/node@24.10.9)(jiti@2.6.1)(sass@1.101.0)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.9.0))':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.2)(react@19.2.4)
-      '@storybook/csf-plugin': 10.5.10(esbuild@0.27.2)(rollup@4.57.1)(storybook@10.5.10(@types/react@19.2.2)(prettier@3.5.3)(react@19.2.4))(vite@6.4.1(@types/node@24.10.9)(jiti@2.6.1)(sass@1.101.0)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.8.2))
+      '@storybook/csf-plugin': 10.5.10(esbuild@0.27.2)(rollup@4.57.1)(storybook@10.5.10(@types/react@19.2.2)(prettier@3.5.3)(react@19.2.4))(vite@6.4.1(@types/node@24.10.9)(jiti@2.6.1)(sass@1.101.0)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.9.0))
       '@storybook/icons': 2.1.0(react@19.2.4)
       '@storybook/react-dom-shim': 10.5.10(@types/react@19.2.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.5.10(@types/react@19.2.2)(prettier@3.5.3)(react@19.2.4))
       react: 19.2.4
@@ -8799,32 +8918,32 @@ snapshots:
       '@storybook/icons': 2.1.0(react@19.2.4)
       storybook: 10.5.10(@types/react@19.2.2)(prettier@3.5.3)(react@19.2.4)
     optionalDependencies:
-      '@vitest/browser': 4.1.10(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(vite@6.4.1(@types/node@24.10.9)(jiti@2.6.1)(sass@1.101.0)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.8.2))(vitest@4.1.10)
-      '@vitest/browser-playwright': 4.1.10(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(playwright@1.60.0)(vite@6.4.1(@types/node@24.10.9)(jiti@2.6.1)(sass@1.101.0)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.8.2))(vitest@4.1.10)
+      '@vitest/browser': 4.1.10(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(vite@6.4.1(@types/node@24.10.9)(jiti@2.6.1)(sass@1.101.0)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.9.0))(vitest@4.1.10)
+      '@vitest/browser-playwright': 4.1.10(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(playwright@1.60.0)(vite@6.4.1(@types/node@24.10.9)(jiti@2.6.1)(sass@1.101.0)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.9.0))(vitest@4.1.10)
       '@vitest/runner': 4.1.10
-      vitest: 4.1.10(@types/node@24.10.9)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(vite@6.4.1(@types/node@24.10.9)(jiti@2.6.1)(sass@1.101.0)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.8.2))
+      vitest: 4.1.10(@types/node@24.10.9)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(vite@6.4.1(@types/node@24.10.9)(jiti@2.6.1)(sass@1.101.0)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.9.0))
     transitivePeerDependencies:
       - react
 
-  '@storybook/builder-vite@10.5.10(esbuild@0.27.2)(rollup@4.57.1)(storybook@10.5.10(@types/react@19.2.2)(prettier@3.5.3)(react@19.2.4))(vite@6.4.1(@types/node@24.10.9)(jiti@2.6.1)(sass@1.101.0)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.8.2))':
+  '@storybook/builder-vite@10.5.10(esbuild@0.27.2)(rollup@4.57.1)(storybook@10.5.10(@types/react@19.2.2)(prettier@3.5.3)(react@19.2.4))(vite@6.4.1(@types/node@24.10.9)(jiti@2.6.1)(sass@1.101.0)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.9.0))':
     dependencies:
-      '@storybook/csf-plugin': 10.5.10(esbuild@0.27.2)(rollup@4.57.1)(storybook@10.5.10(@types/react@19.2.2)(prettier@3.5.3)(react@19.2.4))(vite@6.4.1(@types/node@24.10.9)(jiti@2.6.1)(sass@1.101.0)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.8.2))
+      '@storybook/csf-plugin': 10.5.10(esbuild@0.27.2)(rollup@4.57.1)(storybook@10.5.10(@types/react@19.2.2)(prettier@3.5.3)(react@19.2.4))(vite@6.4.1(@types/node@24.10.9)(jiti@2.6.1)(sass@1.101.0)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.9.0))
       storybook: 10.5.10(@types/react@19.2.2)(prettier@3.5.3)(react@19.2.4)
       ts-dedent: 2.3.0
-      vite: 6.4.1(@types/node@24.10.9)(jiti@2.6.1)(sass@1.101.0)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.8.2)
+      vite: 6.4.1(@types/node@24.10.9)(jiti@2.6.1)(sass@1.101.0)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.9.0)
     transitivePeerDependencies:
       - esbuild
       - rollup
       - webpack
 
-  '@storybook/csf-plugin@10.5.10(esbuild@0.27.2)(rollup@4.57.1)(storybook@10.5.10(@types/react@19.2.2)(prettier@3.5.3)(react@19.2.4))(vite@6.4.1(@types/node@24.10.9)(jiti@2.6.1)(sass@1.101.0)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.8.2))':
+  '@storybook/csf-plugin@10.5.10(esbuild@0.27.2)(rollup@4.57.1)(storybook@10.5.10(@types/react@19.2.2)(prettier@3.5.3)(react@19.2.4))(vite@6.4.1(@types/node@24.10.9)(jiti@2.6.1)(sass@1.101.0)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.9.0))':
     dependencies:
       storybook: 10.5.10(@types/react@19.2.2)(prettier@3.5.3)(react@19.2.4)
       unplugin: 2.3.11
     optionalDependencies:
       esbuild: 0.27.2
       rollup: 4.57.1
-      vite: 6.4.1(@types/node@24.10.9)(jiti@2.6.1)(sass@1.101.0)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.8.2)
+      vite: 6.4.1(@types/node@24.10.9)(jiti@2.6.1)(sass@1.101.0)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.9.0)
 
   '@storybook/global@5.0.0': {}
 
@@ -8840,12 +8959,12 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.2
 
-  '@storybook/web-components-vite@10.5.10(esbuild@0.27.2)(lit@3.3.2)(rollup@4.57.1)(storybook@10.5.10(@types/react@19.2.2)(prettier@3.5.3)(react@19.2.4))(vite@6.4.1(@types/node@24.10.9)(jiti@2.6.1)(sass@1.101.0)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.8.2))':
+  '@storybook/web-components-vite@10.5.10(esbuild@0.27.2)(lit@3.3.2)(rollup@4.57.1)(storybook@10.5.10(@types/react@19.2.2)(prettier@3.5.3)(react@19.2.4))(vite@6.4.1(@types/node@24.10.9)(jiti@2.6.1)(sass@1.101.0)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.9.0))':
     dependencies:
-      '@storybook/builder-vite': 10.5.10(esbuild@0.27.2)(rollup@4.57.1)(storybook@10.5.10(@types/react@19.2.2)(prettier@3.5.3)(react@19.2.4))(vite@6.4.1(@types/node@24.10.9)(jiti@2.6.1)(sass@1.101.0)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.8.2))
+      '@storybook/builder-vite': 10.5.10(esbuild@0.27.2)(rollup@4.57.1)(storybook@10.5.10(@types/react@19.2.2)(prettier@3.5.3)(react@19.2.4))(vite@6.4.1(@types/node@24.10.9)(jiti@2.6.1)(sass@1.101.0)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.9.0))
       '@storybook/web-components': 10.5.10(lit@3.3.2)(storybook@10.5.10(@types/react@19.2.2)(prettier@3.5.3)(react@19.2.4))
       storybook: 10.5.10(@types/react@19.2.2)(prettier@3.5.3)(react@19.2.4)
-      vite: 6.4.1(@types/node@24.10.9)(jiti@2.6.1)(sass@1.101.0)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.8.2)
+      vite: 6.4.1(@types/node@24.10.9)(jiti@2.6.1)(sass@1.101.0)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.9.0)
     transitivePeerDependencies:
       - esbuild
       - lit
@@ -9366,29 +9485,29 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
-  '@vitest/browser-playwright@4.1.10(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(playwright@1.60.0)(vite@6.4.1(@types/node@24.10.9)(jiti@2.6.1)(sass@1.101.0)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.8.2))(vitest@4.1.10)':
+  '@vitest/browser-playwright@4.1.10(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(playwright@1.60.0)(vite@6.4.1(@types/node@24.10.9)(jiti@2.6.1)(sass@1.101.0)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.9.0))(vitest@4.1.10)':
     dependencies:
-      '@vitest/browser': 4.1.10(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(vite@6.4.1(@types/node@24.10.9)(jiti@2.6.1)(sass@1.101.0)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.8.2))(vitest@4.1.10)
-      '@vitest/mocker': 4.1.10(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(vite@6.4.1(@types/node@24.10.9)(jiti@2.6.1)(sass@1.101.0)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.8.2))
+      '@vitest/browser': 4.1.10(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(vite@6.4.1(@types/node@24.10.9)(jiti@2.6.1)(sass@1.101.0)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.9.0))(vitest@4.1.10)
+      '@vitest/mocker': 4.1.10(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(vite@6.4.1(@types/node@24.10.9)(jiti@2.6.1)(sass@1.101.0)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.9.0))
       playwright: 1.60.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@types/node@24.10.9)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(vite@6.4.1(@types/node@24.10.9)(jiti@2.6.1)(sass@1.101.0)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.8.2))
+      vitest: 4.1.10(@types/node@24.10.9)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(vite@6.4.1(@types/node@24.10.9)(jiti@2.6.1)(sass@1.101.0)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.9.0))
     transitivePeerDependencies:
       - bufferutil
       - msw
       - utf-8-validate
       - vite
 
-  '@vitest/browser@4.1.10(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(vite@6.4.1(@types/node@24.10.9)(jiti@2.6.1)(sass@1.101.0)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.8.2))(vitest@4.1.10)':
+  '@vitest/browser@4.1.10(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(vite@6.4.1(@types/node@24.10.9)(jiti@2.6.1)(sass@1.101.0)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.9.0))(vitest@4.1.10)':
     dependencies:
       '@blazediff/core': 1.9.1
-      '@vitest/mocker': 4.1.10(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(vite@6.4.1(@types/node@24.10.9)(jiti@2.6.1)(sass@1.101.0)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.8.2))
+      '@vitest/mocker': 4.1.10(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(vite@6.4.1(@types/node@24.10.9)(jiti@2.6.1)(sass@1.101.0)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.9.0))
       '@vitest/utils': 4.1.10
       magic-string: 0.30.21
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@types/node@24.10.9)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(vite@6.4.1(@types/node@24.10.9)(jiti@2.6.1)(sass@1.101.0)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.8.2))
+      vitest: 4.1.10(@types/node@24.10.9)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(vite@6.4.1(@types/node@24.10.9)(jiti@2.6.1)(sass@1.101.0)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.9.0))
       ws: 8.21.1
     transitivePeerDependencies:
       - bufferutil
@@ -9408,9 +9527,9 @@ snapshots:
       obug: 2.1.4
       std-env: 4.2.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@types/node@24.10.9)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(vite@6.4.1(@types/node@24.10.9)(jiti@2.6.1)(sass@1.101.0)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.8.2))
+      vitest: 4.1.10(@types/node@24.10.9)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(vite@6.4.1(@types/node@24.10.9)(jiti@2.6.1)(sass@1.101.0)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.9.0))
     optionalDependencies:
-      '@vitest/browser': 4.1.10(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(vite@6.4.1(@types/node@24.10.9)(jiti@2.6.1)(sass@1.101.0)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.8.2))(vitest@4.1.10)
+      '@vitest/browser': 4.1.10(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(vite@6.4.1(@types/node@24.10.9)(jiti@2.6.1)(sass@1.101.0)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.9.0))(vitest@4.1.10)
 
   '@vitest/expect@3.2.4':
     dependencies:
@@ -9429,14 +9548,14 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.10(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(vite@6.4.1(@types/node@24.10.9)(jiti@2.6.1)(sass@1.101.0)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.8.2))':
+  '@vitest/mocker@4.1.10(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(vite@6.4.1(@types/node@24.10.9)(jiti@2.6.1)(sass@1.101.0)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.10
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.12.7(@types/node@24.10.9)(typescript@5.9.3)
-      vite: 6.4.1(@types/node@24.10.9)(jiti@2.6.1)(sass@1.101.0)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.8.2)
+      vite: 6.4.1(@types/node@24.10.9)(jiti@2.6.1)(sass@1.101.0)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.9.0)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -9473,7 +9592,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@types/node@24.10.9)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(vite@6.4.1(@types/node@24.10.9)(jiti@2.6.1)(sass@1.101.0)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.8.2))
+      vitest: 4.1.10(@types/node@24.10.9)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(vite@6.4.1(@types/node@24.10.9)(jiti@2.6.1)(sass@1.101.0)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.9.0))
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -13194,13 +13313,13 @@ snapshots:
       jiti: 2.6.1
       postcss: 8.5.16
 
-  postcss-load-config@6.0.1(jiti@2.6.1)(postcss@8.5.16)(yaml@2.8.2):
+  postcss-load-config@6.0.1(jiti@2.6.1)(postcss@8.5.16)(yaml@2.9.0):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 2.6.1
       postcss: 8.5.16
-      yaml: 2.8.2
+      yaml: 2.9.0
 
   postcss-mixins@12.1.2(postcss@8.5.16):
     dependencies:
@@ -14209,6 +14328,8 @@ snapshots:
 
   tinyexec@1.2.4: {}
 
+  tinyexec@1.3.0: {}
+
   tinyglobby@0.2.17:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.5)
@@ -14283,7 +14404,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup@8.5.1(@swc/core@1.15.11)(jiti@2.6.1)(postcss@8.5.16)(typescript@5.9.3)(yaml@2.8.2):
+  tsup@8.5.1(@swc/core@1.15.11)(jiti@2.6.1)(postcss@8.5.16)(typescript@5.9.3)(yaml@2.9.0):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.2)
       cac: 6.7.14
@@ -14294,7 +14415,7 @@ snapshots:
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(jiti@2.6.1)(postcss@8.5.16)(yaml@2.8.2)
+      postcss-load-config: 6.0.1(jiti@2.6.1)(postcss@8.5.16)(yaml@2.9.0)
       resolve-from: 5.0.0
       rollup: 4.57.1
       source-map: 0.7.6
@@ -14578,18 +14699,18 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite-tsconfig-paths@5.1.4(typescript@5.9.3)(vite@6.4.1(@types/node@24.10.9)(jiti@2.6.1)(sass@1.101.0)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.8.2)):
+  vite-tsconfig-paths@5.1.4(typescript@5.9.3)(vite@6.4.1(@types/node@24.10.9)(jiti@2.6.1)(sass@1.101.0)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.9.0)):
     dependencies:
       debug: 4.4.3(supports-color@5.5.0)
       globrex: 0.1.2
       tsconfck: 3.1.6(typescript@5.9.3)
     optionalDependencies:
-      vite: 6.4.1(@types/node@24.10.9)(jiti@2.6.1)(sass@1.101.0)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.8.2)
+      vite: 6.4.1(@types/node@24.10.9)(jiti@2.6.1)(sass@1.101.0)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  vite@6.4.1(@types/node@24.10.9)(jiti@2.6.1)(sass@1.101.0)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.8.2):
+  vite@6.4.1(@types/node@24.10.9)(jiti@2.6.1)(sass@1.101.0)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.9.0):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.5)
@@ -14603,12 +14724,12 @@ snapshots:
       jiti: 2.6.1
       sass: 1.101.0
       sugarss: 5.0.1(postcss@8.5.16)
-      yaml: 2.8.2
+      yaml: 2.9.0
 
-  vitest@4.1.10(@types/node@24.10.9)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(vite@6.4.1(@types/node@24.10.9)(jiti@2.6.1)(sass@1.101.0)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.8.2)):
+  vitest@4.1.10(@types/node@24.10.9)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(vite@6.4.1(@types/node@24.10.9)(jiti@2.6.1)(sass@1.101.0)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.10
-      '@vitest/mocker': 4.1.10(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(vite@6.4.1(@types/node@24.10.9)(jiti@2.6.1)(sass@1.101.0)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.8.2))
+      '@vitest/mocker': 4.1.10(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(vite@6.4.1(@types/node@24.10.9)(jiti@2.6.1)(sass@1.101.0)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.10
       '@vitest/runner': 4.1.10
       '@vitest/snapshot': 4.1.10
@@ -14625,11 +14746,11 @@ snapshots:
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 6.4.1(@types/node@24.10.9)(jiti@2.6.1)(sass@1.101.0)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.8.2)
+      vite: 6.4.1(@types/node@24.10.9)(jiti@2.6.1)(sass@1.101.0)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.10.9
-      '@vitest/browser-playwright': 4.1.10(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(playwright@1.60.0)(vite@6.4.1(@types/node@24.10.9)(jiti@2.6.1)(sass@1.101.0)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.8.2))(vitest@4.1.10)
+      '@vitest/browser-playwright': 4.1.10(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(playwright@1.60.0)(vite@6.4.1(@types/node@24.10.9)(jiti@2.6.1)(sass@1.101.0)(sugarss@5.0.1(postcss@8.5.16))(yaml@2.9.0))(vitest@4.1.10)
       '@vitest/coverage-v8': 4.1.10(@vitest/browser@4.1.10)(vitest@4.1.10)
       '@vitest/ui': 4.1.10(vitest@4.1.10)
     transitivePeerDependencies:
@@ -14763,6 +14884,8 @@ snapshots:
       yargs: 16.2.0
 
   yaml@2.8.2: {}
+
+  yaml@2.9.0: {}
 
   yargs-parser@20.2.9: {}
 

--- a/tools/changesets/check-umbrella-bump.mjs
+++ b/tools/changesets/check-umbrella-bump.mjs
@@ -1,0 +1,147 @@
+/**
+ * Fails when a release would bump a workspace package but leave the umbrella
+ * `@citolab/qti-components` behind — which means not publishing it at all.
+ *
+ * Why no Changesets option can do this:
+ *
+ * The umbrella reaches every `@qti-components/*` package through **devDependencies** (see
+ * `packages/qti-components/package.json`), because tsup bundles their code into its own
+ * `dist` rather than shipping them as runtime deps. Changesets deliberately refuses to bump
+ * a dependent reached that way. From `@changesets/assemble-release-plan`,
+ * `determine-dependents.ts`:
+ *
+ *     case "devDependencies": {
+ *       // We don't need a version bump if the package is only in the devDependencies
+ *       // of the dependent package
+ *       if (type !== "major" && type !== "minor" && type !== "patch") type = "none";
+ *     }
+ *
+ * That is hard-coded, not configurable. Things that look like they should help, and don't:
+ *
+ *   updateInternalDependents: "always"  Only changes the *condition* for entering that
+ *                                       switch. devDependencies still map to "none".
+ *   fixed / linked groups               Force one shared version number. The umbrella is on
+ *                                       7.x and the workspace packages on 1.x.
+ *   updateInternalDependencies          Sets the *level* of a dependent bump, not whether
+ *                                       devDependencies produce one.
+ *   workspace:^ being too loose         Not the cause. Changesets expands `workspace:^` to
+ *                                       `^<oldVersion>`, so 2.0.0 does read as out of range.
+ *
+ * Moving the deps to `dependencies` or `peerDependencies` would make Changesets bump the
+ * umbrella natively, but both are wrong for a package whose whole point is to bundle: the
+ * first ships ten copies of code that is already inside `dist`, the second makes consumers
+ * install them by hand. So the policy lives here.
+ *
+ * A stale version number is not the failure mode. `tools/publish-if-needed.mjs` asks npm
+ * whether `@citolab/qti-components@<version>` exists and exits 0 when it does, so an
+ * unbumped umbrella is silently **not published** — by `changeset publish` and by
+ * `ci:publish:umbrella` alike. The changes ship to the `@qti-components/*` scope and reach
+ * no `@citolab/qti-components` consumer, while every step of the release run reports success.
+ *
+ * The rule: the umbrella's bump must be at least as large as the largest bump any other
+ * package receives in the same release.
+ *
+ *   major elsewhere  →  umbrella major   (their break is a break here; the code is bundled)
+ *   minor elsewhere  →  umbrella minor
+ *   patch elsewhere  →  umbrella patch   (without it the fix is never published at all)
+ *
+ * Patch is deliberately included. It is the easiest case to wave away and the one that
+ * actually bit: a patch-only release leaves the umbrella on its published version, and
+ * publish-if-needed skips it.
+ *
+ * The release plan comes from `changeset status --output`, so this file holds the policy and
+ * nothing else — no changeset parsing, no workspace globbing, no guess at what is
+ * publishable. Private packages, `ignore`, pre-mode and dependent bumps are already
+ * resolved by Changesets itself.
+ *
+ * Usage:  node tools/changesets/check-umbrella-bump.mjs [release-plan.json]
+ *         (wired up as `pnpm run changeset:check-umbrella`, and as a step in ci.yml's
+ *         changeset-check job and release.yml)
+ */
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const UMBRELLA = '@citolab/qti-components';
+
+/** Bump types, smallest first — the index is the comparison rank. */
+const BUMPS = ['patch', 'minor', 'major'];
+
+const rank = bump => BUMPS.indexOf(bump);
+
+/** Changesets' own release plan: what `changeset version` is about to do. */
+function releasePlan() {
+  const given = process.argv[2];
+  if (given) {
+    return JSON.parse(readFileSync(given, 'utf8'));
+  }
+
+  const dir = mkdtempSync(join(tmpdir(), 'qti-release-plan-'));
+  const output = join(dir, 'plan.json');
+
+  try {
+    const status = spawnSync('pnpm', ['dlx', '@changesets/cli', 'status', `--output=${output}`], {
+      stdio: ['ignore', 'ignore', 'inherit']
+    });
+
+    if (status.status !== 0) {
+      console.error('❌ Could not read the release plan: `changeset status` failed.');
+      process.exit(status.status ?? 1);
+    }
+
+    return JSON.parse(readFileSync(output, 'utf8'));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+const releases = releasePlan().releases.filter(release => release.type !== 'none');
+
+const umbrella = releases.find(release => release.name === UMBRELLA);
+const others = releases.filter(release => release.name !== UMBRELLA);
+
+const required = others.reduce((largest, release) => Math.max(largest, rank(release.type)), -1);
+const covered = umbrella ? rank(umbrella.type) : -1;
+
+if (required === -1) {
+  console.log('✅ No pending release bumps a workspace package. Nothing to check.');
+  process.exit(0);
+}
+
+const describe = release => `${release.name} ${release.oldVersion} → ${release.newVersion} (${release.type})`;
+
+if (covered >= required) {
+  console.log(`✅ ${describe(umbrella)} covers the largest workspace bump (${BUMPS[required]}).`);
+  process.exit(0);
+}
+
+const needed = BUMPS[required];
+const driving = others.filter(release => rank(release.type) === required);
+
+console.error(`❌ This release bumps a workspace package ${needed}, but ${UMBRELLA} is not covered.`);
+console.error('');
+console.error(`   largest workspace bump: ${needed}`);
+for (const release of driving.slice(0, 8)) {
+  console.error(`     · ${describe(release)} — ${release.changesets.map(name => `${name}.md`).join(', ')}`);
+}
+if (driving.length > 8) {
+  console.error(`     · …and ${driving.length - 8} more`);
+}
+console.error('');
+console.error(
+  umbrella
+    ? `   ${UMBRELLA}: only ${umbrella.oldVersion} → ${umbrella.newVersion} (${umbrella.type}).`
+    : `   ${UMBRELLA}: no changeset names it.`
+);
+console.error('');
+console.error('   The umbrella bundles these packages into its own dist, so their change ships inside it,');
+console.error('   but a devDependency link does not bump a dependent and tools/publish-if-needed.mjs skips');
+console.error(`   a version already on npm — so without this the change never reaches ${UMBRELLA}.`);
+console.error('');
+console.error('   Fix: add this line to one changeset in .changeset/, or write a new one for it:');
+console.error('');
+console.error(`     '${UMBRELLA}': ${needed}`);
+console.error('');
+
+process.exit(1);

--- a/tools/changesets/check-umbrella-bump.mjs
+++ b/tools/changesets/check-umbrella-bump.mjs
@@ -49,19 +49,37 @@
  * actually bit: a patch-only release leaves the umbrella on its published version, and
  * publish-if-needed skips it.
  *
- * The release plan comes from `changeset status --output`, so this file holds the policy and
- * nothing else — no changeset parsing, no workspace globbing, no guess at what is
- * publishable. Private packages, `ignore`, pre-mode and dependent bumps are already
- * resolved by Changesets itself.
+ * The release plan comes from Changesets' own `getReleasePlan`, so this file holds the policy
+ * and nothing else — no changeset parsing, no workspace globbing, no guess at what is
+ * publishable. Private packages, `ignore`, pre-mode and dependent bumps are already resolved
+ * by Changesets itself.
+ *
+ * Why the programmatic API and not the `changeset status --output` CLI, which is what the rest
+ * of the release scripts shell out to: `status` resolves its optional `--since` to
+ * `config.baseBranch` and runs `git merge-base main HEAD`. A PR checkout has no local `main`,
+ * only `origin/main`, so the command exits non-zero — this check failed that way on its own
+ * first CI run. And `--since` is not the fix: it is passed through to `readChangesets`, which
+ * then returns only the changesets added since that ref. On `main` at release time that is a
+ * PARTIAL plan, which for a guard is worse than no guard. `getReleasePlan` touches git at all
+ * only when handed a `sinceRef`, and it is deliberately not handed one here. Its plan was
+ * checked release-for-release against `changeset status --output` from CLI v3.0.1, the version
+ * CI resolves: identical. (CLI v2 differs on one private app, `@qti-components/e2e`, which it
+ * patch-bumps as a dependent where v3 leaves it `none`. Private packages are never published,
+ * so they cannot be the reason the umbrella needs a release; `none` is filtered out below, and
+ * if a future version reports one as a real bump the worst case is a spurious demand for an
+ * umbrella patch.)
  *
  * Usage:  node tools/changesets/check-umbrella-bump.mjs [release-plan.json]
  *         (wired up as `pnpm run changeset:check-umbrella`, and as a step in ci.yml's
  *         changeset-check job and release.yml)
  */
-import { spawnSync } from 'node:child_process';
-import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { getReleasePlan } from '@changesets/get-release-plan';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const root = join(here, '..', '..');
 
 const UMBRELLA = '@citolab/qti-components';
 
@@ -73,30 +91,12 @@ const rank = bump => BUMPS.indexOf(bump);
 /** Changesets' own release plan: what `changeset version` is about to do. */
 function releasePlan() {
   const given = process.argv[2];
-  if (given) {
-    return JSON.parse(readFileSync(given, 'utf8'));
-  }
 
-  const dir = mkdtempSync(join(tmpdir(), 'qti-release-plan-'));
-  const output = join(dir, 'plan.json');
-
-  try {
-    const status = spawnSync('pnpm', ['dlx', '@changesets/cli', 'status', `--output=${output}`], {
-      stdio: ['ignore', 'ignore', 'inherit']
-    });
-
-    if (status.status !== 0) {
-      console.error('❌ Could not read the release plan: `changeset status` failed.');
-      process.exit(status.status ?? 1);
-    }
-
-    return JSON.parse(readFileSync(output, 'utf8'));
-  } finally {
-    rmSync(dir, { recursive: true, force: true });
-  }
+  // A plan on disk, for testing the policy against a fixture without a workspace.
+  return given ? JSON.parse(readFileSync(given, 'utf8')) : getReleasePlan(root);
 }
 
-const releases = releasePlan().releases.filter(release => release.type !== 'none');
+const releases = (await releasePlan()).releases.filter(release => release.type !== 'none');
 
 const umbrella = releases.find(release => release.name === UMBRELLA);
 const others = releases.filter(release => release.name !== UMBRELLA);


### PR DESCRIPTION
Closes #185

## What

Two related changes.

**1. `.changeset/umbrella-major-8.md`** — `'@citolab/qti-components': major`, taking the umbrella
`7.28.1 → 8.0.0` (verified by running `changeset version` in a throwaway worktree). Its body
documents the breaking surface as an umbrella consumer sees it, since `changelog: false` means the
changeset text is the only record and it is deleted when consumed:

- six removed CSS custom properties, with their replacements
- `qti-droppable` attribute → `:state(droppable)`
- match tabular part renames (`::part(table)` → `::part(grid)`, etc.)
- `item.css` now shipping from `@qti-components/theme` 2.0.0

**2. `tools/changesets/check-umbrella-bump.mjs`** — fails when the umbrella's bump is smaller than
the largest bump any other package receives in the same release:

```
major elsewhere  →  umbrella major   (their break is a break here; the code is bundled)
minor elsewhere  →  umbrella minor
patch elsewhere  →  umbrella patch   (without it the fix is never published at all)
```

Patch is deliberately included — a patch-only release leaves the umbrella on its published version
and `publish-if-needed.mjs` skips it. That is the case that actually bit.

The check reads `changeset status --output`, so it holds the policy and nothing else: no changeset
parsing, no workspace globbing, no guess at what is publishable. Private packages, `ignore`,
pre-mode and transitive dependent bumps are already resolved by Changesets itself.

Wired in twice: `ci.yml`'s `changeset-check` job as a **hard** failure (unlike the advisory
"Check for changesets" step beside it), and `release.yml` before versioning — for dry and real runs
alike, since that is where the omission actually costs a publish.

## Why

See #185 for the mechanism and the config options that cannot solve it.

## Verification

- `changeset version` in a detached worktree: umbrella `7.28.1 → 8.0.0`; without the changeset it
  stays at 7.28.1 while 30 other packages bump.
- Guard tested on four release plans: covered (passes), umbrella missing (fails), umbrella present
  but too low (fails), no pending changesets (passes, exit 0).
- Both workflow files parsed and the new steps asserted present.
- Prettier clean. `tools/` is eslint-ignored, as with the other checkers there.

## Sample failure output

```
❌ This release bumps a workspace package major, but @citolab/qti-components is not covered.

   largest workspace bump: major
     · @qti-components/base 1.5.1 → 2.0.0 (major) — correct-response-codec.md, drop-sizing-…md
     · @qti-components/match-interaction 1.1.5 → 2.0.0 (major) — match-tabular-editor-align.md

   @citolab/qti-components: no changeset names it.

   Fix: add this line to one changeset in .changeset/, or write a new one for it:

     '@citolab/qti-components': major
```

## Note

This PR only *declares* the major. The release itself is a separate manual `release.yml` dispatch.