### PR TITLE
fix(ci): check out the PR under test, not main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
         with:
-          ref: ${{ inputs.branch || 'main' }}
+          # `github.ref`, not 'main'. `inputs` is empty on anything but workflow_dispatch, so the
+          # fallback is what every pull_request and push actually used — and it was the literal
+          # string 'main'. This job therefore tested main on every PR, never the PR's own code:
+          # run 33399522449 reported main's 1166 tests against a head SHA whose branch has 1169,
+          # and failed on an assertion the branch fixes.
+          #
+          # A green check was worth nothing either, which is the more dangerous half: a broken main
+          # at least made it visible. On pull_request `github.ref` is refs/pull/N/merge, so this
+          # tests the merge result, which is the thing being asked about. workflow_dispatch still
+          # gets its branch input.
+          ref: ${{ inputs.branch || github.ref }}
 
       - name: Install pnpm
         uses: pnpm/action-setup@v6


### PR DESCRIPTION
The `ci` job has never tested a pull request. It tests `main`, every time.

## The bug

```yaml
- name: Checkout
  uses: actions/checkout@v5
  with:
    ref: ${{ inputs.branch || 'main' }}
```

`inputs` is populated only for `workflow_dispatch`. On `pull_request` and `push` it is empty, so
the expression falls through to the literal string `'main'` — and the lane checks out `main`
instead of the code under review.

## How it surfaced

On #187, which fixes a failing layout assertion:

| | value |
|---|---|
| run 33399522449 head SHA | `3c44dfbe` (the PR's commit) |
| tests reported by that run | **1166** — identical to `main`'s run |
| tests on that branch locally | **1169** (it adds 3 cases) |

The three added cases do not exist in what CI executed, and the run failed on the same assertion
with byte-identical numbers before and after a change that provably moves those numbers locally.

## Why this matters more than the red check

A red check at least made the problem visible. The green ones were worth nothing — and that is the
half that bites next: the moment `main` goes green, **every PR reports a green `ci` check
regardless of its content**, including PRs that break the suite outright.

## The fix

`ref: ${{ inputs.branch || github.ref }}`

- `pull_request` → `refs/pull/N/merge`, so the lane tests the **merge result**, which is what a PR
  check is asked about.
- `push` to main → `refs/heads/main`, unchanged behaviour.
- `workflow_dispatch` → keeps its `branch` input, unchanged behaviour.

`changeset-check` was never affected: it declares no `ref`, so it has always checked out the merge
ref correctly. That is why it is the one check on a PR today that means anything.

## Verification

Only the workflow file changes; the workflow is what has to run to demonstrate it. Prettier parses
and formats the YAML clean. The proof is downstream and immediate: with this merged, #187's `ci`
run should report **1169** tests instead of 1166, and pass.

## Note

Land this before #187 and #186 — both have `ci` failures that are reports about `main`, not about
themselves. #186 also edits `ci.yml`, in a different hunk, and will want a rebase.