### PR TITLE
fix(base): let a placed chip shrink to its drop

### DIFF
--- a/.changeset/drop-region-chip-shrink.md
+++ b/.changeset/drop-region-chip-shrink.md
@@ -1,0 +1,31 @@
+---
+'@qti-components/base': patch
+'@citolab/qti-components': patch
+---
+
+Let a placed chip shrink to its drop, so it is the same box in the bank and in
+the drop when the bank is narrower than the chip's label.
+
+`dropRegion` gave every drop child `flex: 0 0 auto`, on the reading that a drop
+must not resize a chip. `flex-shrink: 0` does not say that. It does not preserve
+the chip's size — it preserves the chip's _unconstrained max-content_ size, and
+those are the same number only while the bank is wide enough to hand the chip its
+full width. Below that the bank chip shrinks and wraps, as any flex item does,
+and the placed chip stays pinned at max-content.
+
+Measured on an order interaction, bank vs placed: `209x36` / `209x36` at 480px,
+but `204x55` / `209x36` at 440px and `154x55` / `209x36` at 340px — a placed chip
+a fixed 209px wide, overflowing a drop that had reserved exactly the right 156px
+for it. The drop and the measurement were right the whole time; only the chip
+inside ignored them.
+
+`flex: 0 1 auto` fixes it, and shrinking cannot undersize a chip: the floor is
+`--qti-dropzone-min-*`, which _is_ the measured chip, applied to the drop's
+content box. `flex-grow: 0` is what prevents the stretch-and-centre that block
+exists to prevent, and it is unchanged.
+
+Reached CI as a font difference — the same label measures ~227px under Linux
+fonts and ~209px on macOS, which puts a 480px interaction on either side of the
+boundary — so `drag-drop.invariance.spec.ts` gains a narrow-bank order fixture
+that wraps at any plausible text metric, instead of leaving the assertion to the
+font the suite happens to run under.

--- a/packages/interactions/core/src/mixins/drag-drop-observables/drag-drop.invariance.spec.ts
+++ b/packages/interactions/core/src/mixins/drag-drop-observables/drag-drop.invariance.spec.ts
@@ -188,6 +188,30 @@ const INTERACTIONS: Array<{ name: string; html: string; chip: string; target: ()
     chip: 'A',
     target: () => el<any>('qti-order-interaction').shadowRoot!.querySelector(`[part~='drop']`) as HTMLElement
   },
+  /*
+   * The same interaction with a bank too narrow for its widest label.
+   *
+   * `order` above passes on a box-model bug, as long as the bank can give the chip its full width:
+   * both chips then sit at max-content and agree by coincidence. Narrow the bank and they stop
+   * agreeing — the bank chip shrinks and wraps like any flex item, and a placed chip pinned at
+   * `flex-shrink: 0` does not. Measured before the fix: 154x55 in the bank, 209x36 in the drop,
+   * the placed chip overflowing a drop that had reserved exactly the right 156px for it.
+   *
+   * This is the fixture that states the rule in pixels rather than leaving it to the font: the
+   * 480px case above is one text-metric change away from wrapping (it broke on CI's Linux fonts,
+   * where the same label measures ~227px, while passing on macOS at ~209px). A label that must
+   * wrap at any plausible metric cannot be talked out of the assertion.
+   */
+  {
+    name: 'order (narrow bank)',
+    html: `
+      <qti-order-interaction response-identifier="R" style="width: 340px">
+        <qti-simple-choice identifier="A">Hypothese formuleren</qti-simple-choice>
+        <qti-simple-choice identifier="B">Data verzamelen</qti-simple-choice>
+      </qti-order-interaction>`,
+    chip: 'A',
+    target: () => el<any>('qti-order-interaction').shadowRoot!.querySelector(`[part~='drop']`) as HTMLElement
+  },
   {
     name: 'associate',
     html: `

--- a/packages/qti-base/src/styles/drop-region.styles.ts
+++ b/packages/qti-base/src/styles/drop-region.styles.ts
@@ -8,14 +8,32 @@ import { css } from 'lit';
  * once dropped — and a container that centres or stretches it makes the drop the one place where
  * that stops being true. That is felt as the chip jumping the instant it lands.
  *
- * `flex: 0 0 auto` on the children says "intrinsic size, no growing, no shrinking".
+ * `flex: 0 1 auto` on the children says "intrinsic size, no growing, shrink if you must".
  * `align-items: flex-start` stops the cross axis stretching them, which is the flex default and
  * the reason a chip in a tall dropzone used to grow to fill it.
+ *
+ * The shrink half used to be 0 as well, on the reading that a drop must not resize a chip. It does
+ * not say that. `flex-shrink: 0` does not preserve the chip's size, it preserves the chip's
+ * UNCONSTRAINED max-content size — and those are the same number only while the bank is wide enough
+ * to give the chip its full width. Once the bank is narrower, the bank chip (`flex: 0 1 auto`, like
+ * any flex item) shrinks and wraps, the placed chip does not, and the two disagree.
+ *
+ * Measured on the order fixture, bank vs placed: 209x36 / 209x36 at a 480px interaction, but
+ * 204x55 / 209x36 at 440px and 154x55 / 209x36 at 340px — the placed chip a fixed 209px wide,
+ * overflowing a drop that had correctly reserved 156px for it. It reached CI as a font difference:
+ * the same label measures ~227px under the Linux fonts, which puts 480px on the wrong side of the
+ * boundary too.
+ *
+ * Shrinking cannot make a placed chip smaller than the reservation, because the reservation IS the
+ * measured chip (`--qti-dropzone-min-*`, applied to this region's content box). So the floor a
+ * shrink stops at is the chip's own size, which is the rule above, not an exception to it.
+ * `flex-grow: 0` is what actually prevents the stretch this block cares about, and it is untouched.
  *
  * A container that wants a *minimum* size still declares one (see `--qti-dropzone-min-*`). That
  * sizes the container, never its contents.
  *
- * Verified by drag-drop.invariance.spec.ts: "a chip is the same chip wherever it lives".
+ * Verified by drag-drop.invariance.spec.ts: "a chip is the same chip wherever it lives" — including
+ * the narrow-bank order fixture, which is there because the wide one passes either way.
  */
 export const dropRegion = css`
   [part~='drop'] {
@@ -54,7 +72,7 @@ export const dropRegion = css`
   }
 
   [part~='drop'] > * {
-    flex: 0 0 auto;
+    flex: 0 1 auto;
     align-self: flex-start;
   }
 `;


### PR DESCRIPTION
Fixes the `drag-drop.invariance.spec.ts` failure that has had `main` red since #184.

## What

One property, in `dropRegion` (`packages/qti-base/src/styles/drop-region.styles.ts`):

```diff
 [part~='drop'] > * {
-  flex: 0 0 auto;
+  flex: 0 1 auto;
```

## Why

`flex-shrink: 0` was there on the reading that a drop must not resize a chip. It does not say
that. It does not preserve the chip's size — it preserves the chip's **unconstrained max-content**
size, and those are the same number only while the bank is wide enough to hand the chip its full
width. Once the bank is narrower, the bank chip shrinks and wraps like any flex item, the placed
chip stays pinned, and the two disagree.

Measured on an order interaction, bank vs placed:

| interaction width | bank | placed | |
|---|---|---|---|
| 480px | 209x36 | 209x36 | ✅ agrees by coincidence |
| 440px | 204x55 | 209x36 | ❌ |
| 340px | 154x55 | 209x36 | ❌ placed chip overflows a 156px drop |

Note the placed chip is a fixed 209px at every width. The drop and the measurement were right the
whole time — the drop reserves 156px, exactly the bank chip plus its border — only the chip inside
ignored them. So this is also a real overflow bug in narrow order interactions, not just a failing
assertion.

Shrinking cannot undersize a chip: the floor is `--qti-dropzone-min-*`, which *is* the measured
chip, applied to the drop's content box. `flex-grow: 0` is what prevents the stretch-and-centre
that block exists to prevent, and it is untouched. The block's docblock is updated, since it
previously said "no growing, no shrinking" and cited the invariance test it was breaking.

## Why CI saw it and you don't

CI is not measuring anything wrong. "Hypothese formuleren" renders ~227px under the Linux
container's fonts and ~209px on macOS, which puts a 480px interaction on either side of the bank
boundary. The defect was equally present locally at any width ≤440px.

That also means the existing 480px fixture is a poor guard — it passes either way on macOS. So the
spec gains a **narrow-bank order fixture** (340px) that wraps at any plausible text metric.

## Verification

- New fixture **fails without the fix**, with the same shape CI reported:
  `expected { w: 209, h: 36 } to deeply equal { w: 154, h: 55 }`. Passes with it.
- Width sweep 480→340px: every width matches after the fix; no overflow.
- Full local lane green — `lint`, `madge`, `test`: **1168 passed, 1 skipped**, exit 0. Nothing in
  gap-match, associate or match regressed, despite two theme files whose comments lean on
  `flex: 0 0 auto`.
- VRT: 17 passed (pre-commit hook). No baselines re-blessed.

## Note

Independent of #186, which is release tooling. #186 needs a rebase once this lands; its umbrella
`major` then covers this patch under the guard it adds.