### PR TITLE
fix(test): keep the test-level outcomes a document declares

### DIFF
--- a/.changeset/testdoc-loaded-reset.md
+++ b/.changeset/testdoc-loaded-reset.md
@@ -1,0 +1,22 @@
+---
+'@qti-components/test': minor
+'@citolab/qti-components': minor
+---
+
+Keep the test-level outcomes a test document declares.
+
+Test-level `qti-outcome-declaration` elements register themselves into the test context as they
+connect, by dispatching `qti-register-variable`. They are children of `qti-assessment-test`, so they
+connect — and register — *before* the test element announces `qti-assessment-test-connected`.
+
+The test host reset its context on that announcement, which threw every one of those registrations
+away. No test-level outcome could then be read or set: `getOutcome` returned nothing, and
+`qti-set-outcome-value` at test level reported the identifier as unavailable.
+
+`test-container` now announces a new test document with `qti-testdoc-loaded` at the point it assigns
+it, and the host resets on that instead. Lit's re-render is async, so the reset still lands before
+any child of the new document connects. `qti-assessment-test-connected` keeps its remaining job of
+adding the item-refs, and now preserves what the document registered.
+
+This also removes a dead guard: the old handler tested `testContext.items.length > 0` immediately
+after assigning the initial context, so the condition could never hold.

--- a/custom-elements.json
+++ b/custom-elements.json
@@ -49273,6 +49273,25 @@
               "default": "null"
             },
             {
+              "kind": "method",
+              "name": "#setTestDoc",
+              "privacy": "private",
+              "return": {
+                "type": {
+                  "text": "void"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "testDoc",
+                  "type": {
+                    "text": "DocumentFragment"
+                  }
+                }
+              ],
+              "description": "Assign a new test document and announce it.\n\nThe announcement has to happen here rather than on\n`qti-assessment-test-connected`, because by then the new document's\nchildren have already connected and registered themselves — a host that\nresets its context on that event throws those registrations away. Lit's\nre-render is async, so a handler running now still gets in before any child\nof the new `qti-assessment-test` connects."
+            },
+            {
               "kind": "field",
               "name": "#templateContent",
               "privacy": "private",
@@ -49338,6 +49357,14 @@
               },
               "default": "null",
               "description": "The raw XML string"
+            }
+          ],
+          "events": [
+            {
+              "name": "qti-testdoc-loaded",
+              "type": {
+                "text": "CustomEvent"
+              }
             }
           ],
           "attributes": [

--- a/packages/qti-test/src/components/test-container/test-container.ts
+++ b/packages/qti-test/src/components/test-container/test-container.ts
@@ -89,10 +89,30 @@ export class TestContainer extends LitElement {
         }
       }
 
-      this.testDoc = api.htmlDoc(this.#resolvedCustomElementRegistry ?? undefined);
+      this.#setTestDoc(api.htmlDoc(this.#resolvedCustomElementRegistry ?? undefined));
     } catch (error) {
       console.error('Error loading or parsing XML:', error);
     }
+  }
+
+  /**
+   * Assign a new test document and announce it.
+   *
+   * The announcement has to happen here rather than on
+   * `qti-assessment-test-connected`, because by then the new document's
+   * children have already connected and registered themselves — a host that
+   * resets its context on that event throws those registrations away. Lit's
+   * re-render is async, so a handler running now still gets in before any child
+   * of the new `qti-assessment-test` connects.
+   */
+  #setTestDoc(testDoc: DocumentFragment): void {
+    this.testDoc = testDoc;
+    this.dispatchEvent(
+      new CustomEvent('qti-testdoc-loaded', {
+        bubbles: true,
+        composed: true
+      })
+    );
   }
 
   @watch('testXML', { waitUntilFirstUpdate: true })
@@ -100,10 +120,12 @@ export class TestContainer extends LitElement {
     if (!this.testXML) return;
     try {
       const explicitSeed = this.qtiContext?.QTI_CONTEXT?.seed;
-      this.testDoc = qtiTransformTest()
-        .parse(this.testXML)
-        .shuffleOrdering(explicitSeed)
-        .htmlDoc(this.#resolvedCustomElementRegistry ?? undefined);
+      this.#setTestDoc(
+        qtiTransformTest()
+          .parse(this.testXML)
+          .shuffleOrdering(explicitSeed)
+          .htmlDoc(this.#resolvedCustomElementRegistry ?? undefined)
+      );
     } catch (error) {
       console.error('Error parsing XML:', error);
     }

--- a/packages/qti-test/src/mixins/test-base.ts
+++ b/packages/qti-test/src/mixins/test-base.ts
@@ -60,14 +60,26 @@ export const TestBaseMixin = <T extends Constructor<LitElement>>(superClass: T) 
 
     private _initializeEventListeners(): void {
       /**
-       * When the test is connected, the items are updated in the test context.
-       * An existing context item is updated with the itemRef properties if nessesary.
+       * A new test document means a new test and session context.
+       *
+       * This resets on the document being loaded rather than on
+       * `qti-assessment-test-connected`, because the new document's children —
+       * test-level `qti-outcome-declaration` among them — connect and register
+       * themselves into the context *before* the test element announces itself.
+       * Resetting on that announcement discarded every one of those
+       * registrations, so no test-level outcome could be read or set.
+       */
+      this.addEventListener('qti-testdoc-loaded', () => {
+        this.testContext = INITIAL_TEST_CONTEXT;
+        this.sessionContext = INITIAL_SESSION_CONTEXT;
+      });
+
+      /**
+       * When the test is connected, its item-refs are added to the test context.
+       * Registrations from the document's children are already present on the
+       * context reset above, so this must preserve what is there.
        */
       this.addEventListener('qti-assessment-test-connected', (e: CustomEvent<QtiAssessmentTest>) => {
-        this.testContext = INITIAL_TEST_CONTEXT; // new test, new test context!
-        this.sessionContext = INITIAL_SESSION_CONTEXT; // new test, new session context!
-        if (this.testContext && this.testContext.items.length > 0) return;
-
         this._testElement = e.detail;
         const items = Array.from(this._testElement.querySelectorAll('qti-assessment-item-ref')).map(itemRef => {
           return {

--- a/packages/qti-test/src/mixins/test-outcome-registration.spec.ts
+++ b/packages/qti-test/src/mixins/test-outcome-registration.spec.ts
@@ -1,0 +1,64 @@
+import '@citolab/qti-components';
+
+import { html, render } from 'lit';
+
+import type { QtiTest } from '../components/qti-test/qti-test';
+
+/**
+ * Test-level outcome declarations register themselves into the test context by
+ * dispatching `qti-register-variable` as they connect, which the test host
+ * collects into `testContext.testOutcomeVariables`.
+ *
+ * Those declarations are children of `qti-assessment-test`, so they connect —
+ * and register — before the test element itself announces
+ * `qti-assessment-test-connected`. Anything that resets the test context on
+ * that announcement therefore throws their registrations away, and every later
+ * read of a test-level outcome finds nothing declared.
+ */
+const assessmentTest = html`
+  <qti-test navigate="item">
+    <test-container>
+      <qti-assessment-test
+        xmlns="http://www.imsglobal.org/xsd/imsqtiasi_v3p0"
+        identifier="T1"
+        title="Outcome registration"
+      >
+        <qti-outcome-declaration identifier="TEST_SCORE" cardinality="single" base-type="float">
+          <qti-default-value><qti-value>0</qti-value></qti-default-value>
+        </qti-outcome-declaration>
+        <qti-outcome-declaration identifier="TEST_RESULT" cardinality="single" base-type="identifier">
+        </qti-outcome-declaration>
+        <qti-test-part identifier="P1" navigation-mode="nonlinear" submission-mode="simultaneous">
+          <qti-assessment-section identifier="S1" title="S1" visible="true"> </qti-assessment-section>
+        </qti-test-part>
+      </qti-assessment-test>
+    </test-container>
+  </qti-test>
+`;
+
+describe('test-level outcome registration', () => {
+  let qtiTest: QtiTest;
+
+  beforeEach(async () => {
+    render(assessmentTest, document.body);
+    qtiTest = document.body.querySelector('qti-test') as QtiTest;
+    await qtiTest.updateComplete;
+  });
+
+  it('keeps the declarations the test document registered', () => {
+    const declared = qtiTest.testContext.testOutcomeVariables?.map(v => v.identifier) ?? [];
+
+    expect(declared).toContain('TEST_SCORE');
+    expect(declared).toContain('TEST_RESULT');
+  });
+
+  it('can read a declared test-level outcome back', () => {
+    expect(qtiTest.getOutcome('TEST_SCORE')).toBeTruthy();
+  });
+
+  it('can set a declared test-level outcome', () => {
+    qtiTest.updateOutcomeVariable('TEST_RESULT', 'ENCOURAGE');
+
+    expect(qtiTest.getOutcome('TEST_RESULT')?.value).toBe('ENCOURAGE');
+  });
+});


### PR DESCRIPTION
Test-level qti-outcome-declaration elements register into the test context as they connect, by dispatching qti-register-variable. They are children of qti-assessment-test, so they register before the test element announces qti-assessment-test-connected.

The host reset its context on that announcement, discarding every one of those registrations. No test-level outcome could be read or set: getOutcome returned nothing and qti-set-outcome-value at test level reported the identifier as unavailable.

test-container now announces a new document with qti-testdoc-loaded where it assigns it, and the host resets on that instead. Lit re-renders asynchronously, so the reset still lands before any child of the new document connects. qti-assessment-test-connected keeps its remaining job of adding the item-refs and now preserves what the document registered.

Also drops a dead guard: the old handler tested items.length > 0 immediately after assigning the initial context, so it could never hold.