### PR TITLE
feat(test): present test feedback per its access characteristic

### DIFF
--- a/.changeset/test-feedback-access.md
+++ b/.changeset/test-feedback-access.md
@@ -9,7 +9,9 @@ Present test feedback according to its `access` characteristic.
 context the inherited implementation reads:
 
 - `during` — presented after each instance of outcome processing, while the test is in progress.
-- `atEnd` — presented only at the conclusion of the test, or of the test part the feedback sits in.
+- `atEnd` — reachable only at the conclusion of the test, or of the test part the feedback sits in.
+  Concluding that scope makes the feedback available rather than showing it; the candidate reaches
+  it through a `test-show-feedback` button.
 
 `test-navigation` announces `qti-part-completed` and `qti-test-completed` the first time each part,
 and then the test, becomes done — it already owns the per-item view through the computed context, so

--- a/.changeset/test-feedback-access.md
+++ b/.changeset/test-feedback-access.md
@@ -1,0 +1,27 @@
+---
+'@qti-components/test': minor
+'@citolab/qti-components': minor
+---
+
+Present test feedback according to its `access` characteristic.
+
+`qti-test-feedback` gains `access`, and evaluates against the test context rather than the item
+context the inherited implementation reads:
+
+- `during` — presented after each instance of outcome processing, while the test is in progress.
+- `atEnd` — presented only at the conclusion of the test, or of the test part the feedback sits in.
+
+`test-navigation` announces `qti-part-completed` and `qti-test-completed` the first time each part,
+and then the test, becomes done — it already owns the per-item view through the computed context, so
+completion is detected there. Both are one-shot per test, since a part that is done stays done and
+re-announcing would re-run outcome processing on every context rebuild.
+
+`test-processing.mixin` listens for those and runs outcome processing with the scope that concluded,
+which is what gives `atEnd` feedback its chance to evaluate. `outcomeProcessing()` now takes an
+optional `{ atEnd, partId }`, and announces `qti-test-outcome-changed` from the assessment-test
+element carrying the same scope. `qti-assessment-test` re-evaluates the test feedback below it on
+that event, passing the scope through — so only the run that ended a feedback's own scope can
+satisfy `atEnd`, and part-scoped feedback does not fire at the end of the whole test.
+
+`qti-test-feedback` also renders its content now; it previously rendered nothing at all, so no test
+feedback could ever be seen.

--- a/.changeset/test-show-feedback.md
+++ b/.changeset/test-show-feedback.md
@@ -1,0 +1,29 @@
+---
+'@qti-components/base': minor
+'@qti-components/test': minor
+'@citolab/qti-components': minor
+---
+
+Gate `atEnd` test feedback behind a `test-show-feedback` button.
+
+This revises the `atEnd` behaviour introduced by the `access` characteristic: matching the
+outcome now makes the feedback *available* rather than showing it immediately. It stays hidden
+until the candidate navigates to it — a host without a `test-show-feedback` button never shows
+`atEnd` feedback at all. `during` feedback is unaffected; it still shows the instant its outcome
+matches.
+
+- `SessionContext` gains `navFeedbackIdentifier` — the identifier of the atEnd feedback currently
+  on screen, or null otherwise.
+- `ComputedContext` gains `availableFeedbacks` (`{ identifier, partId }[]`) — the atEnd feedbacks
+  whose end-of-part/end-of-test outcome has matched. `test-navigation` builds this from a new
+  `qti-test-feedback-availability-changed` event that `qti-test-feedback` dispatches whenever its
+  own availability flips.
+- `qti-test-feedback` derives its `atEnd` visibility from navigation: available and the
+  candidate's current `navFeedbackIdentifier` matches its own identifier. It withdraws
+  availability the moment the candidate moves into a different test part.
+- A new `<test-show-feedback>` button enables once a feedback is available for the active
+  part (or a test-root feedback), and disables again once the candidate is already viewing it.
+  Clicking dispatches a `feedback`-typed `qti-request-navigation`, which `test-navigation.mixin`
+  now understands alongside `item` and `section` — it clears the on-screen item and records the
+  feedback as shown. Navigating to any item or section afterwards clears
+  `navFeedbackIdentifier`, hiding the feedback again.

--- a/custom-elements.json
+++ b/custom-elements.json
@@ -16495,7 +16495,7 @@
                 "text": "any[] | NodeListOf<QtiAssociableHotspot>"
               },
               "parsedType": {
-                "text": "any[] | { item: {  }, forEach: {  }, entries: {  }, keys: {  }, values: {  }, __@iterator@517: {  }, length: number }"
+                "text": "any[] | { item: {  }, forEach: {  }, entries: {  }, keys: {  }, values: {  }, __@iterator@535: {  }, length: number }"
               }
             },
             {
@@ -32705,7 +32705,7 @@
               },
               "privacy": "private",
               "parsedType": {
-                "text": "{ view: '' | 'author' | 'candidate' | 'proctor' | 'scorer' | 'testConstructor' | 'tutor', identifier: string, title: string, testParts: { active: boolean, identifier: string, navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean, sections: { active: boolean, identifier: string, title: string, completed: boolean, items: { identifier: string, href: string, correct: boolean, incorrect: boolean, completed: boolean, adaptive: boolean, timeDependent: boolean, title: string, label: string, score: number, maxScore: number, completionStatus: string, variables: ReadonlyArray } & { categories: Array, type: type | type, index: number, active: boolean, allowSkipping: boolean, maxAttempts: number, showFeedback: boolean, showSolution: boolean, numAttempts: number, valid: boolean, isDefaultResponse: boolean, done: boolean, optimal: boolean }[], navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean }[] }[] }"
+                "text": "{ view: '' | 'author' | 'candidate' | 'proctor' | 'scorer' | 'testConstructor' | 'tutor', identifier: string, title: string, availableFeedbacks: { identifier: string, partId: string }[], testParts: { active: boolean, identifier: string, navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean, sections: { active: boolean, identifier: string, title: string, completed: boolean, items: { identifier: string, href: string, correct: boolean, incorrect: boolean, completed: boolean, adaptive: boolean, timeDependent: boolean, title: string, label: string, score: number, maxScore: number, completionStatus: string, variables: ReadonlyArray } & { categories: Array, type: type | type, index: number, active: boolean, allowSkipping: boolean, maxAttempts: number, showFeedback: boolean, showSolution: boolean, numAttempts: number, valid: boolean, isDefaultResponse: boolean, done: boolean, optimal: boolean }[], navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean }[] }[] }"
               }
             },
             {
@@ -35876,6 +35876,31 @@
             },
             {
               "kind": "field",
+              "name": "#availableFeedbacks",
+              "privacy": "private",
+              "default": "new Map<string, string | null>()",
+              "description": "atEnd feedbacks that have announced themselves available, keyed by identifier → partId.",
+              "inheritedFrom": {
+                "name": "TestNavigation",
+                "module": "packages/qti-test/src/components/test-navigation/test-navigation.ts"
+              }
+            },
+            {
+              "kind": "method",
+              "name": "#availableFeedbacksList",
+              "privacy": "private",
+              "return": {
+                "type": {
+                  "text": "AvailableFeedback[]"
+                }
+              },
+              "inheritedFrom": {
+                "name": "TestNavigation",
+                "module": "packages/qti-test/src/components/test-navigation/test-navigation.ts"
+              }
+            },
+            {
+              "kind": "field",
               "name": "#endedParts",
               "privacy": "private",
               "default": "new Set<string>()",
@@ -35903,6 +35928,29 @@
                 }
               ],
               "description": "Extract default values from a qti-context-declaration element",
+              "inheritedFrom": {
+                "name": "TestNavigation",
+                "module": "packages/qti-test/src/components/test-navigation/test-navigation.ts"
+              }
+            },
+            {
+              "kind": "method",
+              "name": "#handleFeedbackAvailabilityChanged",
+              "privacy": "private",
+              "return": {
+                "type": {
+                  "text": "void"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "event",
+                  "type": {
+                    "text": "QtiTestFeedbackAvailabilityChangedEvent"
+                  }
+                }
+              ],
+              "description": "Record (or clear) an atEnd feedback's availability and rebuild the computed\ncontext so test-show-feedback can react. Owned here because test-navigation\nalready provides computedContext to the navigation buttons.",
               "inheritedFrom": {
                 "name": "TestNavigation",
                 "module": "packages/qti-test/src/components/test-navigation/test-navigation.ts"
@@ -36202,7 +36250,7 @@
               },
               "privacy": "protected",
               "parsedType": {
-                "text": "{ view: '' | 'author' | 'candidate' | 'proctor' | 'scorer' | 'testConstructor' | 'tutor', identifier: string, title: string, testParts: { active: boolean, identifier: string, navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean, sections: { active: boolean, identifier: string, title: string, completed: boolean, items: { identifier: string, href: string, correct: boolean, incorrect: boolean, completed: boolean, adaptive: boolean, timeDependent: boolean, title: string, label: string, score: number, maxScore: number, completionStatus: string, variables: ReadonlyArray } & { categories: Array, type: type | type, index: number, active: boolean, allowSkipping: boolean, maxAttempts: number, showFeedback: boolean, showSolution: boolean, numAttempts: number, valid: boolean, isDefaultResponse: boolean, done: boolean, optimal: boolean }[], navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean }[] }[] }"
+                "text": "{ view: '' | 'author' | 'candidate' | 'proctor' | 'scorer' | 'testConstructor' | 'tutor', identifier: string, title: string, availableFeedbacks: { identifier: string, partId: string }[], testParts: { active: boolean, identifier: string, navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean, sections: { active: boolean, identifier: string, title: string, completed: boolean, items: { identifier: string, href: string, correct: boolean, incorrect: boolean, completed: boolean, adaptive: boolean, timeDependent: boolean, title: string, label: string, score: number, maxScore: number, completionStatus: string, variables: ReadonlyArray } & { categories: Array, type: type | type, index: number, active: boolean, allowSkipping: boolean, maxAttempts: number, showFeedback: boolean, showSolution: boolean, numAttempts: number, valid: boolean, isDefaultResponse: boolean, done: boolean, optimal: boolean }[], navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean }[] }[] }"
               },
               "inheritedFrom": {
                 "name": "TestNavigation",
@@ -36453,7 +36501,7 @@
               },
               "privacy": "public",
               "parsedType": {
-                "text": "{ view: '' | 'author' | 'candidate' | 'proctor' | 'scorer' | 'testConstructor' | 'tutor', identifier: string, title: string, testParts: { active: boolean, identifier: string, navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean, sections: { active: boolean, identifier: string, title: string, completed: boolean, items: { identifier: string, href: string, correct: boolean, incorrect: boolean, completed: boolean, adaptive: boolean, timeDependent: boolean, title: string, label: string, score: number, maxScore: number, completionStatus: string, variables: ReadonlyArray } & { categories: Array, type: type | type, index: number, active: boolean, allowSkipping: boolean, maxAttempts: number, showFeedback: boolean, showSolution: boolean, numAttempts: number, valid: boolean, isDefaultResponse: boolean, done: boolean, optimal: boolean }[], navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean }[] }[] }"
+                "text": "{ view: '' | 'author' | 'candidate' | 'proctor' | 'scorer' | 'testConstructor' | 'tutor', identifier: string, title: string, availableFeedbacks: { identifier: string, partId: string }[], testParts: { active: boolean, identifier: string, navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean, sections: { active: boolean, identifier: string, title: string, completed: boolean, items: { identifier: string, href: string, correct: boolean, incorrect: boolean, completed: boolean, adaptive: boolean, timeDependent: boolean, title: string, label: string, score: number, maxScore: number, completionStatus: string, variables: ReadonlyArray } & { categories: Array, type: type | type, index: number, active: boolean, allowSkipping: boolean, maxAttempts: number, showFeedback: boolean, showSolution: boolean, numAttempts: number, valid: boolean, isDefaultResponse: boolean, done: boolean, optimal: boolean }[], navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean }[] }[] }"
               }
             },
             {
@@ -37630,7 +37678,7 @@
               },
               "privacy": "private",
               "parsedType": {
-                "text": "{ view: '' | 'author' | 'candidate' | 'proctor' | 'scorer' | 'testConstructor' | 'tutor', identifier: string, title: string, testParts: { active: boolean, identifier: string, navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean, sections: { active: boolean, identifier: string, title: string, completed: boolean, items: { identifier: string, href: string, correct: boolean, incorrect: boolean, completed: boolean, adaptive: boolean, timeDependent: boolean, title: string, label: string, score: number, maxScore: number, completionStatus: string, variables: ReadonlyArray } & { categories: Array, type: type | type, index: number, active: boolean, allowSkipping: boolean, maxAttempts: number, showFeedback: boolean, showSolution: boolean, numAttempts: number, valid: boolean, isDefaultResponse: boolean, done: boolean, optimal: boolean }[], navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean }[] }[] }"
+                "text": "{ view: '' | 'author' | 'candidate' | 'proctor' | 'scorer' | 'testConstructor' | 'tutor', identifier: string, title: string, availableFeedbacks: { identifier: string, partId: string }[], testParts: { active: boolean, identifier: string, navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean, sections: { active: boolean, identifier: string, title: string, completed: boolean, items: { identifier: string, href: string, correct: boolean, incorrect: boolean, completed: boolean, adaptive: boolean, timeDependent: boolean, title: string, label: string, score: number, maxScore: number, completionStatus: string, variables: ReadonlyArray } & { categories: Array, type: type | type, index: number, active: boolean, allowSkipping: boolean, maxAttempts: number, showFeedback: boolean, showSolution: boolean, numAttempts: number, valid: boolean, isDefaultResponse: boolean, done: boolean, optimal: boolean }[], navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean }[] }[] }"
               },
               "inheritedFrom": {
                 "name": "QtiFeedback",
@@ -37854,7 +37902,7 @@
               },
               "privacy": "private",
               "parsedType": {
-                "text": "{ view: '' | 'author' | 'candidate' | 'proctor' | 'scorer' | 'testConstructor' | 'tutor', identifier: string, title: string, testParts: { active: boolean, identifier: string, navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean, sections: { active: boolean, identifier: string, title: string, completed: boolean, items: { identifier: string, href: string, correct: boolean, incorrect: boolean, completed: boolean, adaptive: boolean, timeDependent: boolean, title: string, label: string, score: number, maxScore: number, completionStatus: string, variables: ReadonlyArray } & { categories: Array, type: type | type, index: number, active: boolean, allowSkipping: boolean, maxAttempts: number, showFeedback: boolean, showSolution: boolean, numAttempts: number, valid: boolean, isDefaultResponse: boolean, done: boolean, optimal: boolean }[], navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean }[] }[] }"
+                "text": "{ view: '' | 'author' | 'candidate' | 'proctor' | 'scorer' | 'testConstructor' | 'tutor', identifier: string, title: string, availableFeedbacks: { identifier: string, partId: string }[], testParts: { active: boolean, identifier: string, navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean, sections: { active: boolean, identifier: string, title: string, completed: boolean, items: { identifier: string, href: string, correct: boolean, incorrect: boolean, completed: boolean, adaptive: boolean, timeDependent: boolean, title: string, label: string, score: number, maxScore: number, completionStatus: string, variables: ReadonlyArray } & { categories: Array, type: type | type, index: number, active: boolean, allowSkipping: boolean, maxAttempts: number, showFeedback: boolean, showSolution: boolean, numAttempts: number, valid: boolean, isDefaultResponse: boolean, done: boolean, optimal: boolean }[], navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean }[] }[] }"
               },
               "inheritedFrom": {
                 "name": "QtiFeedback",
@@ -38132,7 +38180,7 @@
               },
               "privacy": "private",
               "parsedType": {
-                "text": "{ view: '' | 'author' | 'candidate' | 'proctor' | 'scorer' | 'testConstructor' | 'tutor', identifier: string, title: string, testParts: { active: boolean, identifier: string, navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean, sections: { active: boolean, identifier: string, title: string, completed: boolean, items: { identifier: string, href: string, correct: boolean, incorrect: boolean, completed: boolean, adaptive: boolean, timeDependent: boolean, title: string, label: string, score: number, maxScore: number, completionStatus: string, variables: ReadonlyArray } & { categories: Array, type: type | type, index: number, active: boolean, allowSkipping: boolean, maxAttempts: number, showFeedback: boolean, showSolution: boolean, numAttempts: number, valid: boolean, isDefaultResponse: boolean, done: boolean, optimal: boolean }[], navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean }[] }[] }"
+                "text": "{ view: '' | 'author' | 'candidate' | 'proctor' | 'scorer' | 'testConstructor' | 'tutor', identifier: string, title: string, availableFeedbacks: { identifier: string, partId: string }[], testParts: { active: boolean, identifier: string, navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean, sections: { active: boolean, identifier: string, title: string, completed: boolean, items: { identifier: string, href: string, correct: boolean, incorrect: boolean, completed: boolean, adaptive: boolean, timeDependent: boolean, title: string, label: string, score: number, maxScore: number, completionStatus: string, variables: ReadonlyArray } & { categories: Array, type: type | type, index: number, active: boolean, allowSkipping: boolean, maxAttempts: number, showFeedback: boolean, showSolution: boolean, numAttempts: number, valid: boolean, isDefaultResponse: boolean, done: boolean, optimal: boolean }[], navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean }[] }[] }"
               },
               "inheritedFrom": {
                 "name": "QtiFeedback",
@@ -49518,6 +49566,14 @@
           "name": "*",
           "declaration": {
             "name": "*",
+            "module": "packages/qti-test/src/components/test-show-feedback/test-show-feedback"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "*",
+          "declaration": {
+            "name": "*",
             "module": "packages/qti-test/src/components/test-view-toggle/test-view"
           }
         },
@@ -50366,13 +50422,23 @@
           "members": [
             {
               "kind": "field",
+              "name": "_available",
+              "type": {
+                "text": "boolean"
+              },
+              "privacy": "private",
+              "default": "false",
+              "description": "For `access=\"atEnd\"`: whether the feedback's outcome has matched and it is\nready to be shown. While available, the feedback stays hidden until a\ntest-show-feedback button navigates the candidate to it\n(`_sessionContext.navFeedbackIdentifier`). `during` feedback ignores this\nflag and shows the instant its outcome matches."
+            },
+            {
+              "kind": "field",
               "name": "_computedContext",
               "type": {
                 "text": "ComputedContext | undefined"
               },
               "privacy": "private",
               "parsedType": {
-                "text": "{ view: '' | 'author' | 'candidate' | 'proctor' | 'scorer' | 'testConstructor' | 'tutor', identifier: string, title: string, testParts: { active: boolean, identifier: string, navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean, sections: { active: boolean, identifier: string, title: string, completed: boolean, items: { identifier: string, href: string, correct: boolean, incorrect: boolean, completed: boolean, adaptive: boolean, timeDependent: boolean, title: string, label: string, score: number, maxScore: number, completionStatus: string, variables: ReadonlyArray } & { categories: Array, type: type | type, index: number, active: boolean, allowSkipping: boolean, maxAttempts: number, showFeedback: boolean, showSolution: boolean, numAttempts: number, valid: boolean, isDefaultResponse: boolean, done: boolean, optimal: boolean }[], navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean }[] }[] }"
+                "text": "{ view: '' | 'author' | 'candidate' | 'proctor' | 'scorer' | 'testConstructor' | 'tutor', identifier: string, title: string, availableFeedbacks: { identifier: string, partId: string }[], testParts: { active: boolean, identifier: string, navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean, sections: { active: boolean, identifier: string, title: string, completed: boolean, items: { identifier: string, href: string, correct: boolean, incorrect: boolean, completed: boolean, adaptive: boolean, timeDependent: boolean, title: string, label: string, score: number, maxScore: number, completionStatus: string, variables: ReadonlyArray } & { categories: Array, type: type | type, index: number, active: boolean, allowSkipping: boolean, maxAttempts: number, showFeedback: boolean, showSolution: boolean, numAttempts: number, valid: boolean, isDefaultResponse: boolean, done: boolean, optimal: boolean }[], navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean }[] }[] }"
               },
               "inheritedFrom": {
                 "name": "QtiFeedback",
@@ -50390,6 +50456,14 @@
                 "name": "QtiFeedback",
                 "module": "packages/qti-base/src/abstract/qti-feedback.ts"
               }
+            },
+            {
+              "kind": "field",
+              "name": "_sessionContext",
+              "type": {
+                "text": "SessionContext | undefined"
+              },
+              "privacy": "private"
             },
             {
               "kind": "field",
@@ -50440,6 +50514,25 @@
             },
             {
               "kind": "method",
+              "name": "#setAvailable",
+              "privacy": "private",
+              "return": {
+                "type": {
+                  "text": "void"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "available",
+                  "type": {
+                    "text": "boolean"
+                  }
+                }
+              ],
+              "description": "Update availability and announce the change so test-show-feedback can enable."
+            },
+            {
+              "kind": "method",
               "name": "#showFeedback",
               "privacy": "private",
               "parameters": [
@@ -50463,7 +50556,7 @@
               },
               "privacy": "public",
               "default": "'atEnd'",
-              "description": "When the feedback may be presented, per the QTI 3 `access` characteristic.\n\n- `atEnd` — only at the conclusion of the test, or of the test part the\n  feedback sits in.\n- `during` — while the test is still in progress, after each instance of\n  outcome processing.",
+              "description": "When the feedback may be presented, per the QTI 3 `access` characteristic.\n\n- `atEnd` — only at the conclusion of the test, or of the test part the\n  feedback sits in. Becoming available only unlocks a test-show-feedback\n  button — the feedback itself stays hidden until the candidate navigates\n  to it.\n- `during` — while the test is still in progress, after each instance of\n  outcome processing. Shows the instant its outcome matches.",
               "attribute": "access",
               "parsedType": {
                 "text": "'atEnd' | 'during'"
@@ -50580,6 +50673,24 @@
               }
             }
           ],
+          "events": [
+            {
+              "name": "qti-register-feedback",
+              "type": {
+                "text": "CustomEvent"
+              },
+              "inheritedFrom": {
+                "name": "QtiFeedback",
+                "module": "packages/qti-base/src/abstract/qti-feedback.ts"
+              }
+            },
+            {
+              "name": "qti-test-feedback-availability-changed",
+              "type": {
+                "text": "CustomEvent"
+              }
+            }
+          ],
           "attributes": [
             {
               "name": "access",
@@ -50587,7 +50698,7 @@
                 "text": "TestFeedbackAccess"
               },
               "default": "'atEnd'",
-              "description": "When the feedback may be presented, per the QTI 3 `access` characteristic.\n\n- `atEnd` — only at the conclusion of the test, or of the test part the\n  feedback sits in.\n- `during` — while the test is still in progress, after each instance of\n  outcome processing.",
+              "description": "When the feedback may be presented, per the QTI 3 `access` characteristic.\n\n- `atEnd` — only at the conclusion of the test, or of the test part the\n  feedback sits in. Becoming available only unlocks a test-show-feedback\n  button — the feedback itself stays hidden until the candidate navigates\n  to it.\n- `during` — while the test is still in progress, after each instance of\n  outcome processing. Shows the instant its outcome matches.",
               "fieldName": "access",
               "parsedType": {
                 "text": "'atEnd' | 'during'"
@@ -50635,18 +50746,6 @@
             "name": "QtiModalFeedback",
             "package": "@qti-components/elements/elements"
           },
-          "events": [
-            {
-              "name": "qti-register-feedback",
-              "type": {
-                "text": "CustomEvent"
-              },
-              "inheritedFrom": {
-                "name": "QtiFeedback",
-                "module": "packages/qti-base/src/abstract/qti-feedback.ts"
-              }
-            }
-          ],
           "tagName": "qti-test-feedback",
           "customElement": true,
           "modulePath": "packages/qti-test/src/components/qti-test-feedback/qti-test-feedback.ts",
@@ -51370,7 +51469,7 @@
               },
               "privacy": "protected",
               "parsedType": {
-                "text": "{ view: '' | 'author' | 'candidate' | 'proctor' | 'scorer' | 'testConstructor' | 'tutor', identifier: string, title: string, testParts: { active: boolean, identifier: string, navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean, sections: { active: boolean, identifier: string, title: string, completed: boolean, items: { identifier: string, href: string, correct: boolean, incorrect: boolean, completed: boolean, adaptive: boolean, timeDependent: boolean, title: string, label: string, score: number, maxScore: number, completionStatus: string, variables: ReadonlyArray } & { categories: Array, type: type | type, index: number, active: boolean, allowSkipping: boolean, maxAttempts: number, showFeedback: boolean, showSolution: boolean, numAttempts: number, valid: boolean, isDefaultResponse: boolean, done: boolean, optimal: boolean }[], navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean }[] }[] }"
+                "text": "{ view: '' | 'author' | 'candidate' | 'proctor' | 'scorer' | 'testConstructor' | 'tutor', identifier: string, title: string, availableFeedbacks: { identifier: string, partId: string }[], testParts: { active: boolean, identifier: string, navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean, sections: { active: boolean, identifier: string, title: string, completed: boolean, items: { identifier: string, href: string, correct: boolean, incorrect: boolean, completed: boolean, adaptive: boolean, timeDependent: boolean, title: string, label: string, score: number, maxScore: number, completionStatus: string, variables: ReadonlyArray } & { categories: Array, type: type | type, index: number, active: boolean, allowSkipping: boolean, maxAttempts: number, showFeedback: boolean, showSolution: boolean, numAttempts: number, valid: boolean, isDefaultResponse: boolean, done: boolean, optimal: boolean }[], navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean }[] }[] }"
               }
             }
           ],
@@ -52328,6 +52427,23 @@
             },
             {
               "kind": "field",
+              "name": "#availableFeedbacks",
+              "privacy": "private",
+              "default": "new Map<string, string | null>()",
+              "description": "atEnd feedbacks that have announced themselves available, keyed by identifier → partId."
+            },
+            {
+              "kind": "method",
+              "name": "#availableFeedbacksList",
+              "privacy": "private",
+              "return": {
+                "type": {
+                  "text": "AvailableFeedback[]"
+                }
+              }
+            },
+            {
+              "kind": "field",
               "name": "#endedParts",
               "privacy": "private",
               "default": "new Set<string>()",
@@ -52351,6 +52467,25 @@
                 }
               ],
               "description": "Extract default values from a qti-context-declaration element"
+            },
+            {
+              "kind": "method",
+              "name": "#handleFeedbackAvailabilityChanged",
+              "privacy": "private",
+              "return": {
+                "type": {
+                  "text": "void"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "event",
+                  "type": {
+                    "text": "QtiTestFeedbackAvailabilityChangedEvent"
+                  }
+                }
+              ],
+              "description": "Record (or clear) an atEnd feedback's availability and rebuild the computed\ncontext so test-show-feedback can react. Owned here because test-navigation\nalready provides computedContext to the navigation buttons."
             },
             {
               "kind": "method",
@@ -52578,7 +52713,7 @@
               },
               "privacy": "protected",
               "parsedType": {
-                "text": "{ view: '' | 'author' | 'candidate' | 'proctor' | 'scorer' | 'testConstructor' | 'tutor', identifier: string, title: string, testParts: { active: boolean, identifier: string, navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean, sections: { active: boolean, identifier: string, title: string, completed: boolean, items: { identifier: string, href: string, correct: boolean, incorrect: boolean, completed: boolean, adaptive: boolean, timeDependent: boolean, title: string, label: string, score: number, maxScore: number, completionStatus: string, variables: ReadonlyArray } & { categories: Array, type: type | type, index: number, active: boolean, allowSkipping: boolean, maxAttempts: number, showFeedback: boolean, showSolution: boolean, numAttempts: number, valid: boolean, isDefaultResponse: boolean, done: boolean, optimal: boolean }[], navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean }[] }[] }"
+                "text": "{ view: '' | 'author' | 'candidate' | 'proctor' | 'scorer' | 'testConstructor' | 'tutor', identifier: string, title: string, availableFeedbacks: { identifier: string, partId: string }[], testParts: { active: boolean, identifier: string, navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean, sections: { active: boolean, identifier: string, title: string, completed: boolean, items: { identifier: string, href: string, correct: boolean, incorrect: boolean, completed: boolean, adaptive: boolean, timeDependent: boolean, title: string, label: string, score: number, maxScore: number, completionStatus: string, variables: ReadonlyArray } & { categories: Array, type: type | type, index: number, active: boolean, allowSkipping: boolean, maxAttempts: number, showFeedback: boolean, showSolution: boolean, numAttempts: number, valid: boolean, isDefaultResponse: boolean, done: boolean, optimal: boolean }[], navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean }[] }[] }"
               }
             },
             {
@@ -52800,7 +52935,7 @@
               },
               "privacy": "protected",
               "parsedType": {
-                "text": "{ view: '' | 'author' | 'candidate' | 'proctor' | 'scorer' | 'testConstructor' | 'tutor', identifier: string, title: string, testParts: { active: boolean, identifier: string, navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean, sections: { active: boolean, identifier: string, title: string, completed: boolean, items: { identifier: string, href: string, correct: boolean, incorrect: boolean, completed: boolean, adaptive: boolean, timeDependent: boolean, title: string, label: string, score: number, maxScore: number, completionStatus: string, variables: ReadonlyArray } & { categories: Array, type: type | type, index: number, active: boolean, allowSkipping: boolean, maxAttempts: number, showFeedback: boolean, showSolution: boolean, numAttempts: number, valid: boolean, isDefaultResponse: boolean, done: boolean, optimal: boolean }[], navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean }[] }[] }"
+                "text": "{ view: '' | 'author' | 'candidate' | 'proctor' | 'scorer' | 'testConstructor' | 'tutor', identifier: string, title: string, availableFeedbacks: { identifier: string, partId: string }[], testParts: { active: boolean, identifier: string, navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean, sections: { active: boolean, identifier: string, title: string, completed: boolean, items: { identifier: string, href: string, correct: boolean, incorrect: boolean, completed: boolean, adaptive: boolean, timeDependent: boolean, title: string, label: string, score: number, maxScore: number, completionStatus: string, variables: ReadonlyArray } & { categories: Array, type: type | type, index: number, active: boolean, allowSkipping: boolean, maxAttempts: number, showFeedback: boolean, showSolution: boolean, numAttempts: number, valid: boolean, isDefaultResponse: boolean, done: boolean, optimal: boolean }[], navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean }[] }[] }"
               }
             },
             {
@@ -52906,7 +53041,7 @@
               },
               "privacy": "private",
               "parsedType": {
-                "text": "{ view: '' | 'author' | 'candidate' | 'proctor' | 'scorer' | 'testConstructor' | 'tutor', identifier: string, title: string, testParts: { active: boolean, identifier: string, navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean, sections: { active: boolean, identifier: string, title: string, completed: boolean, items: { identifier: string, href: string, correct: boolean, incorrect: boolean, completed: boolean, adaptive: boolean, timeDependent: boolean, title: string, label: string, score: number, maxScore: number, completionStatus: string, variables: ReadonlyArray } & { categories: Array, type: type | type, index: number, active: boolean, allowSkipping: boolean, maxAttempts: number, showFeedback: boolean, showSolution: boolean, numAttempts: number, valid: boolean, isDefaultResponse: boolean, done: boolean, optimal: boolean }[], navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean }[] }[] }"
+                "text": "{ view: '' | 'author' | 'candidate' | 'proctor' | 'scorer' | 'testConstructor' | 'tutor', identifier: string, title: string, availableFeedbacks: { identifier: string, partId: string }[], testParts: { active: boolean, identifier: string, navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean, sections: { active: boolean, identifier: string, title: string, completed: boolean, items: { identifier: string, href: string, correct: boolean, incorrect: boolean, completed: boolean, adaptive: boolean, timeDependent: boolean, title: string, label: string, score: number, maxScore: number, completionStatus: string, variables: ReadonlyArray } & { categories: Array, type: type | type, index: number, active: boolean, allowSkipping: boolean, maxAttempts: number, showFeedback: boolean, showSolution: boolean, numAttempts: number, valid: boolean, isDefaultResponse: boolean, done: boolean, optimal: boolean }[], navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean }[] }[] }"
               }
             },
             {
@@ -53021,7 +53156,7 @@
               },
               "privacy": "private",
               "parsedType": {
-                "text": "{ view: '' | 'author' | 'candidate' | 'proctor' | 'scorer' | 'testConstructor' | 'tutor', identifier: string, title: string, testParts: { active: boolean, identifier: string, navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean, sections: { active: boolean, identifier: string, title: string, completed: boolean, items: { identifier: string, href: string, correct: boolean, incorrect: boolean, completed: boolean, adaptive: boolean, timeDependent: boolean, title: string, label: string, score: number, maxScore: number, completionStatus: string, variables: ReadonlyArray } & { categories: Array, type: type | type, index: number, active: boolean, allowSkipping: boolean, maxAttempts: number, showFeedback: boolean, showSolution: boolean, numAttempts: number, valid: boolean, isDefaultResponse: boolean, done: boolean, optimal: boolean }[], navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean }[] }[] }"
+                "text": "{ view: '' | 'author' | 'candidate' | 'proctor' | 'scorer' | 'testConstructor' | 'tutor', identifier: string, title: string, availableFeedbacks: { identifier: string, partId: string }[], testParts: { active: boolean, identifier: string, navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean, sections: { active: boolean, identifier: string, title: string, completed: boolean, items: { identifier: string, href: string, correct: boolean, incorrect: boolean, completed: boolean, adaptive: boolean, timeDependent: boolean, title: string, label: string, score: number, maxScore: number, completionStatus: string, variables: ReadonlyArray } & { categories: Array, type: type | type, index: number, active: boolean, allowSkipping: boolean, maxAttempts: number, showFeedback: boolean, showSolution: boolean, numAttempts: number, valid: boolean, isDefaultResponse: boolean, done: boolean, optimal: boolean }[], navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean }[] }[] }"
               }
             },
             {
@@ -53103,7 +53238,7 @@
               },
               "privacy": "public",
               "parsedType": {
-                "text": "{ view: '' | 'author' | 'candidate' | 'proctor' | 'scorer' | 'testConstructor' | 'tutor', identifier: string, title: string, testParts: { active: boolean, identifier: string, navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean, sections: { active: boolean, identifier: string, title: string, completed: boolean, items: { identifier: string, href: string, correct: boolean, incorrect: boolean, completed: boolean, adaptive: boolean, timeDependent: boolean, title: string, label: string, score: number, maxScore: number, completionStatus: string, variables: ReadonlyArray } & { categories: Array, type: type | type, index: number, active: boolean, allowSkipping: boolean, maxAttempts: number, showFeedback: boolean, showSolution: boolean, numAttempts: number, valid: boolean, isDefaultResponse: boolean, done: boolean, optimal: boolean }[], navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean }[] }[] }"
+                "text": "{ view: '' | 'author' | 'candidate' | 'proctor' | 'scorer' | 'testConstructor' | 'tutor', identifier: string, title: string, availableFeedbacks: { identifier: string, partId: string }[], testParts: { active: boolean, identifier: string, navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean, sections: { active: boolean, identifier: string, title: string, completed: boolean, items: { identifier: string, href: string, correct: boolean, incorrect: boolean, completed: boolean, adaptive: boolean, timeDependent: boolean, title: string, label: string, score: number, maxScore: number, completionStatus: string, variables: ReadonlyArray } & { categories: Array, type: type | type, index: number, active: boolean, allowSkipping: boolean, maxAttempts: number, showFeedback: boolean, showSolution: boolean, numAttempts: number, valid: boolean, isDefaultResponse: boolean, done: boolean, optimal: boolean }[], navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean }[] }[] }"
               }
             }
           ],
@@ -53153,7 +53288,7 @@
               },
               "privacy": "public",
               "parsedType": {
-                "text": "{ view: '' | 'author' | 'candidate' | 'proctor' | 'scorer' | 'testConstructor' | 'tutor', identifier: string, title: string, testParts: { active: boolean, identifier: string, navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean, sections: { active: boolean, identifier: string, title: string, completed: boolean, items: { identifier: string, href: string, correct: boolean, incorrect: boolean, completed: boolean, adaptive: boolean, timeDependent: boolean, title: string, label: string, score: number, maxScore: number, completionStatus: string, variables: ReadonlyArray } & { categories: Array, type: type | type, index: number, active: boolean, allowSkipping: boolean, maxAttempts: number, showFeedback: boolean, showSolution: boolean, numAttempts: number, valid: boolean, isDefaultResponse: boolean, done: boolean, optimal: boolean }[], navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean }[] }[] }"
+                "text": "{ view: '' | 'author' | 'candidate' | 'proctor' | 'scorer' | 'testConstructor' | 'tutor', identifier: string, title: string, availableFeedbacks: { identifier: string, partId: string }[], testParts: { active: boolean, identifier: string, navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean, sections: { active: boolean, identifier: string, title: string, completed: boolean, items: { identifier: string, href: string, correct: boolean, incorrect: boolean, completed: boolean, adaptive: boolean, timeDependent: boolean, title: string, label: string, score: number, maxScore: number, completionStatus: string, variables: ReadonlyArray } & { categories: Array, type: type | type, index: number, active: boolean, allowSkipping: boolean, maxAttempts: number, showFeedback: boolean, showSolution: boolean, numAttempts: number, valid: boolean, isDefaultResponse: boolean, done: boolean, optimal: boolean }[], navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean }[] }[] }"
               }
             }
           ],
@@ -53216,7 +53351,7 @@
               },
               "privacy": "protected",
               "parsedType": {
-                "text": "{ view: '' | 'author' | 'candidate' | 'proctor' | 'scorer' | 'testConstructor' | 'tutor', identifier: string, title: string, testParts: { active: boolean, identifier: string, navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean, sections: { active: boolean, identifier: string, title: string, completed: boolean, items: { identifier: string, href: string, correct: boolean, incorrect: boolean, completed: boolean, adaptive: boolean, timeDependent: boolean, title: string, label: string, score: number, maxScore: number, completionStatus: string, variables: ReadonlyArray } & { categories: Array, type: type | type, index: number, active: boolean, allowSkipping: boolean, maxAttempts: number, showFeedback: boolean, showSolution: boolean, numAttempts: number, valid: boolean, isDefaultResponse: boolean, done: boolean, optimal: boolean }[], navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean }[] }[] }"
+                "text": "{ view: '' | 'author' | 'candidate' | 'proctor' | 'scorer' | 'testConstructor' | 'tutor', identifier: string, title: string, availableFeedbacks: { identifier: string, partId: string }[], testParts: { active: boolean, identifier: string, navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean, sections: { active: boolean, identifier: string, title: string, completed: boolean, items: { identifier: string, href: string, correct: boolean, incorrect: boolean, completed: boolean, adaptive: boolean, timeDependent: boolean, title: string, label: string, score: number, maxScore: number, completionStatus: string, variables: ReadonlyArray } & { categories: Array, type: type | type, index: number, active: boolean, allowSkipping: boolean, maxAttempts: number, showFeedback: boolean, showSolution: boolean, numAttempts: number, valid: boolean, isDefaultResponse: boolean, done: boolean, optimal: boolean }[], navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean }[] }[] }"
               }
             },
             {
@@ -53318,7 +53453,7 @@
               },
               "privacy": "protected",
               "parsedType": {
-                "text": "{ view: '' | 'author' | 'candidate' | 'proctor' | 'scorer' | 'testConstructor' | 'tutor', identifier: string, title: string, testParts: { active: boolean, identifier: string, navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean, sections: { active: boolean, identifier: string, title: string, completed: boolean, items: { identifier: string, href: string, correct: boolean, incorrect: boolean, completed: boolean, adaptive: boolean, timeDependent: boolean, title: string, label: string, score: number, maxScore: number, completionStatus: string, variables: ReadonlyArray } & { categories: Array, type: type | type, index: number, active: boolean, allowSkipping: boolean, maxAttempts: number, showFeedback: boolean, showSolution: boolean, numAttempts: number, valid: boolean, isDefaultResponse: boolean, done: boolean, optimal: boolean }[], navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean }[] }[] }"
+                "text": "{ view: '' | 'author' | 'candidate' | 'proctor' | 'scorer' | 'testConstructor' | 'tutor', identifier: string, title: string, availableFeedbacks: { identifier: string, partId: string }[], testParts: { active: boolean, identifier: string, navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean, sections: { active: boolean, identifier: string, title: string, completed: boolean, items: { identifier: string, href: string, correct: boolean, incorrect: boolean, completed: boolean, adaptive: boolean, timeDependent: boolean, title: string, label: string, score: number, maxScore: number, completionStatus: string, variables: ReadonlyArray } & { categories: Array, type: type | type, index: number, active: boolean, allowSkipping: boolean, maxAttempts: number, showFeedback: boolean, showSolution: boolean, numAttempts: number, valid: boolean, isDefaultResponse: boolean, done: boolean, optimal: boolean }[], navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean }[] }[] }"
               }
             },
             {
@@ -53410,7 +53545,7 @@
               },
               "privacy": "private",
               "parsedType": {
-                "text": "{ view: '' | 'author' | 'candidate' | 'proctor' | 'scorer' | 'testConstructor' | 'tutor', identifier: string, title: string, testParts: { active: boolean, identifier: string, navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean, sections: { active: boolean, identifier: string, title: string, completed: boolean, items: { identifier: string, href: string, correct: boolean, incorrect: boolean, completed: boolean, adaptive: boolean, timeDependent: boolean, title: string, label: string, score: number, maxScore: number, completionStatus: string, variables: ReadonlyArray } & { categories: Array, type: type | type, index: number, active: boolean, allowSkipping: boolean, maxAttempts: number, showFeedback: boolean, showSolution: boolean, numAttempts: number, valid: boolean, isDefaultResponse: boolean, done: boolean, optimal: boolean }[], navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean }[] }[] }"
+                "text": "{ view: '' | 'author' | 'candidate' | 'proctor' | 'scorer' | 'testConstructor' | 'tutor', identifier: string, title: string, availableFeedbacks: { identifier: string, partId: string }[], testParts: { active: boolean, identifier: string, navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean, sections: { active: boolean, identifier: string, title: string, completed: boolean, items: { identifier: string, href: string, correct: boolean, incorrect: boolean, completed: boolean, adaptive: boolean, timeDependent: boolean, title: string, label: string, score: number, maxScore: number, completionStatus: string, variables: ReadonlyArray } & { categories: Array, type: type | type, index: number, active: boolean, allowSkipping: boolean, maxAttempts: number, showFeedback: boolean, showSolution: boolean, numAttempts: number, valid: boolean, isDefaultResponse: boolean, done: boolean, optimal: boolean }[], navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean }[] }[] }"
               }
             },
             {
@@ -53533,6 +53668,169 @@
     },
     {
       "kind": "javascript-module",
+      "path": "packages/qti-test/src/components/test-show-feedback/test-show-feedback.ts",
+      "declarations": [
+        {
+          "kind": "class",
+          "description": "Navigates the candidate to an `access=\"atEnd\"` qti-test-feedback once it has\nbecome available (its end-of-part / end-of-test outcome has matched). The\nbutton is disabled until then, so a host can keep it hidden until enabled.\n\nClicking dispatches a `feedback` navigation request, which clears the current\nassessment item and shows the feedback. Navigating to any item afterwards (or\nmoving into a later test-part) hides the feedback again.",
+          "name": "TestShowFeedback",
+          "members": [
+            {
+              "kind": "method",
+              "name": "_handleComputedContextChange",
+              "parameters": [
+                {
+                  "name": "_oldValue",
+                  "type": {
+                    "text": "ComputedContext"
+                  }
+                },
+                {
+                  "name": "newValue",
+                  "type": {
+                    "text": "ComputedContext"
+                  }
+                }
+              ],
+              "type": {
+                "text": "_handleComputedContextChange(_oldValue: ComputedContext, newValue: ComputedContext) => void"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "_internalDisabled",
+              "type": {
+                "text": "boolean"
+              },
+              "privacy": "public",
+              "default": "true",
+              "attribute": "disabled",
+              "reflects": true
+            },
+            {
+              "kind": "method",
+              "name": "_requestFeedback",
+              "privacy": "protected",
+              "return": {
+                "type": {
+                  "text": "void"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "identifier",
+                  "type": {
+                    "text": "string"
+                  }
+                }
+              ]
+            },
+            {
+              "kind": "field",
+              "name": "#feedbackId",
+              "privacy": "private",
+              "type": {
+                "text": "string | null"
+              },
+              "default": "null",
+              "description": "Identifier of the feedback to navigate to, set whenever one is available.",
+              "parsedType": {
+                "text": "string"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "#internals",
+              "privacy": "private",
+              "type": {
+                "text": "ElementInternals"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "ariaLabel",
+              "type": {
+                "text": "string"
+              },
+              "default": "'Show feedback'"
+            },
+            {
+              "kind": "field",
+              "name": "computedContext",
+              "type": {
+                "text": "ComputedContext"
+              },
+              "privacy": "private",
+              "parsedType": {
+                "text": "{ view: '' | 'author' | 'candidate' | 'proctor' | 'scorer' | 'testConstructor' | 'tutor', identifier: string, title: string, availableFeedbacks: { identifier: string, partId: string }[], testParts: { active: boolean, identifier: string, navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean, sections: { active: boolean, identifier: string, title: string, completed: boolean, items: { identifier: string, href: string, correct: boolean, incorrect: boolean, completed: boolean, adaptive: boolean, timeDependent: boolean, title: string, label: string, score: number, maxScore: number, completionStatus: string, variables: ReadonlyArray } & { categories: Array, type: type | type, index: number, active: boolean, allowSkipping: boolean, maxAttempts: number, showFeedback: boolean, showSolution: boolean, numAttempts: number, valid: boolean, isDefaultResponse: boolean, done: boolean, optimal: boolean }[], navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean }[] }[] }"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "role",
+              "type": {
+                "text": "string"
+              },
+              "default": "'button'"
+            },
+            {
+              "kind": "field",
+              "name": "sessionContext",
+              "type": {
+                "text": "SessionContext"
+              },
+              "privacy": "private"
+            }
+          ],
+          "events": [
+            {
+              "name": "qti-request-navigation",
+              "type": {
+                "text": "CustomEvent"
+              }
+            }
+          ],
+          "attributes": [
+            {
+              "name": "disabled",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "true",
+              "fieldName": "_internalDisabled"
+            }
+          ],
+          "superclass": {
+            "name": "LitElement",
+            "package": "lit"
+          },
+          "customElement": true,
+          "tagName": "test-show-feedback",
+          "modulePath": "packages/qti-test/src/components/test-show-feedback/test-show-feedback.ts",
+          "definitionPath": "packages/qti-test/src/components/test-show-feedback/test-show-feedback.ts"
+        }
+      ],
+      "exports": [
+        {
+          "kind": "custom-element-definition",
+          "name": "test-show-feedback",
+          "declaration": {
+            "name": "TestShowFeedback",
+            "module": "packages/qti-test/src/components/test-show-feedback/test-show-feedback.ts"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "TestShowFeedback",
+          "declaration": {
+            "name": "TestShowFeedback",
+            "module": "packages/qti-test/src/components/test-show-feedback/test-show-feedback.ts"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
       "path": "packages/qti-test/src/components/test-stamp/test-stamp.ts",
       "declarations": [
         {
@@ -53548,7 +53846,7 @@
               },
               "privacy": "private",
               "parsedType": {
-                "text": "{ view: '' | 'author' | 'candidate' | 'proctor' | 'scorer' | 'testConstructor' | 'tutor', identifier: string, title: string, testParts: { active: boolean, identifier: string, navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean, sections: { active: boolean, identifier: string, title: string, completed: boolean, items: { identifier: string, href: string, correct: boolean, incorrect: boolean, completed: boolean, adaptive: boolean, timeDependent: boolean, title: string, label: string, score: number, maxScore: number, completionStatus: string, variables: ReadonlyArray } & { categories: Array, type: type | type, index: number, active: boolean, allowSkipping: boolean, maxAttempts: number, showFeedback: boolean, showSolution: boolean, numAttempts: number, valid: boolean, isDefaultResponse: boolean, done: boolean, optimal: boolean }[], navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean }[] }[] }"
+                "text": "{ view: '' | 'author' | 'candidate' | 'proctor' | 'scorer' | 'testConstructor' | 'tutor', identifier: string, title: string, availableFeedbacks: { identifier: string, partId: string }[], testParts: { active: boolean, identifier: string, navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean, sections: { active: boolean, identifier: string, title: string, completed: boolean, items: { identifier: string, href: string, correct: boolean, incorrect: boolean, completed: boolean, adaptive: boolean, timeDependent: boolean, title: string, label: string, score: number, maxScore: number, completionStatus: string, variables: ReadonlyArray } & { categories: Array, type: type | type, index: number, active: boolean, allowSkipping: boolean, maxAttempts: number, showFeedback: boolean, showSolution: boolean, numAttempts: number, valid: boolean, isDefaultResponse: boolean, done: boolean, optimal: boolean }[], navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean }[] }[] }"
               }
             },
             {
@@ -53846,9 +54144,9 @@
           "kind": "variable",
           "name": "qtiTestElements",
           "type": {
-            "text": "[\n  { tag: 'qti-assessment-item-ref', ctor: QtiAssessmentItemRef },\n  { tag: 'qti-assessment-section', ctor: QtiAssessmentSection },\n  { tag: 'qti-assessment-test', ctor: QtiAssessmentTest },\n  { tag: 'qti-item-session-control', ctor: QtiItemSessionControl },\n  { tag: 'qti-outcome-processing', ctor: QtiOutcomeProcessing },\n  { tag: 'qti-test', ctor: QtiTest },\n  { tag: 'qti-test-feedback', ctor: QtiTestFeedback },\n  { tag: 'qti-test-part', ctor: QtiTestPart },\n  { tag: 'qti-test-variables', ctor: QtiTestVariables },\n  { tag: 'test-check-item', ctor: TestCheckItem },\n  { tag: 'test-container', ctor: TestContainer },\n  { tag: 'test-end-attempt', ctor: TestEndAttempt },\n  { tag: 'test-item-link', ctor: TestItemLink },\n  { tag: 'test-item-to-speech', ctor: TestItemToSpeech },\n  { tag: 'test-navigation', ctor: TestNavigation },\n  { tag: 'test-next', ctor: TestNext },\n  { tag: 'test-paging-buttons-stamp', ctor: TestPagingButtonsStamp },\n  { tag: 'test-prev', ctor: TestPrev },\n  { tag: 'test-print-context', ctor: TestPrintContext },\n  { tag: 'test-print-item-variables', ctor: TestPrintVariables },\n  { tag: 'test-scoring-buttons', ctor: TestScoringButtons },\n  { tag: 'test-scoring-feedback', ctor: TestScoringFeedback },\n  { tag: 'test-section-buttons-stamp', ctor: TestSectionButtonsStamp },\n  { tag: 'test-section-link', ctor: TestSectionLink },\n  { tag: 'test-stamp', ctor: TestStamp },\n  { tag: 'test-tts-next', ctor: TestTtsNext },\n  { tag: 'test-tts-pause', ctor: TestTtsPause },\n  { tag: 'test-tts-play', ctor: TestTtsPlay },\n  { tag: 'test-tts-prev', ctor: TestTtsPrev },\n  { tag: 'test-tts-resume', ctor: TestTtsResume },\n  { tag: 'test-tts-stop', ctor: TestTtsStop },\n  { tag: 'test-view', ctor: TestView },\n  { tag: 'test-view-toggle', ctor: TestViewToggle }\n]"
+            "text": "[\n  { tag: 'qti-assessment-item-ref', ctor: QtiAssessmentItemRef },\n  { tag: 'qti-assessment-section', ctor: QtiAssessmentSection },\n  { tag: 'qti-assessment-test', ctor: QtiAssessmentTest },\n  { tag: 'qti-item-session-control', ctor: QtiItemSessionControl },\n  { tag: 'qti-outcome-processing', ctor: QtiOutcomeProcessing },\n  { tag: 'qti-test', ctor: QtiTest },\n  { tag: 'qti-test-feedback', ctor: QtiTestFeedback },\n  { tag: 'qti-test-part', ctor: QtiTestPart },\n  { tag: 'qti-test-variables', ctor: QtiTestVariables },\n  { tag: 'test-check-item', ctor: TestCheckItem },\n  { tag: 'test-container', ctor: TestContainer },\n  { tag: 'test-end-attempt', ctor: TestEndAttempt },\n  { tag: 'test-item-link', ctor: TestItemLink },\n  { tag: 'test-item-to-speech', ctor: TestItemToSpeech },\n  { tag: 'test-navigation', ctor: TestNavigation },\n  { tag: 'test-next', ctor: TestNext },\n  { tag: 'test-paging-buttons-stamp', ctor: TestPagingButtonsStamp },\n  { tag: 'test-prev', ctor: TestPrev },\n  { tag: 'test-print-context', ctor: TestPrintContext },\n  { tag: 'test-print-item-variables', ctor: TestPrintVariables },\n  { tag: 'test-scoring-buttons', ctor: TestScoringButtons },\n  { tag: 'test-scoring-feedback', ctor: TestScoringFeedback },\n  { tag: 'test-section-buttons-stamp', ctor: TestSectionButtonsStamp },\n  { tag: 'test-section-link', ctor: TestSectionLink },\n  { tag: 'test-show-feedback', ctor: TestShowFeedback },\n  { tag: 'test-stamp', ctor: TestStamp },\n  { tag: 'test-tts-next', ctor: TestTtsNext },\n  { tag: 'test-tts-pause', ctor: TestTtsPause },\n  { tag: 'test-tts-play', ctor: TestTtsPlay },\n  { tag: 'test-tts-prev', ctor: TestTtsPrev },\n  { tag: 'test-tts-resume', ctor: TestTtsResume },\n  { tag: 'test-tts-stop', ctor: TestTtsStop },\n  { tag: 'test-view', ctor: TestView },\n  { tag: 'test-view-toggle', ctor: TestViewToggle }\n]"
           },
-          "default": "[ { tag: 'qti-assessment-item-ref', ctor: QtiAssessmentItemRef }, { tag: 'qti-assessment-section', ctor: QtiAssessmentSection }, { tag: 'qti-assessment-test', ctor: QtiAssessmentTest }, { tag: 'qti-item-session-control', ctor: QtiItemSessionControl }, { tag: 'qti-outcome-processing', ctor: QtiOutcomeProcessing }, { tag: 'qti-test', ctor: QtiTest }, { tag: 'qti-test-feedback', ctor: QtiTestFeedback }, { tag: 'qti-test-part', ctor: QtiTestPart }, { tag: 'qti-test-variables', ctor: QtiTestVariables }, { tag: 'test-check-item', ctor: TestCheckItem }, { tag: 'test-container', ctor: TestContainer }, { tag: 'test-end-attempt', ctor: TestEndAttempt }, { tag: 'test-item-link', ctor: TestItemLink }, { tag: 'test-item-to-speech', ctor: TestItemToSpeech }, { tag: 'test-navigation', ctor: TestNavigation }, { tag: 'test-next', ctor: TestNext }, { tag: 'test-paging-buttons-stamp', ctor: TestPagingButtonsStamp }, { tag: 'test-prev', ctor: TestPrev }, { tag: 'test-print-context', ctor: TestPrintContext }, { tag: 'test-print-item-variables', ctor: TestPrintVariables }, { tag: 'test-scoring-buttons', ctor: TestScoringButtons }, { tag: 'test-scoring-feedback', ctor: TestScoringFeedback }, { tag: 'test-section-buttons-stamp', ctor: TestSectionButtonsStamp }, { tag: 'test-section-link', ctor: TestSectionLink }, { tag: 'test-stamp', ctor: TestStamp }, { tag: 'test-tts-next', ctor: TestTtsNext }, { tag: 'test-tts-pause', ctor: TestTtsPause }, { tag: 'test-tts-play', ctor: TestTtsPlay }, { tag: 'test-tts-prev', ctor: TestTtsPrev }, { tag: 'test-tts-resume', ctor: TestTtsResume }, { tag: 'test-tts-stop', ctor: TestTtsStop }, { tag: 'test-view', ctor: TestView }, { tag: 'test-view-toggle', ctor: TestViewToggle } ]"
+          "default": "[ { tag: 'qti-assessment-item-ref', ctor: QtiAssessmentItemRef }, { tag: 'qti-assessment-section', ctor: QtiAssessmentSection }, { tag: 'qti-assessment-test', ctor: QtiAssessmentTest }, { tag: 'qti-item-session-control', ctor: QtiItemSessionControl }, { tag: 'qti-outcome-processing', ctor: QtiOutcomeProcessing }, { tag: 'qti-test', ctor: QtiTest }, { tag: 'qti-test-feedback', ctor: QtiTestFeedback }, { tag: 'qti-test-part', ctor: QtiTestPart }, { tag: 'qti-test-variables', ctor: QtiTestVariables }, { tag: 'test-check-item', ctor: TestCheckItem }, { tag: 'test-container', ctor: TestContainer }, { tag: 'test-end-attempt', ctor: TestEndAttempt }, { tag: 'test-item-link', ctor: TestItemLink }, { tag: 'test-item-to-speech', ctor: TestItemToSpeech }, { tag: 'test-navigation', ctor: TestNavigation }, { tag: 'test-next', ctor: TestNext }, { tag: 'test-paging-buttons-stamp', ctor: TestPagingButtonsStamp }, { tag: 'test-prev', ctor: TestPrev }, { tag: 'test-print-context', ctor: TestPrintContext }, { tag: 'test-print-item-variables', ctor: TestPrintVariables }, { tag: 'test-scoring-buttons', ctor: TestScoringButtons }, { tag: 'test-scoring-feedback', ctor: TestScoringFeedback }, { tag: 'test-section-buttons-stamp', ctor: TestSectionButtonsStamp }, { tag: 'test-section-link', ctor: TestSectionLink }, { tag: 'test-show-feedback', ctor: TestShowFeedback }, { tag: 'test-stamp', ctor: TestStamp }, { tag: 'test-tts-next', ctor: TestTtsNext }, { tag: 'test-tts-pause', ctor: TestTtsPause }, { tag: 'test-tts-play', ctor: TestTtsPlay }, { tag: 'test-tts-prev', ctor: TestTtsPrev }, { tag: 'test-tts-resume', ctor: TestTtsResume }, { tag: 'test-tts-stop', ctor: TestTtsStop }, { tag: 'test-view', ctor: TestView }, { tag: 'test-view-toggle', ctor: TestViewToggle } ]"
         }
       ],
       "exports": [
@@ -54049,6 +54347,14 @@
           "name": "TestSectionLink",
           "declaration": {
             "name": "TestSectionLink",
+            "module": "packages/qti-test/src/elements.ts"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "TestShowFeedback",
+          "declaration": {
+            "name": "TestShowFeedback",
             "module": "packages/qti-test/src/elements.ts"
           }
         },

--- a/custom-elements.json
+++ b/custom-elements.json
@@ -16495,7 +16495,7 @@
                 "text": "any[] | NodeListOf<QtiAssociableHotspot>"
               },
               "parsedType": {
-                "text": "any[] | { item: {  }, forEach: {  }, entries: {  }, keys: {  }, values: {  }, __@iterator@515: {  }, length: number }"
+                "text": "any[] | { item: {  }, forEach: {  }, entries: {  }, keys: {  }, values: {  }, __@iterator@517: {  }, length: number }"
               }
             },
             {
@@ -35815,6 +35815,21 @@
             },
             {
               "kind": "method",
+              "name": "#announceCompletionTransitions",
+              "privacy": "private",
+              "return": {
+                "type": {
+                  "text": "void"
+                }
+              },
+              "description": "After computedContext has been rebuilt, fire one-shot transition events the\nfirst time each test-part — and the test as a whole — becomes done.\nCompletion detection belongs here because this element already owns the\nper-item view; `test-processing.mixin` listens and runs outcome processing\nin response, so `atEnd` feedback gets a chance to evaluate.\n\nOne-shot per test: a part that is done stays done, and re-announcing on\nevery context rebuild would re-run outcome processing on every keystroke.",
+              "inheritedFrom": {
+                "name": "TestNavigation",
+                "module": "packages/qti-test/src/components/test-navigation/test-navigation.ts"
+              }
+            },
+            {
+              "kind": "method",
               "name": "#assessmentItemFor",
               "privacy": "private",
               "return": {
@@ -35854,6 +35869,17 @@
                 }
               ],
               "description": "Decide whether an item's submission is as good as it can get — i.e. the\ncandidate reached the *optimal* outcome, so there's no reason to make them\ntry again. 'optimal' means best achievable, 'suboptimal' means a better\nattempt is still possible, 'unscored' means there's nothing to judge against.\n(\"optimal\" is the spec's own word — a qti-correct-response is defined as\n\"the (or an) optimal value\".)\n\nTwo signals, in order of authority:\n 1. The scored outcome: optimal ⟺ SCORE has reached its maximum (MAXSCORE).\n    This correctly handles partial-credit / qti-mapping items, where an exact\n    response match would under- or over-judge.\n 2. The declared qti-correct-response, for items that aren't scored (no\n    SCORE/MAXSCORE) — an exact match is the best available proxy. Bookkeeping\n    variables like numAttempts can be typed 'response' but never declare a\n    correctResponse, so we filter on a declared correctResponse.\n\nItems with neither a comparable score nor a correctResponse (essays, info\nitems, etc.) are 'unscored' — there's no optimal value to require, so one\nattempt is enough.",
+              "inheritedFrom": {
+                "name": "TestNavigation",
+                "module": "packages/qti-test/src/components/test-navigation/test-navigation.ts"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "#endedParts",
+              "privacy": "private",
+              "default": "new Set<string>()",
+              "description": "Test-parts whose end-of-part transition has already been announced.",
               "inheritedFrom": {
                 "name": "TestNavigation",
                 "module": "packages/qti-test/src/components/test-navigation/test-navigation.ts"
@@ -36094,6 +36120,20 @@
             },
             {
               "kind": "field",
+              "name": "#testEnded",
+              "privacy": "private",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "description": "Whether the end-of-test transition has already been announced.",
+              "inheritedFrom": {
+                "name": "TestNavigation",
+                "module": "packages/qti-test/src/components/test-navigation/test-navigation.ts"
+              }
+            },
+            {
+              "kind": "field",
               "name": "activeAssessmentItem",
               "type": {
                 "text": "QtiAssessmentItem | undefined"
@@ -36284,6 +36324,26 @@
           "events": [
             {
               "name": "qti-computed-context-updated",
+              "type": {
+                "text": "CustomEvent"
+              },
+              "inheritedFrom": {
+                "name": "TestNavigation",
+                "module": "packages/qti-test/src/components/test-navigation/test-navigation.ts"
+              }
+            },
+            {
+              "name": "qti-part-completed",
+              "type": {
+                "text": "CustomEvent"
+              },
+              "inheritedFrom": {
+                "name": "TestNavigation",
+                "module": "packages/qti-test/src/components/test-navigation/test-navigation.ts"
+              }
+            },
+            {
+              "name": "qti-test-completed",
               "type": {
                 "text": "CustomEvent"
               },
@@ -49968,6 +50028,12 @@
             },
             {
               "kind": "field",
+              "name": "#handleTestOutcomeChanged",
+              "privacy": "private",
+              "description": "Outcome processing has run, so give every test feedback below this element a\nchance to re-evaluate. The flags travel with the event rather than being\nre-derived here: only the run that concluded a part or the test can satisfy\n`access=\"atEnd\"`, and only feedback scoped to that part should respond."
+            },
+            {
+              "kind": "field",
               "name": "#title",
               "privacy": "private",
               "type": {
@@ -50326,6 +50392,38 @@
               }
             },
             {
+              "kind": "field",
+              "name": "_testContext",
+              "type": {
+                "text": "TestContext | undefined"
+              },
+              "privacy": "private"
+            },
+            {
+              "kind": "method",
+              "name": "#outcomeMatches",
+              "privacy": "private",
+              "return": {
+                "type": {
+                  "text": "boolean"
+                }
+              },
+              "description": "Whether this feedback's test-level outcome currently names its identifier."
+            },
+            {
+              "kind": "field",
+              "name": "#ownPartId",
+              "privacy": "private",
+              "type": {
+                "text": "string | null"
+              },
+              "description": "The test part this feedback belongs to, or null when it is test-root feedback.",
+              "readonly": true,
+              "parsedType": {
+                "text": "string"
+              }
+            },
+            {
               "kind": "method",
               "name": "#sessionControlAllowsFeedback",
               "privacy": "private",
@@ -50358,6 +50456,20 @@
               }
             },
             {
+              "kind": "field",
+              "name": "access",
+              "type": {
+                "text": "TestFeedbackAccess"
+              },
+              "privacy": "public",
+              "default": "'atEnd'",
+              "description": "When the feedback may be presented, per the QTI 3 `access` characteristic.\n\n- `atEnd` — only at the conclusion of the test, or of the test part the\n  feedback sits in.\n- `during` — while the test is still in progress, after each instance of\n  outcome processing.",
+              "attribute": "access",
+              "parsedType": {
+                "text": "'atEnd' | 'during'"
+              }
+            },
+            {
               "kind": "method",
               "name": "checkShowFeedback",
               "privacy": "public",
@@ -50367,14 +50479,27 @@
                   "type": {
                     "text": "string"
                   }
+                },
+                {
+                  "name": "trigger",
+                  "default": "{}",
+                  "type": {
+                    "text": "{ atEnd?: boolean; partId?: string | null }"
+                  }
                 }
               ],
               "inheritedFrom": {
                 "name": "QtiFeedback",
                 "module": "packages/qti-base/src/abstract/qti-feedback.ts"
               },
+              "return": {
+                "type": {
+                  "text": "void"
+                }
+              },
+              "description": "Re-evaluate against the *test* context, rather than the item context the\ninherited implementation reads.\n\n`qti-assessment-test` calls this after each outcome-processing run, passing\nwhat that run concluded. `atEnd` feedback responds only to the run that\nended its own scope — the whole test for test-root feedback, or its own\ntest part for part-scoped feedback — while `during` feedback responds to\nevery run.",
               "type": {
-                "text": "checkShowFeedback(outcomeIdentifier: string) => void"
+                "text": "checkShowFeedback(outcomeIdentifier: string, trigger: { atEnd?: boolean; partId?: string | null } = {}) => void"
               }
             },
             {
@@ -50455,11 +50580,19 @@
               }
             }
           ],
-          "superclass": {
-            "name": "QtiModalFeedback",
-            "package": "@qti-components/elements/elements"
-          },
           "attributes": [
+            {
+              "name": "access",
+              "type": {
+                "text": "TestFeedbackAccess"
+              },
+              "default": "'atEnd'",
+              "description": "When the feedback may be presented, per the QTI 3 `access` characteristic.\n\n- `atEnd` — only at the conclusion of the test, or of the test part the\n  feedback sits in.\n- `during` — while the test is still in progress, after each instance of\n  outcome processing.",
+              "fieldName": "access",
+              "parsedType": {
+                "text": "'atEnd' | 'during'"
+              }
+            },
             {
               "name": "identifier",
               "type": {
@@ -50498,6 +50631,10 @@
               }
             }
           ],
+          "superclass": {
+            "name": "QtiModalFeedback",
+            "package": "@qti-components/elements/elements"
+          },
           "events": [
             {
               "name": "qti-register-feedback",
@@ -52142,6 +52279,17 @@
             },
             {
               "kind": "method",
+              "name": "#announceCompletionTransitions",
+              "privacy": "private",
+              "return": {
+                "type": {
+                  "text": "void"
+                }
+              },
+              "description": "After computedContext has been rebuilt, fire one-shot transition events the\nfirst time each test-part — and the test as a whole — becomes done.\nCompletion detection belongs here because this element already owns the\nper-item view; `test-processing.mixin` listens and runs outcome processing\nin response, so `atEnd` feedback gets a chance to evaluate.\n\nOne-shot per test: a part that is done stays done, and re-announcing on\nevery context rebuild would re-run outcome processing on every keystroke."
+            },
+            {
+              "kind": "method",
               "name": "#assessmentItemFor",
               "privacy": "private",
               "return": {
@@ -52177,6 +52325,13 @@
                 }
               ],
               "description": "Decide whether an item's submission is as good as it can get — i.e. the\ncandidate reached the *optimal* outcome, so there's no reason to make them\ntry again. 'optimal' means best achievable, 'suboptimal' means a better\nattempt is still possible, 'unscored' means there's nothing to judge against.\n(\"optimal\" is the spec's own word — a qti-correct-response is defined as\n\"the (or an) optimal value\".)\n\nTwo signals, in order of authority:\n 1. The scored outcome: optimal ⟺ SCORE has reached its maximum (MAXSCORE).\n    This correctly handles partial-credit / qti-mapping items, where an exact\n    response match would under- or over-judge.\n 2. The declared qti-correct-response, for items that aren't scored (no\n    SCORE/MAXSCORE) — an exact match is the best available proxy. Bookkeeping\n    variables like numAttempts can be typed 'response' but never declare a\n    correctResponse, so we filter on a declared correctResponse.\n\nItems with neither a comparable score nor a correctResponse (essays, info\nitems, etc.) are 'unscored' — there's no optimal value to require, so one\nattempt is enough."
+            },
+            {
+              "kind": "field",
+              "name": "#endedParts",
+              "privacy": "private",
+              "default": "new Set<string>()",
+              "description": "Test-parts whose end-of-part transition has already been announced."
             },
             {
               "kind": "method",
@@ -52357,6 +52512,16 @@
             },
             {
               "kind": "field",
+              "name": "#testEnded",
+              "privacy": "private",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "description": "Whether the end-of-test transition has already been announced."
+            },
+            {
+              "kind": "field",
               "name": "activeAssessmentItem",
               "type": {
                 "text": "QtiAssessmentItem | undefined"
@@ -52478,6 +52643,18 @@
           "events": [
             {
               "name": "qti-computed-context-updated",
+              "type": {
+                "text": "CustomEvent"
+              }
+            },
+            {
+              "name": "qti-part-completed",
+              "type": {
+                "text": "CustomEvent"
+              }
+            },
+            {
+              "name": "qti-test-completed",
               "type": {
                 "text": "CustomEvent"
               }

--- a/packages/qti-base/src/context/session.context.ts
+++ b/packages/qti-base/src/context/session.context.ts
@@ -6,6 +6,8 @@ export interface SessionContext {
   navPartId?: string | null;
   navSectionId?: string | null;
   navItemRefId?: string | null;
+  /** Identifier of the atEnd qti-test-feedback currently on screen, or null/absent otherwise. */
+  navFeedbackIdentifier?: string | null;
   navItemLoading?: boolean;
   navTestLoading?: boolean;
   view?: View;

--- a/packages/qti-base/src/context/types/computed.types.ts
+++ b/packages/qti-base/src/context/types/computed.types.ts
@@ -18,10 +18,19 @@ export type ComputedItem = ComputedItemContext & {
   optimal?: boolean;
 };
 
+/** A qti-test-feedback that has become available to view (its atEnd outcome matched). */
+export type AvailableFeedback = {
+  identifier: string;
+  /** Identifier of the enclosing qti-test-part, or null for test-root feedback. */
+  partId: string | null;
+};
+
 export type ComputedContext = {
   view: View;
   identifier: string;
   title: string;
+  /** atEnd feedbacks that are ready to show, surfaced for test-show-feedback. */
+  availableFeedbacks?: AvailableFeedback[];
   testParts: {
     active?: boolean;
     identifier: string;

--- a/packages/qti-components/custom-elements.json
+++ b/packages/qti-components/custom-elements.json
@@ -16495,7 +16495,7 @@
                 "text": "any[] | NodeListOf<QtiAssociableHotspot>"
               },
               "parsedType": {
-                "text": "any[] | { item: {  }, forEach: {  }, entries: {  }, keys: {  }, values: {  }, __@iterator@515: {  }, length: number }"
+                "text": "any[] | { item: {  }, forEach: {  }, entries: {  }, keys: {  }, values: {  }, __@iterator@519: {  }, length: number }"
               }
             },
             {
@@ -32705,7 +32705,7 @@
               },
               "privacy": "private",
               "parsedType": {
-                "text": "{ view: '' | 'author' | 'candidate' | 'proctor' | 'scorer' | 'testConstructor' | 'tutor', identifier: string, title: string, testParts: { active: boolean, identifier: string, navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean, sections: { active: boolean, identifier: string, title: string, completed: boolean, items: { identifier: string, href: string, correct: boolean, incorrect: boolean, completed: boolean, adaptive: boolean, timeDependent: boolean, title: string, label: string, score: number, maxScore: number, completionStatus: string, variables: ReadonlyArray } & { categories: Array, type: type | type, index: number, active: boolean, allowSkipping: boolean, maxAttempts: number, showFeedback: boolean, showSolution: boolean, numAttempts: number, valid: boolean, isDefaultResponse: boolean, done: boolean, optimal: boolean }[], navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean }[] }[] }"
+                "text": "{ view: '' | 'author' | 'candidate' | 'proctor' | 'scorer' | 'testConstructor' | 'tutor', identifier: string, title: string, availableFeedbacks: { identifier: string, partId: string }[], testParts: { active: boolean, identifier: string, navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean, sections: { active: boolean, identifier: string, title: string, completed: boolean, items: { identifier: string, href: string, correct: boolean, incorrect: boolean, completed: boolean, adaptive: boolean, timeDependent: boolean, title: string, label: string, score: number, maxScore: number, completionStatus: string, variables: ReadonlyArray } & { categories: Array, type: type | type, index: number, active: boolean, allowSkipping: boolean, maxAttempts: number, showFeedback: boolean, showSolution: boolean, numAttempts: number, valid: boolean, isDefaultResponse: boolean, done: boolean, optimal: boolean }[], navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean }[] }[] }"
               }
             },
             {
@@ -35815,6 +35815,21 @@
             },
             {
               "kind": "method",
+              "name": "#announceCompletionTransitions",
+              "privacy": "private",
+              "return": {
+                "type": {
+                  "text": "void"
+                }
+              },
+              "description": "After computedContext has been rebuilt, fire one-shot transition events the\nfirst time each test-part — and the test as a whole — becomes done.\nCompletion detection belongs here because this element already owns the\nper-item view; `test-processing.mixin` listens and runs outcome processing\nin response, so `atEnd` feedback gets a chance to evaluate.\n\nOne-shot per test: a part that is done stays done, and re-announcing on\nevery context rebuild would re-run outcome processing on every keystroke.",
+              "inheritedFrom": {
+                "name": "TestNavigation",
+                "module": "packages/qti-test/src/components/test-navigation/test-navigation.ts"
+              }
+            },
+            {
+              "kind": "method",
               "name": "#assessmentItemFor",
               "privacy": "private",
               "return": {
@@ -35860,6 +35875,42 @@
               }
             },
             {
+              "kind": "field",
+              "name": "#availableFeedbacks",
+              "privacy": "private",
+              "default": "new Map<string, string | null>()",
+              "description": "atEnd feedbacks that have announced themselves available, keyed by identifier → partId.",
+              "inheritedFrom": {
+                "name": "TestNavigation",
+                "module": "packages/qti-test/src/components/test-navigation/test-navigation.ts"
+              }
+            },
+            {
+              "kind": "method",
+              "name": "#availableFeedbacksList",
+              "privacy": "private",
+              "return": {
+                "type": {
+                  "text": "AvailableFeedback[]"
+                }
+              },
+              "inheritedFrom": {
+                "name": "TestNavigation",
+                "module": "packages/qti-test/src/components/test-navigation/test-navigation.ts"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "#endedParts",
+              "privacy": "private",
+              "default": "new Set<string>()",
+              "description": "Test-parts whose end-of-part transition has already been announced.",
+              "inheritedFrom": {
+                "name": "TestNavigation",
+                "module": "packages/qti-test/src/components/test-navigation/test-navigation.ts"
+              }
+            },
+            {
               "kind": "method",
               "name": "#extractDefaultValues",
               "privacy": "private",
@@ -35877,6 +35928,29 @@
                 }
               ],
               "description": "Extract default values from a qti-context-declaration element",
+              "inheritedFrom": {
+                "name": "TestNavigation",
+                "module": "packages/qti-test/src/components/test-navigation/test-navigation.ts"
+              }
+            },
+            {
+              "kind": "method",
+              "name": "#handleFeedbackAvailabilityChanged",
+              "privacy": "private",
+              "return": {
+                "type": {
+                  "text": "void"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "event",
+                  "type": {
+                    "text": "QtiTestFeedbackAvailabilityChangedEvent"
+                  }
+                }
+              ],
+              "description": "Record (or clear) an atEnd feedback's availability and rebuild the computed\ncontext so test-show-feedback can react. Owned here because test-navigation\nalready provides computedContext to the navigation buttons.",
               "inheritedFrom": {
                 "name": "TestNavigation",
                 "module": "packages/qti-test/src/components/test-navigation/test-navigation.ts"
@@ -36094,6 +36168,20 @@
             },
             {
               "kind": "field",
+              "name": "#testEnded",
+              "privacy": "private",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "description": "Whether the end-of-test transition has already been announced.",
+              "inheritedFrom": {
+                "name": "TestNavigation",
+                "module": "packages/qti-test/src/components/test-navigation/test-navigation.ts"
+              }
+            },
+            {
+              "kind": "field",
               "name": "activeAssessmentItem",
               "type": {
                 "text": "QtiAssessmentItem | undefined"
@@ -36162,7 +36250,7 @@
               },
               "privacy": "protected",
               "parsedType": {
-                "text": "{ view: '' | 'author' | 'candidate' | 'proctor' | 'scorer' | 'testConstructor' | 'tutor', identifier: string, title: string, testParts: { active: boolean, identifier: string, navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean, sections: { active: boolean, identifier: string, title: string, completed: boolean, items: { identifier: string, href: string, correct: boolean, incorrect: boolean, completed: boolean, adaptive: boolean, timeDependent: boolean, title: string, label: string, score: number, maxScore: number, completionStatus: string, variables: ReadonlyArray } & { categories: Array, type: type | type, index: number, active: boolean, allowSkipping: boolean, maxAttempts: number, showFeedback: boolean, showSolution: boolean, numAttempts: number, valid: boolean, isDefaultResponse: boolean, done: boolean, optimal: boolean }[], navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean }[] }[] }"
+                "text": "{ view: '' | 'author' | 'candidate' | 'proctor' | 'scorer' | 'testConstructor' | 'tutor', identifier: string, title: string, availableFeedbacks: { identifier: string, partId: string }[], testParts: { active: boolean, identifier: string, navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean, sections: { active: boolean, identifier: string, title: string, completed: boolean, items: { identifier: string, href: string, correct: boolean, incorrect: boolean, completed: boolean, adaptive: boolean, timeDependent: boolean, title: string, label: string, score: number, maxScore: number, completionStatus: string, variables: ReadonlyArray } & { categories: Array, type: type | type, index: number, active: boolean, allowSkipping: boolean, maxAttempts: number, showFeedback: boolean, showSolution: boolean, numAttempts: number, valid: boolean, isDefaultResponse: boolean, done: boolean, optimal: boolean }[], navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean }[] }[] }"
               },
               "inheritedFrom": {
                 "name": "TestNavigation",
@@ -36291,6 +36379,26 @@
                 "name": "TestNavigation",
                 "module": "packages/qti-test/src/components/test-navigation/test-navigation.ts"
               }
+            },
+            {
+              "name": "qti-part-completed",
+              "type": {
+                "text": "CustomEvent"
+              },
+              "inheritedFrom": {
+                "name": "TestNavigation",
+                "module": "packages/qti-test/src/components/test-navigation/test-navigation.ts"
+              }
+            },
+            {
+              "name": "qti-test-completed",
+              "type": {
+                "text": "CustomEvent"
+              },
+              "inheritedFrom": {
+                "name": "TestNavigation",
+                "module": "packages/qti-test/src/components/test-navigation/test-navigation.ts"
+              }
             }
           ],
           "tagName": "test-navigation",
@@ -36393,7 +36501,7 @@
               },
               "privacy": "public",
               "parsedType": {
-                "text": "{ view: '' | 'author' | 'candidate' | 'proctor' | 'scorer' | 'testConstructor' | 'tutor', identifier: string, title: string, testParts: { active: boolean, identifier: string, navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean, sections: { active: boolean, identifier: string, title: string, completed: boolean, items: { identifier: string, href: string, correct: boolean, incorrect: boolean, completed: boolean, adaptive: boolean, timeDependent: boolean, title: string, label: string, score: number, maxScore: number, completionStatus: string, variables: ReadonlyArray } & { categories: Array, type: type | type, index: number, active: boolean, allowSkipping: boolean, maxAttempts: number, showFeedback: boolean, showSolution: boolean, numAttempts: number, valid: boolean, isDefaultResponse: boolean, done: boolean, optimal: boolean }[], navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean }[] }[] }"
+                "text": "{ view: '' | 'author' | 'candidate' | 'proctor' | 'scorer' | 'testConstructor' | 'tutor', identifier: string, title: string, availableFeedbacks: { identifier: string, partId: string }[], testParts: { active: boolean, identifier: string, navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean, sections: { active: boolean, identifier: string, title: string, completed: boolean, items: { identifier: string, href: string, correct: boolean, incorrect: boolean, completed: boolean, adaptive: boolean, timeDependent: boolean, title: string, label: string, score: number, maxScore: number, completionStatus: string, variables: ReadonlyArray } & { categories: Array, type: type | type, index: number, active: boolean, allowSkipping: boolean, maxAttempts: number, showFeedback: boolean, showSolution: boolean, numAttempts: number, valid: boolean, isDefaultResponse: boolean, done: boolean, optimal: boolean }[], navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean }[] }[] }"
               }
             },
             {
@@ -37570,7 +37678,7 @@
               },
               "privacy": "private",
               "parsedType": {
-                "text": "{ view: '' | 'author' | 'candidate' | 'proctor' | 'scorer' | 'testConstructor' | 'tutor', identifier: string, title: string, testParts: { active: boolean, identifier: string, navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean, sections: { active: boolean, identifier: string, title: string, completed: boolean, items: { identifier: string, href: string, correct: boolean, incorrect: boolean, completed: boolean, adaptive: boolean, timeDependent: boolean, title: string, label: string, score: number, maxScore: number, completionStatus: string, variables: ReadonlyArray } & { categories: Array, type: type | type, index: number, active: boolean, allowSkipping: boolean, maxAttempts: number, showFeedback: boolean, showSolution: boolean, numAttempts: number, valid: boolean, isDefaultResponse: boolean, done: boolean, optimal: boolean }[], navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean }[] }[] }"
+                "text": "{ view: '' | 'author' | 'candidate' | 'proctor' | 'scorer' | 'testConstructor' | 'tutor', identifier: string, title: string, availableFeedbacks: { identifier: string, partId: string }[], testParts: { active: boolean, identifier: string, navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean, sections: { active: boolean, identifier: string, title: string, completed: boolean, items: { identifier: string, href: string, correct: boolean, incorrect: boolean, completed: boolean, adaptive: boolean, timeDependent: boolean, title: string, label: string, score: number, maxScore: number, completionStatus: string, variables: ReadonlyArray } & { categories: Array, type: type | type, index: number, active: boolean, allowSkipping: boolean, maxAttempts: number, showFeedback: boolean, showSolution: boolean, numAttempts: number, valid: boolean, isDefaultResponse: boolean, done: boolean, optimal: boolean }[], navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean }[] }[] }"
               },
               "inheritedFrom": {
                 "name": "QtiFeedback",
@@ -37794,7 +37902,7 @@
               },
               "privacy": "private",
               "parsedType": {
-                "text": "{ view: '' | 'author' | 'candidate' | 'proctor' | 'scorer' | 'testConstructor' | 'tutor', identifier: string, title: string, testParts: { active: boolean, identifier: string, navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean, sections: { active: boolean, identifier: string, title: string, completed: boolean, items: { identifier: string, href: string, correct: boolean, incorrect: boolean, completed: boolean, adaptive: boolean, timeDependent: boolean, title: string, label: string, score: number, maxScore: number, completionStatus: string, variables: ReadonlyArray } & { categories: Array, type: type | type, index: number, active: boolean, allowSkipping: boolean, maxAttempts: number, showFeedback: boolean, showSolution: boolean, numAttempts: number, valid: boolean, isDefaultResponse: boolean, done: boolean, optimal: boolean }[], navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean }[] }[] }"
+                "text": "{ view: '' | 'author' | 'candidate' | 'proctor' | 'scorer' | 'testConstructor' | 'tutor', identifier: string, title: string, availableFeedbacks: { identifier: string, partId: string }[], testParts: { active: boolean, identifier: string, navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean, sections: { active: boolean, identifier: string, title: string, completed: boolean, items: { identifier: string, href: string, correct: boolean, incorrect: boolean, completed: boolean, adaptive: boolean, timeDependent: boolean, title: string, label: string, score: number, maxScore: number, completionStatus: string, variables: ReadonlyArray } & { categories: Array, type: type | type, index: number, active: boolean, allowSkipping: boolean, maxAttempts: number, showFeedback: boolean, showSolution: boolean, numAttempts: number, valid: boolean, isDefaultResponse: boolean, done: boolean, optimal: boolean }[], navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean }[] }[] }"
               },
               "inheritedFrom": {
                 "name": "QtiFeedback",
@@ -38072,7 +38180,7 @@
               },
               "privacy": "private",
               "parsedType": {
-                "text": "{ view: '' | 'author' | 'candidate' | 'proctor' | 'scorer' | 'testConstructor' | 'tutor', identifier: string, title: string, testParts: { active: boolean, identifier: string, navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean, sections: { active: boolean, identifier: string, title: string, completed: boolean, items: { identifier: string, href: string, correct: boolean, incorrect: boolean, completed: boolean, adaptive: boolean, timeDependent: boolean, title: string, label: string, score: number, maxScore: number, completionStatus: string, variables: ReadonlyArray } & { categories: Array, type: type | type, index: number, active: boolean, allowSkipping: boolean, maxAttempts: number, showFeedback: boolean, showSolution: boolean, numAttempts: number, valid: boolean, isDefaultResponse: boolean, done: boolean, optimal: boolean }[], navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean }[] }[] }"
+                "text": "{ view: '' | 'author' | 'candidate' | 'proctor' | 'scorer' | 'testConstructor' | 'tutor', identifier: string, title: string, availableFeedbacks: { identifier: string, partId: string }[], testParts: { active: boolean, identifier: string, navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean, sections: { active: boolean, identifier: string, title: string, completed: boolean, items: { identifier: string, href: string, correct: boolean, incorrect: boolean, completed: boolean, adaptive: boolean, timeDependent: boolean, title: string, label: string, score: number, maxScore: number, completionStatus: string, variables: ReadonlyArray } & { categories: Array, type: type | type, index: number, active: boolean, allowSkipping: boolean, maxAttempts: number, showFeedback: boolean, showSolution: boolean, numAttempts: number, valid: boolean, isDefaultResponse: boolean, done: boolean, optimal: boolean }[], navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean }[] }[] }"
               },
               "inheritedFrom": {
                 "name": "QtiFeedback",
@@ -49458,6 +49566,14 @@
           "name": "*",
           "declaration": {
             "name": "*",
+            "module": "packages/qti-test/src/components/test-show-feedback/test-show-feedback"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "*",
+          "declaration": {
+            "name": "*",
             "module": "packages/qti-test/src/components/test-view-toggle/test-view"
           }
         },
@@ -49968,6 +50084,12 @@
             },
             {
               "kind": "field",
+              "name": "#handleTestOutcomeChanged",
+              "privacy": "private",
+              "description": "Outcome processing has run, so give every test feedback below this element a\nchance to re-evaluate. The flags travel with the event rather than being\nre-derived here: only the run that concluded a part or the test can satisfy\n`access=\"atEnd\"`, and only feedback scoped to that part should respond."
+            },
+            {
+              "kind": "field",
               "name": "#title",
               "privacy": "private",
               "type": {
@@ -50300,13 +50422,23 @@
           "members": [
             {
               "kind": "field",
+              "name": "_available",
+              "type": {
+                "text": "boolean"
+              },
+              "privacy": "private",
+              "default": "false",
+              "description": "For `access=\"atEnd\"`: whether the feedback's outcome has matched and it is\nready to be shown. While available, the feedback stays hidden until a\ntest-show-feedback button navigates the candidate to it\n(`_sessionContext.navFeedbackIdentifier`). `during` feedback ignores this\nflag and shows the instant its outcome matches."
+            },
+            {
+              "kind": "field",
               "name": "_computedContext",
               "type": {
                 "text": "ComputedContext | undefined"
               },
               "privacy": "private",
               "parsedType": {
-                "text": "{ view: '' | 'author' | 'candidate' | 'proctor' | 'scorer' | 'testConstructor' | 'tutor', identifier: string, title: string, testParts: { active: boolean, identifier: string, navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean, sections: { active: boolean, identifier: string, title: string, completed: boolean, items: { identifier: string, href: string, correct: boolean, incorrect: boolean, completed: boolean, adaptive: boolean, timeDependent: boolean, title: string, label: string, score: number, maxScore: number, completionStatus: string, variables: ReadonlyArray } & { categories: Array, type: type | type, index: number, active: boolean, allowSkipping: boolean, maxAttempts: number, showFeedback: boolean, showSolution: boolean, numAttempts: number, valid: boolean, isDefaultResponse: boolean, done: boolean, optimal: boolean }[], navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean }[] }[] }"
+                "text": "{ view: '' | 'author' | 'candidate' | 'proctor' | 'scorer' | 'testConstructor' | 'tutor', identifier: string, title: string, availableFeedbacks: { identifier: string, partId: string }[], testParts: { active: boolean, identifier: string, navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean, sections: { active: boolean, identifier: string, title: string, completed: boolean, items: { identifier: string, href: string, correct: boolean, incorrect: boolean, completed: boolean, adaptive: boolean, timeDependent: boolean, title: string, label: string, score: number, maxScore: number, completionStatus: string, variables: ReadonlyArray } & { categories: Array, type: type | type, index: number, active: boolean, allowSkipping: boolean, maxAttempts: number, showFeedback: boolean, showSolution: boolean, numAttempts: number, valid: boolean, isDefaultResponse: boolean, done: boolean, optimal: boolean }[], navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean }[] }[] }"
               },
               "inheritedFrom": {
                 "name": "QtiFeedback",
@@ -50326,6 +50458,46 @@
               }
             },
             {
+              "kind": "field",
+              "name": "_sessionContext",
+              "type": {
+                "text": "SessionContext | undefined"
+              },
+              "privacy": "private"
+            },
+            {
+              "kind": "field",
+              "name": "_testContext",
+              "type": {
+                "text": "TestContext | undefined"
+              },
+              "privacy": "private"
+            },
+            {
+              "kind": "method",
+              "name": "#outcomeMatches",
+              "privacy": "private",
+              "return": {
+                "type": {
+                  "text": "boolean"
+                }
+              },
+              "description": "Whether this feedback's test-level outcome currently names its identifier."
+            },
+            {
+              "kind": "field",
+              "name": "#ownPartId",
+              "privacy": "private",
+              "type": {
+                "text": "string | null"
+              },
+              "description": "The test part this feedback belongs to, or null when it is test-root feedback.",
+              "readonly": true,
+              "parsedType": {
+                "text": "string"
+              }
+            },
+            {
               "kind": "method",
               "name": "#sessionControlAllowsFeedback",
               "privacy": "private",
@@ -50339,6 +50511,25 @@
                 "name": "QtiFeedback",
                 "module": "packages/qti-base/src/abstract/qti-feedback.ts"
               }
+            },
+            {
+              "kind": "method",
+              "name": "#setAvailable",
+              "privacy": "private",
+              "return": {
+                "type": {
+                  "text": "void"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "available",
+                  "type": {
+                    "text": "boolean"
+                  }
+                }
+              ],
+              "description": "Update availability and announce the change so test-show-feedback can enable."
             },
             {
               "kind": "method",
@@ -50358,6 +50549,20 @@
               }
             },
             {
+              "kind": "field",
+              "name": "access",
+              "type": {
+                "text": "TestFeedbackAccess"
+              },
+              "privacy": "public",
+              "default": "'atEnd'",
+              "description": "When the feedback may be presented, per the QTI 3 `access` characteristic.\n\n- `atEnd` — only at the conclusion of the test, or of the test part the\n  feedback sits in. Becoming available only unlocks a test-show-feedback\n  button — the feedback itself stays hidden until the candidate navigates\n  to it.\n- `during` — while the test is still in progress, after each instance of\n  outcome processing. Shows the instant its outcome matches.",
+              "attribute": "access",
+              "parsedType": {
+                "text": "'atEnd' | 'during'"
+              }
+            },
+            {
               "kind": "method",
               "name": "checkShowFeedback",
               "privacy": "public",
@@ -50367,14 +50572,27 @@
                   "type": {
                     "text": "string"
                   }
+                },
+                {
+                  "name": "trigger",
+                  "default": "{}",
+                  "type": {
+                    "text": "{ atEnd?: boolean; partId?: string | null }"
+                  }
                 }
               ],
               "inheritedFrom": {
                 "name": "QtiFeedback",
                 "module": "packages/qti-base/src/abstract/qti-feedback.ts"
               },
+              "return": {
+                "type": {
+                  "text": "void"
+                }
+              },
+              "description": "Re-evaluate against the *test* context, rather than the item context the\ninherited implementation reads.\n\n`qti-assessment-test` calls this after each outcome-processing run, passing\nwhat that run concluded. `atEnd` feedback responds only to the run that\nended its own scope — the whole test for test-root feedback, or its own\ntest part for part-scoped feedback — while `during` feedback responds to\nevery run.",
               "type": {
-                "text": "checkShowFeedback(outcomeIdentifier: string) => void"
+                "text": "checkShowFeedback(outcomeIdentifier: string, trigger: { atEnd?: boolean; partId?: string | null } = {}) => void"
               }
             },
             {
@@ -50455,11 +50673,37 @@
               }
             }
           ],
-          "superclass": {
-            "name": "QtiModalFeedback",
-            "package": "@qti-components/elements/elements"
-          },
+          "events": [
+            {
+              "name": "qti-register-feedback",
+              "type": {
+                "text": "CustomEvent"
+              },
+              "inheritedFrom": {
+                "name": "QtiFeedback",
+                "module": "packages/qti-base/src/abstract/qti-feedback.ts"
+              }
+            },
+            {
+              "name": "qti-test-feedback-availability-changed",
+              "type": {
+                "text": "CustomEvent"
+              }
+            }
+          ],
           "attributes": [
+            {
+              "name": "access",
+              "type": {
+                "text": "TestFeedbackAccess"
+              },
+              "default": "'atEnd'",
+              "description": "When the feedback may be presented, per the QTI 3 `access` characteristic.\n\n- `atEnd` — only at the conclusion of the test, or of the test part the\n  feedback sits in. Becoming available only unlocks a test-show-feedback\n  button — the feedback itself stays hidden until the candidate navigates\n  to it.\n- `during` — while the test is still in progress, after each instance of\n  outcome processing. Shows the instant its outcome matches.",
+              "fieldName": "access",
+              "parsedType": {
+                "text": "'atEnd' | 'during'"
+              }
+            },
             {
               "name": "identifier",
               "type": {
@@ -50498,18 +50742,10 @@
               }
             }
           ],
-          "events": [
-            {
-              "name": "qti-register-feedback",
-              "type": {
-                "text": "CustomEvent"
-              },
-              "inheritedFrom": {
-                "name": "QtiFeedback",
-                "module": "packages/qti-base/src/abstract/qti-feedback.ts"
-              }
-            }
-          ],
+          "superclass": {
+            "name": "QtiModalFeedback",
+            "package": "@qti-components/elements/elements"
+          },
           "tagName": "qti-test-feedback",
           "customElement": true,
           "modulePath": "packages/qti-test/src/components/qti-test-feedback/qti-test-feedback.ts",
@@ -51233,7 +51469,7 @@
               },
               "privacy": "protected",
               "parsedType": {
-                "text": "{ view: '' | 'author' | 'candidate' | 'proctor' | 'scorer' | 'testConstructor' | 'tutor', identifier: string, title: string, testParts: { active: boolean, identifier: string, navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean, sections: { active: boolean, identifier: string, title: string, completed: boolean, items: { identifier: string, href: string, correct: boolean, incorrect: boolean, completed: boolean, adaptive: boolean, timeDependent: boolean, title: string, label: string, score: number, maxScore: number, completionStatus: string, variables: ReadonlyArray } & { categories: Array, type: type | type, index: number, active: boolean, allowSkipping: boolean, maxAttempts: number, showFeedback: boolean, showSolution: boolean, numAttempts: number, valid: boolean, isDefaultResponse: boolean, done: boolean, optimal: boolean }[], navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean }[] }[] }"
+                "text": "{ view: '' | 'author' | 'candidate' | 'proctor' | 'scorer' | 'testConstructor' | 'tutor', identifier: string, title: string, availableFeedbacks: { identifier: string, partId: string }[], testParts: { active: boolean, identifier: string, navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean, sections: { active: boolean, identifier: string, title: string, completed: boolean, items: { identifier: string, href: string, correct: boolean, incorrect: boolean, completed: boolean, adaptive: boolean, timeDependent: boolean, title: string, label: string, score: number, maxScore: number, completionStatus: string, variables: ReadonlyArray } & { categories: Array, type: type | type, index: number, active: boolean, allowSkipping: boolean, maxAttempts: number, showFeedback: boolean, showSolution: boolean, numAttempts: number, valid: boolean, isDefaultResponse: boolean, done: boolean, optimal: boolean }[], navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean }[] }[] }"
               }
             }
           ],
@@ -52142,6 +52378,17 @@
             },
             {
               "kind": "method",
+              "name": "#announceCompletionTransitions",
+              "privacy": "private",
+              "return": {
+                "type": {
+                  "text": "void"
+                }
+              },
+              "description": "After computedContext has been rebuilt, fire one-shot transition events the\nfirst time each test-part — and the test as a whole — becomes done.\nCompletion detection belongs here because this element already owns the\nper-item view; `test-processing.mixin` listens and runs outcome processing\nin response, so `atEnd` feedback gets a chance to evaluate.\n\nOne-shot per test: a part that is done stays done, and re-announcing on\nevery context rebuild would re-run outcome processing on every keystroke."
+            },
+            {
+              "kind": "method",
               "name": "#assessmentItemFor",
               "privacy": "private",
               "return": {
@@ -52179,6 +52426,30 @@
               "description": "Decide whether an item's submission is as good as it can get — i.e. the\ncandidate reached the *optimal* outcome, so there's no reason to make them\ntry again. 'optimal' means best achievable, 'suboptimal' means a better\nattempt is still possible, 'unscored' means there's nothing to judge against.\n(\"optimal\" is the spec's own word — a qti-correct-response is defined as\n\"the (or an) optimal value\".)\n\nTwo signals, in order of authority:\n 1. The scored outcome: optimal ⟺ SCORE has reached its maximum (MAXSCORE).\n    This correctly handles partial-credit / qti-mapping items, where an exact\n    response match would under- or over-judge.\n 2. The declared qti-correct-response, for items that aren't scored (no\n    SCORE/MAXSCORE) — an exact match is the best available proxy. Bookkeeping\n    variables like numAttempts can be typed 'response' but never declare a\n    correctResponse, so we filter on a declared correctResponse.\n\nItems with neither a comparable score nor a correctResponse (essays, info\nitems, etc.) are 'unscored' — there's no optimal value to require, so one\nattempt is enough."
             },
             {
+              "kind": "field",
+              "name": "#availableFeedbacks",
+              "privacy": "private",
+              "default": "new Map<string, string | null>()",
+              "description": "atEnd feedbacks that have announced themselves available, keyed by identifier → partId."
+            },
+            {
+              "kind": "method",
+              "name": "#availableFeedbacksList",
+              "privacy": "private",
+              "return": {
+                "type": {
+                  "text": "AvailableFeedback[]"
+                }
+              }
+            },
+            {
+              "kind": "field",
+              "name": "#endedParts",
+              "privacy": "private",
+              "default": "new Set<string>()",
+              "description": "Test-parts whose end-of-part transition has already been announced."
+            },
+            {
               "kind": "method",
               "name": "#extractDefaultValues",
               "privacy": "private",
@@ -52196,6 +52467,25 @@
                 }
               ],
               "description": "Extract default values from a qti-context-declaration element"
+            },
+            {
+              "kind": "method",
+              "name": "#handleFeedbackAvailabilityChanged",
+              "privacy": "private",
+              "return": {
+                "type": {
+                  "text": "void"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "event",
+                  "type": {
+                    "text": "QtiTestFeedbackAvailabilityChangedEvent"
+                  }
+                }
+              ],
+              "description": "Record (or clear) an atEnd feedback's availability and rebuild the computed\ncontext so test-show-feedback can react. Owned here because test-navigation\nalready provides computedContext to the navigation buttons."
             },
             {
               "kind": "method",
@@ -52357,6 +52647,16 @@
             },
             {
               "kind": "field",
+              "name": "#testEnded",
+              "privacy": "private",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "description": "Whether the end-of-test transition has already been announced."
+            },
+            {
+              "kind": "field",
               "name": "activeAssessmentItem",
               "type": {
                 "text": "QtiAssessmentItem | undefined"
@@ -52413,7 +52713,7 @@
               },
               "privacy": "protected",
               "parsedType": {
-                "text": "{ view: '' | 'author' | 'candidate' | 'proctor' | 'scorer' | 'testConstructor' | 'tutor', identifier: string, title: string, testParts: { active: boolean, identifier: string, navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean, sections: { active: boolean, identifier: string, title: string, completed: boolean, items: { identifier: string, href: string, correct: boolean, incorrect: boolean, completed: boolean, adaptive: boolean, timeDependent: boolean, title: string, label: string, score: number, maxScore: number, completionStatus: string, variables: ReadonlyArray } & { categories: Array, type: type | type, index: number, active: boolean, allowSkipping: boolean, maxAttempts: number, showFeedback: boolean, showSolution: boolean, numAttempts: number, valid: boolean, isDefaultResponse: boolean, done: boolean, optimal: boolean }[], navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean }[] }[] }"
+                "text": "{ view: '' | 'author' | 'candidate' | 'proctor' | 'scorer' | 'testConstructor' | 'tutor', identifier: string, title: string, availableFeedbacks: { identifier: string, partId: string }[], testParts: { active: boolean, identifier: string, navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean, sections: { active: boolean, identifier: string, title: string, completed: boolean, items: { identifier: string, href: string, correct: boolean, incorrect: boolean, completed: boolean, adaptive: boolean, timeDependent: boolean, title: string, label: string, score: number, maxScore: number, completionStatus: string, variables: ReadonlyArray } & { categories: Array, type: type | type, index: number, active: boolean, allowSkipping: boolean, maxAttempts: number, showFeedback: boolean, showSolution: boolean, numAttempts: number, valid: boolean, isDefaultResponse: boolean, done: boolean, optimal: boolean }[], navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean }[] }[] }"
               }
             },
             {
@@ -52478,6 +52778,18 @@
           "events": [
             {
               "name": "qti-computed-context-updated",
+              "type": {
+                "text": "CustomEvent"
+              }
+            },
+            {
+              "name": "qti-part-completed",
+              "type": {
+                "text": "CustomEvent"
+              }
+            },
+            {
+              "name": "qti-test-completed",
               "type": {
                 "text": "CustomEvent"
               }
@@ -52623,7 +52935,7 @@
               },
               "privacy": "protected",
               "parsedType": {
-                "text": "{ view: '' | 'author' | 'candidate' | 'proctor' | 'scorer' | 'testConstructor' | 'tutor', identifier: string, title: string, testParts: { active: boolean, identifier: string, navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean, sections: { active: boolean, identifier: string, title: string, completed: boolean, items: { identifier: string, href: string, correct: boolean, incorrect: boolean, completed: boolean, adaptive: boolean, timeDependent: boolean, title: string, label: string, score: number, maxScore: number, completionStatus: string, variables: ReadonlyArray } & { categories: Array, type: type | type, index: number, active: boolean, allowSkipping: boolean, maxAttempts: number, showFeedback: boolean, showSolution: boolean, numAttempts: number, valid: boolean, isDefaultResponse: boolean, done: boolean, optimal: boolean }[], navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean }[] }[] }"
+                "text": "{ view: '' | 'author' | 'candidate' | 'proctor' | 'scorer' | 'testConstructor' | 'tutor', identifier: string, title: string, availableFeedbacks: { identifier: string, partId: string }[], testParts: { active: boolean, identifier: string, navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean, sections: { active: boolean, identifier: string, title: string, completed: boolean, items: { identifier: string, href: string, correct: boolean, incorrect: boolean, completed: boolean, adaptive: boolean, timeDependent: boolean, title: string, label: string, score: number, maxScore: number, completionStatus: string, variables: ReadonlyArray } & { categories: Array, type: type | type, index: number, active: boolean, allowSkipping: boolean, maxAttempts: number, showFeedback: boolean, showSolution: boolean, numAttempts: number, valid: boolean, isDefaultResponse: boolean, done: boolean, optimal: boolean }[], navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean }[] }[] }"
               }
             },
             {
@@ -52729,7 +53041,7 @@
               },
               "privacy": "private",
               "parsedType": {
-                "text": "{ view: '' | 'author' | 'candidate' | 'proctor' | 'scorer' | 'testConstructor' | 'tutor', identifier: string, title: string, testParts: { active: boolean, identifier: string, navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean, sections: { active: boolean, identifier: string, title: string, completed: boolean, items: { identifier: string, href: string, correct: boolean, incorrect: boolean, completed: boolean, adaptive: boolean, timeDependent: boolean, title: string, label: string, score: number, maxScore: number, completionStatus: string, variables: ReadonlyArray } & { categories: Array, type: type | type, index: number, active: boolean, allowSkipping: boolean, maxAttempts: number, showFeedback: boolean, showSolution: boolean, numAttempts: number, valid: boolean, isDefaultResponse: boolean, done: boolean, optimal: boolean }[], navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean }[] }[] }"
+                "text": "{ view: '' | 'author' | 'candidate' | 'proctor' | 'scorer' | 'testConstructor' | 'tutor', identifier: string, title: string, availableFeedbacks: { identifier: string, partId: string }[], testParts: { active: boolean, identifier: string, navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean, sections: { active: boolean, identifier: string, title: string, completed: boolean, items: { identifier: string, href: string, correct: boolean, incorrect: boolean, completed: boolean, adaptive: boolean, timeDependent: boolean, title: string, label: string, score: number, maxScore: number, completionStatus: string, variables: ReadonlyArray } & { categories: Array, type: type | type, index: number, active: boolean, allowSkipping: boolean, maxAttempts: number, showFeedback: boolean, showSolution: boolean, numAttempts: number, valid: boolean, isDefaultResponse: boolean, done: boolean, optimal: boolean }[], navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean }[] }[] }"
               }
             },
             {
@@ -52844,7 +53156,7 @@
               },
               "privacy": "private",
               "parsedType": {
-                "text": "{ view: '' | 'author' | 'candidate' | 'proctor' | 'scorer' | 'testConstructor' | 'tutor', identifier: string, title: string, testParts: { active: boolean, identifier: string, navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean, sections: { active: boolean, identifier: string, title: string, completed: boolean, items: { identifier: string, href: string, correct: boolean, incorrect: boolean, completed: boolean, adaptive: boolean, timeDependent: boolean, title: string, label: string, score: number, maxScore: number, completionStatus: string, variables: ReadonlyArray } & { categories: Array, type: type | type, index: number, active: boolean, allowSkipping: boolean, maxAttempts: number, showFeedback: boolean, showSolution: boolean, numAttempts: number, valid: boolean, isDefaultResponse: boolean, done: boolean, optimal: boolean }[], navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean }[] }[] }"
+                "text": "{ view: '' | 'author' | 'candidate' | 'proctor' | 'scorer' | 'testConstructor' | 'tutor', identifier: string, title: string, availableFeedbacks: { identifier: string, partId: string }[], testParts: { active: boolean, identifier: string, navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean, sections: { active: boolean, identifier: string, title: string, completed: boolean, items: { identifier: string, href: string, correct: boolean, incorrect: boolean, completed: boolean, adaptive: boolean, timeDependent: boolean, title: string, label: string, score: number, maxScore: number, completionStatus: string, variables: ReadonlyArray } & { categories: Array, type: type | type, index: number, active: boolean, allowSkipping: boolean, maxAttempts: number, showFeedback: boolean, showSolution: boolean, numAttempts: number, valid: boolean, isDefaultResponse: boolean, done: boolean, optimal: boolean }[], navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean }[] }[] }"
               }
             },
             {
@@ -52926,7 +53238,7 @@
               },
               "privacy": "public",
               "parsedType": {
-                "text": "{ view: '' | 'author' | 'candidate' | 'proctor' | 'scorer' | 'testConstructor' | 'tutor', identifier: string, title: string, testParts: { active: boolean, identifier: string, navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean, sections: { active: boolean, identifier: string, title: string, completed: boolean, items: { identifier: string, href: string, correct: boolean, incorrect: boolean, completed: boolean, adaptive: boolean, timeDependent: boolean, title: string, label: string, score: number, maxScore: number, completionStatus: string, variables: ReadonlyArray } & { categories: Array, type: type | type, index: number, active: boolean, allowSkipping: boolean, maxAttempts: number, showFeedback: boolean, showSolution: boolean, numAttempts: number, valid: boolean, isDefaultResponse: boolean, done: boolean, optimal: boolean }[], navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean }[] }[] }"
+                "text": "{ view: '' | 'author' | 'candidate' | 'proctor' | 'scorer' | 'testConstructor' | 'tutor', identifier: string, title: string, availableFeedbacks: { identifier: string, partId: string }[], testParts: { active: boolean, identifier: string, navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean, sections: { active: boolean, identifier: string, title: string, completed: boolean, items: { identifier: string, href: string, correct: boolean, incorrect: boolean, completed: boolean, adaptive: boolean, timeDependent: boolean, title: string, label: string, score: number, maxScore: number, completionStatus: string, variables: ReadonlyArray } & { categories: Array, type: type | type, index: number, active: boolean, allowSkipping: boolean, maxAttempts: number, showFeedback: boolean, showSolution: boolean, numAttempts: number, valid: boolean, isDefaultResponse: boolean, done: boolean, optimal: boolean }[], navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean }[] }[] }"
               }
             }
           ],
@@ -52976,7 +53288,7 @@
               },
               "privacy": "public",
               "parsedType": {
-                "text": "{ view: '' | 'author' | 'candidate' | 'proctor' | 'scorer' | 'testConstructor' | 'tutor', identifier: string, title: string, testParts: { active: boolean, identifier: string, navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean, sections: { active: boolean, identifier: string, title: string, completed: boolean, items: { identifier: string, href: string, correct: boolean, incorrect: boolean, completed: boolean, adaptive: boolean, timeDependent: boolean, title: string, label: string, score: number, maxScore: number, completionStatus: string, variables: ReadonlyArray } & { categories: Array, type: type | type, index: number, active: boolean, allowSkipping: boolean, maxAttempts: number, showFeedback: boolean, showSolution: boolean, numAttempts: number, valid: boolean, isDefaultResponse: boolean, done: boolean, optimal: boolean }[], navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean }[] }[] }"
+                "text": "{ view: '' | 'author' | 'candidate' | 'proctor' | 'scorer' | 'testConstructor' | 'tutor', identifier: string, title: string, availableFeedbacks: { identifier: string, partId: string }[], testParts: { active: boolean, identifier: string, navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean, sections: { active: boolean, identifier: string, title: string, completed: boolean, items: { identifier: string, href: string, correct: boolean, incorrect: boolean, completed: boolean, adaptive: boolean, timeDependent: boolean, title: string, label: string, score: number, maxScore: number, completionStatus: string, variables: ReadonlyArray } & { categories: Array, type: type | type, index: number, active: boolean, allowSkipping: boolean, maxAttempts: number, showFeedback: boolean, showSolution: boolean, numAttempts: number, valid: boolean, isDefaultResponse: boolean, done: boolean, optimal: boolean }[], navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean }[] }[] }"
               }
             }
           ],
@@ -53039,7 +53351,7 @@
               },
               "privacy": "protected",
               "parsedType": {
-                "text": "{ view: '' | 'author' | 'candidate' | 'proctor' | 'scorer' | 'testConstructor' | 'tutor', identifier: string, title: string, testParts: { active: boolean, identifier: string, navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean, sections: { active: boolean, identifier: string, title: string, completed: boolean, items: { identifier: string, href: string, correct: boolean, incorrect: boolean, completed: boolean, adaptive: boolean, timeDependent: boolean, title: string, label: string, score: number, maxScore: number, completionStatus: string, variables: ReadonlyArray } & { categories: Array, type: type | type, index: number, active: boolean, allowSkipping: boolean, maxAttempts: number, showFeedback: boolean, showSolution: boolean, numAttempts: number, valid: boolean, isDefaultResponse: boolean, done: boolean, optimal: boolean }[], navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean }[] }[] }"
+                "text": "{ view: '' | 'author' | 'candidate' | 'proctor' | 'scorer' | 'testConstructor' | 'tutor', identifier: string, title: string, availableFeedbacks: { identifier: string, partId: string }[], testParts: { active: boolean, identifier: string, navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean, sections: { active: boolean, identifier: string, title: string, completed: boolean, items: { identifier: string, href: string, correct: boolean, incorrect: boolean, completed: boolean, adaptive: boolean, timeDependent: boolean, title: string, label: string, score: number, maxScore: number, completionStatus: string, variables: ReadonlyArray } & { categories: Array, type: type | type, index: number, active: boolean, allowSkipping: boolean, maxAttempts: number, showFeedback: boolean, showSolution: boolean, numAttempts: number, valid: boolean, isDefaultResponse: boolean, done: boolean, optimal: boolean }[], navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean }[] }[] }"
               }
             },
             {
@@ -53141,7 +53453,7 @@
               },
               "privacy": "protected",
               "parsedType": {
-                "text": "{ view: '' | 'author' | 'candidate' | 'proctor' | 'scorer' | 'testConstructor' | 'tutor', identifier: string, title: string, testParts: { active: boolean, identifier: string, navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean, sections: { active: boolean, identifier: string, title: string, completed: boolean, items: { identifier: string, href: string, correct: boolean, incorrect: boolean, completed: boolean, adaptive: boolean, timeDependent: boolean, title: string, label: string, score: number, maxScore: number, completionStatus: string, variables: ReadonlyArray } & { categories: Array, type: type | type, index: number, active: boolean, allowSkipping: boolean, maxAttempts: number, showFeedback: boolean, showSolution: boolean, numAttempts: number, valid: boolean, isDefaultResponse: boolean, done: boolean, optimal: boolean }[], navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean }[] }[] }"
+                "text": "{ view: '' | 'author' | 'candidate' | 'proctor' | 'scorer' | 'testConstructor' | 'tutor', identifier: string, title: string, availableFeedbacks: { identifier: string, partId: string }[], testParts: { active: boolean, identifier: string, navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean, sections: { active: boolean, identifier: string, title: string, completed: boolean, items: { identifier: string, href: string, correct: boolean, incorrect: boolean, completed: boolean, adaptive: boolean, timeDependent: boolean, title: string, label: string, score: number, maxScore: number, completionStatus: string, variables: ReadonlyArray } & { categories: Array, type: type | type, index: number, active: boolean, allowSkipping: boolean, maxAttempts: number, showFeedback: boolean, showSolution: boolean, numAttempts: number, valid: boolean, isDefaultResponse: boolean, done: boolean, optimal: boolean }[], navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean }[] }[] }"
               }
             },
             {
@@ -53233,7 +53545,7 @@
               },
               "privacy": "private",
               "parsedType": {
-                "text": "{ view: '' | 'author' | 'candidate' | 'proctor' | 'scorer' | 'testConstructor' | 'tutor', identifier: string, title: string, testParts: { active: boolean, identifier: string, navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean, sections: { active: boolean, identifier: string, title: string, completed: boolean, items: { identifier: string, href: string, correct: boolean, incorrect: boolean, completed: boolean, adaptive: boolean, timeDependent: boolean, title: string, label: string, score: number, maxScore: number, completionStatus: string, variables: ReadonlyArray } & { categories: Array, type: type | type, index: number, active: boolean, allowSkipping: boolean, maxAttempts: number, showFeedback: boolean, showSolution: boolean, numAttempts: number, valid: boolean, isDefaultResponse: boolean, done: boolean, optimal: boolean }[], navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean }[] }[] }"
+                "text": "{ view: '' | 'author' | 'candidate' | 'proctor' | 'scorer' | 'testConstructor' | 'tutor', identifier: string, title: string, availableFeedbacks: { identifier: string, partId: string }[], testParts: { active: boolean, identifier: string, navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean, sections: { active: boolean, identifier: string, title: string, completed: boolean, items: { identifier: string, href: string, correct: boolean, incorrect: boolean, completed: boolean, adaptive: boolean, timeDependent: boolean, title: string, label: string, score: number, maxScore: number, completionStatus: string, variables: ReadonlyArray } & { categories: Array, type: type | type, index: number, active: boolean, allowSkipping: boolean, maxAttempts: number, showFeedback: boolean, showSolution: boolean, numAttempts: number, valid: boolean, isDefaultResponse: boolean, done: boolean, optimal: boolean }[], navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean }[] }[] }"
               }
             },
             {
@@ -53356,6 +53668,169 @@
     },
     {
       "kind": "javascript-module",
+      "path": "packages/qti-test/src/components/test-show-feedback/test-show-feedback.ts",
+      "declarations": [
+        {
+          "kind": "class",
+          "description": "Navigates the candidate to an `access=\"atEnd\"` qti-test-feedback once it has\nbecome available (its end-of-part / end-of-test outcome has matched). The\nbutton is disabled until then, so a host can keep it hidden until enabled.\n\nClicking dispatches a `feedback` navigation request, which clears the current\nassessment item and shows the feedback. Navigating to any item afterwards (or\nmoving into a later test-part) hides the feedback again.",
+          "name": "TestShowFeedback",
+          "members": [
+            {
+              "kind": "method",
+              "name": "_handleComputedContextChange",
+              "parameters": [
+                {
+                  "name": "_oldValue",
+                  "type": {
+                    "text": "ComputedContext"
+                  }
+                },
+                {
+                  "name": "newValue",
+                  "type": {
+                    "text": "ComputedContext"
+                  }
+                }
+              ],
+              "type": {
+                "text": "_handleComputedContextChange(_oldValue: ComputedContext, newValue: ComputedContext) => void"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "_internalDisabled",
+              "type": {
+                "text": "boolean"
+              },
+              "privacy": "public",
+              "default": "true",
+              "attribute": "disabled",
+              "reflects": true
+            },
+            {
+              "kind": "method",
+              "name": "_requestFeedback",
+              "privacy": "protected",
+              "return": {
+                "type": {
+                  "text": "void"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "identifier",
+                  "type": {
+                    "text": "string"
+                  }
+                }
+              ]
+            },
+            {
+              "kind": "field",
+              "name": "#feedbackId",
+              "privacy": "private",
+              "type": {
+                "text": "string | null"
+              },
+              "default": "null",
+              "description": "Identifier of the feedback to navigate to, set whenever one is available.",
+              "parsedType": {
+                "text": "string"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "#internals",
+              "privacy": "private",
+              "type": {
+                "text": "ElementInternals"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "ariaLabel",
+              "type": {
+                "text": "string"
+              },
+              "default": "'Show feedback'"
+            },
+            {
+              "kind": "field",
+              "name": "computedContext",
+              "type": {
+                "text": "ComputedContext"
+              },
+              "privacy": "private",
+              "parsedType": {
+                "text": "{ view: '' | 'author' | 'candidate' | 'proctor' | 'scorer' | 'testConstructor' | 'tutor', identifier: string, title: string, availableFeedbacks: { identifier: string, partId: string }[], testParts: { active: boolean, identifier: string, navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean, sections: { active: boolean, identifier: string, title: string, completed: boolean, items: { identifier: string, href: string, correct: boolean, incorrect: boolean, completed: boolean, adaptive: boolean, timeDependent: boolean, title: string, label: string, score: number, maxScore: number, completionStatus: string, variables: ReadonlyArray } & { categories: Array, type: type | type, index: number, active: boolean, allowSkipping: boolean, maxAttempts: number, showFeedback: boolean, showSolution: boolean, numAttempts: number, valid: boolean, isDefaultResponse: boolean, done: boolean, optimal: boolean }[], navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean }[] }[] }"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "role",
+              "type": {
+                "text": "string"
+              },
+              "default": "'button'"
+            },
+            {
+              "kind": "field",
+              "name": "sessionContext",
+              "type": {
+                "text": "SessionContext"
+              },
+              "privacy": "private"
+            }
+          ],
+          "events": [
+            {
+              "name": "qti-request-navigation",
+              "type": {
+                "text": "CustomEvent"
+              }
+            }
+          ],
+          "attributes": [
+            {
+              "name": "disabled",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "true",
+              "fieldName": "_internalDisabled"
+            }
+          ],
+          "superclass": {
+            "name": "LitElement",
+            "package": "lit"
+          },
+          "customElement": true,
+          "tagName": "test-show-feedback",
+          "modulePath": "packages/qti-test/src/components/test-show-feedback/test-show-feedback.ts",
+          "definitionPath": "packages/qti-test/src/components/test-show-feedback/test-show-feedback.ts"
+        }
+      ],
+      "exports": [
+        {
+          "kind": "custom-element-definition",
+          "name": "test-show-feedback",
+          "declaration": {
+            "name": "TestShowFeedback",
+            "module": "packages/qti-test/src/components/test-show-feedback/test-show-feedback.ts"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "TestShowFeedback",
+          "declaration": {
+            "name": "TestShowFeedback",
+            "module": "packages/qti-test/src/components/test-show-feedback/test-show-feedback.ts"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
       "path": "packages/qti-test/src/components/test-stamp/test-stamp.ts",
       "declarations": [
         {
@@ -53371,7 +53846,7 @@
               },
               "privacy": "private",
               "parsedType": {
-                "text": "{ view: '' | 'author' | 'candidate' | 'proctor' | 'scorer' | 'testConstructor' | 'tutor', identifier: string, title: string, testParts: { active: boolean, identifier: string, navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean, sections: { active: boolean, identifier: string, title: string, completed: boolean, items: { identifier: string, href: string, correct: boolean, incorrect: boolean, completed: boolean, adaptive: boolean, timeDependent: boolean, title: string, label: string, score: number, maxScore: number, completionStatus: string, variables: ReadonlyArray } & { categories: Array, type: type | type, index: number, active: boolean, allowSkipping: boolean, maxAttempts: number, showFeedback: boolean, showSolution: boolean, numAttempts: number, valid: boolean, isDefaultResponse: boolean, done: boolean, optimal: boolean }[], navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean }[] }[] }"
+                "text": "{ view: '' | 'author' | 'candidate' | 'proctor' | 'scorer' | 'testConstructor' | 'tutor', identifier: string, title: string, availableFeedbacks: { identifier: string, partId: string }[], testParts: { active: boolean, identifier: string, navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean, sections: { active: boolean, identifier: string, title: string, completed: boolean, items: { identifier: string, href: string, correct: boolean, incorrect: boolean, completed: boolean, adaptive: boolean, timeDependent: boolean, title: string, label: string, score: number, maxScore: number, completionStatus: string, variables: ReadonlyArray } & { categories: Array, type: type | type, index: number, active: boolean, allowSkipping: boolean, maxAttempts: number, showFeedback: boolean, showSolution: boolean, numAttempts: number, valid: boolean, isDefaultResponse: boolean, done: boolean, optimal: boolean }[], navigationMode: 'linear' | 'nonlinear', submissionMode: 'individual' | 'simultaneous', allowSkipping: boolean }[] }[] }"
               }
             },
             {
@@ -53669,9 +54144,9 @@
           "kind": "variable",
           "name": "qtiTestElements",
           "type": {
-            "text": "[\n  { tag: 'qti-assessment-item-ref', ctor: QtiAssessmentItemRef },\n  { tag: 'qti-assessment-section', ctor: QtiAssessmentSection },\n  { tag: 'qti-assessment-test', ctor: QtiAssessmentTest },\n  { tag: 'qti-item-session-control', ctor: QtiItemSessionControl },\n  { tag: 'qti-outcome-processing', ctor: QtiOutcomeProcessing },\n  { tag: 'qti-test', ctor: QtiTest },\n  { tag: 'qti-test-feedback', ctor: QtiTestFeedback },\n  { tag: 'qti-test-part', ctor: QtiTestPart },\n  { tag: 'qti-test-variables', ctor: QtiTestVariables },\n  { tag: 'test-check-item', ctor: TestCheckItem },\n  { tag: 'test-container', ctor: TestContainer },\n  { tag: 'test-end-attempt', ctor: TestEndAttempt },\n  { tag: 'test-item-link', ctor: TestItemLink },\n  { tag: 'test-item-to-speech', ctor: TestItemToSpeech },\n  { tag: 'test-navigation', ctor: TestNavigation },\n  { tag: 'test-next', ctor: TestNext },\n  { tag: 'test-paging-buttons-stamp', ctor: TestPagingButtonsStamp },\n  { tag: 'test-prev', ctor: TestPrev },\n  { tag: 'test-print-context', ctor: TestPrintContext },\n  { tag: 'test-print-item-variables', ctor: TestPrintVariables },\n  { tag: 'test-scoring-buttons', ctor: TestScoringButtons },\n  { tag: 'test-scoring-feedback', ctor: TestScoringFeedback },\n  { tag: 'test-section-buttons-stamp', ctor: TestSectionButtonsStamp },\n  { tag: 'test-section-link', ctor: TestSectionLink },\n  { tag: 'test-stamp', ctor: TestStamp },\n  { tag: 'test-tts-next', ctor: TestTtsNext },\n  { tag: 'test-tts-pause', ctor: TestTtsPause },\n  { tag: 'test-tts-play', ctor: TestTtsPlay },\n  { tag: 'test-tts-prev', ctor: TestTtsPrev },\n  { tag: 'test-tts-resume', ctor: TestTtsResume },\n  { tag: 'test-tts-stop', ctor: TestTtsStop },\n  { tag: 'test-view', ctor: TestView },\n  { tag: 'test-view-toggle', ctor: TestViewToggle }\n]"
+            "text": "[\n  { tag: 'qti-assessment-item-ref', ctor: QtiAssessmentItemRef },\n  { tag: 'qti-assessment-section', ctor: QtiAssessmentSection },\n  { tag: 'qti-assessment-test', ctor: QtiAssessmentTest },\n  { tag: 'qti-item-session-control', ctor: QtiItemSessionControl },\n  { tag: 'qti-outcome-processing', ctor: QtiOutcomeProcessing },\n  { tag: 'qti-test', ctor: QtiTest },\n  { tag: 'qti-test-feedback', ctor: QtiTestFeedback },\n  { tag: 'qti-test-part', ctor: QtiTestPart },\n  { tag: 'qti-test-variables', ctor: QtiTestVariables },\n  { tag: 'test-check-item', ctor: TestCheckItem },\n  { tag: 'test-container', ctor: TestContainer },\n  { tag: 'test-end-attempt', ctor: TestEndAttempt },\n  { tag: 'test-item-link', ctor: TestItemLink },\n  { tag: 'test-item-to-speech', ctor: TestItemToSpeech },\n  { tag: 'test-navigation', ctor: TestNavigation },\n  { tag: 'test-next', ctor: TestNext },\n  { tag: 'test-paging-buttons-stamp', ctor: TestPagingButtonsStamp },\n  { tag: 'test-prev', ctor: TestPrev },\n  { tag: 'test-print-context', ctor: TestPrintContext },\n  { tag: 'test-print-item-variables', ctor: TestPrintVariables },\n  { tag: 'test-scoring-buttons', ctor: TestScoringButtons },\n  { tag: 'test-scoring-feedback', ctor: TestScoringFeedback },\n  { tag: 'test-section-buttons-stamp', ctor: TestSectionButtonsStamp },\n  { tag: 'test-section-link', ctor: TestSectionLink },\n  { tag: 'test-show-feedback', ctor: TestShowFeedback },\n  { tag: 'test-stamp', ctor: TestStamp },\n  { tag: 'test-tts-next', ctor: TestTtsNext },\n  { tag: 'test-tts-pause', ctor: TestTtsPause },\n  { tag: 'test-tts-play', ctor: TestTtsPlay },\n  { tag: 'test-tts-prev', ctor: TestTtsPrev },\n  { tag: 'test-tts-resume', ctor: TestTtsResume },\n  { tag: 'test-tts-stop', ctor: TestTtsStop },\n  { tag: 'test-view', ctor: TestView },\n  { tag: 'test-view-toggle', ctor: TestViewToggle }\n]"
           },
-          "default": "[ { tag: 'qti-assessment-item-ref', ctor: QtiAssessmentItemRef }, { tag: 'qti-assessment-section', ctor: QtiAssessmentSection }, { tag: 'qti-assessment-test', ctor: QtiAssessmentTest }, { tag: 'qti-item-session-control', ctor: QtiItemSessionControl }, { tag: 'qti-outcome-processing', ctor: QtiOutcomeProcessing }, { tag: 'qti-test', ctor: QtiTest }, { tag: 'qti-test-feedback', ctor: QtiTestFeedback }, { tag: 'qti-test-part', ctor: QtiTestPart }, { tag: 'qti-test-variables', ctor: QtiTestVariables }, { tag: 'test-check-item', ctor: TestCheckItem }, { tag: 'test-container', ctor: TestContainer }, { tag: 'test-end-attempt', ctor: TestEndAttempt }, { tag: 'test-item-link', ctor: TestItemLink }, { tag: 'test-item-to-speech', ctor: TestItemToSpeech }, { tag: 'test-navigation', ctor: TestNavigation }, { tag: 'test-next', ctor: TestNext }, { tag: 'test-paging-buttons-stamp', ctor: TestPagingButtonsStamp }, { tag: 'test-prev', ctor: TestPrev }, { tag: 'test-print-context', ctor: TestPrintContext }, { tag: 'test-print-item-variables', ctor: TestPrintVariables }, { tag: 'test-scoring-buttons', ctor: TestScoringButtons }, { tag: 'test-scoring-feedback', ctor: TestScoringFeedback }, { tag: 'test-section-buttons-stamp', ctor: TestSectionButtonsStamp }, { tag: 'test-section-link', ctor: TestSectionLink }, { tag: 'test-stamp', ctor: TestStamp }, { tag: 'test-tts-next', ctor: TestTtsNext }, { tag: 'test-tts-pause', ctor: TestTtsPause }, { tag: 'test-tts-play', ctor: TestTtsPlay }, { tag: 'test-tts-prev', ctor: TestTtsPrev }, { tag: 'test-tts-resume', ctor: TestTtsResume }, { tag: 'test-tts-stop', ctor: TestTtsStop }, { tag: 'test-view', ctor: TestView }, { tag: 'test-view-toggle', ctor: TestViewToggle } ]"
+          "default": "[ { tag: 'qti-assessment-item-ref', ctor: QtiAssessmentItemRef }, { tag: 'qti-assessment-section', ctor: QtiAssessmentSection }, { tag: 'qti-assessment-test', ctor: QtiAssessmentTest }, { tag: 'qti-item-session-control', ctor: QtiItemSessionControl }, { tag: 'qti-outcome-processing', ctor: QtiOutcomeProcessing }, { tag: 'qti-test', ctor: QtiTest }, { tag: 'qti-test-feedback', ctor: QtiTestFeedback }, { tag: 'qti-test-part', ctor: QtiTestPart }, { tag: 'qti-test-variables', ctor: QtiTestVariables }, { tag: 'test-check-item', ctor: TestCheckItem }, { tag: 'test-container', ctor: TestContainer }, { tag: 'test-end-attempt', ctor: TestEndAttempt }, { tag: 'test-item-link', ctor: TestItemLink }, { tag: 'test-item-to-speech', ctor: TestItemToSpeech }, { tag: 'test-navigation', ctor: TestNavigation }, { tag: 'test-next', ctor: TestNext }, { tag: 'test-paging-buttons-stamp', ctor: TestPagingButtonsStamp }, { tag: 'test-prev', ctor: TestPrev }, { tag: 'test-print-context', ctor: TestPrintContext }, { tag: 'test-print-item-variables', ctor: TestPrintVariables }, { tag: 'test-scoring-buttons', ctor: TestScoringButtons }, { tag: 'test-scoring-feedback', ctor: TestScoringFeedback }, { tag: 'test-section-buttons-stamp', ctor: TestSectionButtonsStamp }, { tag: 'test-section-link', ctor: TestSectionLink }, { tag: 'test-show-feedback', ctor: TestShowFeedback }, { tag: 'test-stamp', ctor: TestStamp }, { tag: 'test-tts-next', ctor: TestTtsNext }, { tag: 'test-tts-pause', ctor: TestTtsPause }, { tag: 'test-tts-play', ctor: TestTtsPlay }, { tag: 'test-tts-prev', ctor: TestTtsPrev }, { tag: 'test-tts-resume', ctor: TestTtsResume }, { tag: 'test-tts-stop', ctor: TestTtsStop }, { tag: 'test-view', ctor: TestView }, { tag: 'test-view-toggle', ctor: TestViewToggle } ]"
         }
       ],
       "exports": [
@@ -53872,6 +54347,14 @@
           "name": "TestSectionLink",
           "declaration": {
             "name": "TestSectionLink",
+            "module": "packages/qti-test/src/elements.ts"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "TestShowFeedback",
+          "declaration": {
+            "name": "TestShowFeedback",
             "module": "packages/qti-test/src/elements.ts"
           }
         },

--- a/packages/qti-test/src/components/index.ts
+++ b/packages/qti-test/src/components/index.ts
@@ -12,6 +12,7 @@ export * from '../components/qti-item-session-control/qti-item-session-control';
 export * from './test-navigation/test-navigation';
 export * from './test-next/test-next';
 export * from './test-prev/test-prev';
+export * from './test-show-feedback/test-show-feedback';
 export * from './test-view-toggle/test-view';
 export * from './test-item-link/test-item-link';
 export * from './test-end-attempt/test-end-attempt';

--- a/packages/qti-test/src/components/qti-assessment-test/qti-assessment-test.ts
+++ b/packages/qti-test/src/components/qti-assessment-test/qti-assessment-test.ts
@@ -4,6 +4,7 @@ import { property } from 'lit/decorators.js';
 
 import { testContext } from '@qti-components/base';
 
+import type { QtiTestFeedback } from '../qti-test-feedback/qti-test-feedback';
 import type { TestContext } from '@qti-components/base';
 
 export class QtiAssessmentTest extends LitElement {
@@ -24,6 +25,7 @@ export class QtiAssessmentTest extends LitElement {
 
   override async connectedCallback(): Promise<void> {
     super.connectedCallback();
+    this.addEventListener('qti-test-outcome-changed', this.#handleTestOutcomeChanged);
     await this.updateComplete;
     this.dispatchEvent(
       new CustomEvent('qti-assessment-test-connected', {
@@ -34,13 +36,37 @@ export class QtiAssessmentTest extends LitElement {
     );
   }
 
+  override disconnectedCallback(): void {
+    this.removeEventListener('qti-test-outcome-changed', this.#handleTestOutcomeChanged);
+    super.disconnectedCallback();
+  }
+
+  /**
+   * Outcome processing has run, so give every test feedback below this element a
+   * chance to re-evaluate. The flags travel with the event rather than being
+   * re-derived here: only the run that concluded a part or the test can satisfy
+   * `access="atEnd"`, and only feedback scoped to that part should respond.
+   */
+  #handleTestOutcomeChanged = (e: QtiTestOutcomeChangedEvent): void => {
+    const atEnd = e.detail.atEnd === true;
+    const partId = e.detail.partId ?? null;
+    this.querySelectorAll<QtiTestFeedback>('qti-test-feedback').forEach(fb => {
+      fb.checkShowFeedback(fb.outcomeIdentifier, { atEnd, partId });
+    });
+  };
+
   override render() {
     return html` <slot></slot>`;
   }
 }
 
+export type QtiTestOutcomeChangedEvent = CustomEvent<{ atEnd?: boolean; partId?: string | null }>;
+
 declare global {
   interface HTMLElementTagNameMap {
     'qti-assessment-test': QtiAssessmentTest;
+  }
+  interface GlobalEventHandlersEventMap {
+    'qti-test-outcome-changed': QtiTestOutcomeChangedEvent;
   }
 }

--- a/packages/qti-test/src/components/qti-test-feedback/qti-test-feedback.spec.ts
+++ b/packages/qti-test/src/components/qti-test-feedback/qti-test-feedback.spec.ts
@@ -1,0 +1,119 @@
+import '@citolab/qti-components';
+
+import { html, render } from 'lit';
+
+import type { QtiTestFeedback } from './qti-test-feedback';
+import type { QtiTest } from '../qti-test/qti-test';
+
+/**
+ * Test feedback is presented per its `access` characteristic: `during` after
+ * each instance of outcome processing, `atEnd` only at the conclusion of the
+ * test — or of the test part the feedback sits in.
+ *
+ * Each feedback keys off its own outcome, set by hand, and
+ * `qti-outcome-processing` is left empty — so these cover the presentation
+ * rules rather than the processing that feeds them.
+ */
+const assessmentTest = html`
+  <qti-test navigate="item">
+    <test-container>
+      <qti-assessment-test xmlns="http://www.imsglobal.org/xsd/imsqtiasi_v3p0" identifier="T1" title="Feedback">
+        <qti-outcome-declaration identifier="FB_PART" cardinality="single" base-type="identifier">
+        </qti-outcome-declaration>
+        <qti-outcome-declaration identifier="FB_TEST" cardinality="single" base-type="identifier">
+        </qti-outcome-declaration>
+        <qti-outcome-declaration identifier="FB_DURING" cardinality="single" base-type="identifier">
+        </qti-outcome-declaration>
+        <qti-test-part identifier="P1" navigation-mode="nonlinear" submission-mode="simultaneous">
+          <qti-assessment-section identifier="S1" title="S1" visible="true"> </qti-assessment-section>
+          <qti-test-feedback identifier="part-over" outcome-identifier="FB_PART" access="atEnd" show-hide="show">
+            End of part
+          </qti-test-feedback>
+        </qti-test-part>
+        <qti-test-feedback identifier="test-over" outcome-identifier="FB_TEST" access="atEnd" show-hide="show">
+          End of test
+        </qti-test-feedback>
+        <qti-test-feedback identifier="in-progress" outcome-identifier="FB_DURING" access="during" show-hide="show">
+          Still going
+        </qti-test-feedback>
+        <qti-outcome-processing></qti-outcome-processing>
+      </qti-assessment-test>
+    </test-container>
+  </qti-test>
+`;
+
+describe('qti-test-feedback access', () => {
+  let container: HTMLDivElement;
+  let qtiTest: QtiTest;
+
+  const feedback = (identifier: string) =>
+    container.querySelector<QtiTestFeedback>(`qti-test-feedback[identifier='${identifier}']`);
+
+  /** Never presented — an unevaluated feedback has no showStatus at all. */
+  const isHidden = (identifier: string) => feedback(identifier)?.showStatus !== 'on';
+
+  beforeEach(async () => {
+    // A fresh container per case: rendering the same template into a shared
+    // root reuses the elements, so showStatus would leak between tests.
+    container = document.createElement('div');
+    document.body.appendChild(container);
+
+    render(assessmentTest, container);
+    qtiTest = container.querySelector('qti-test') as QtiTest;
+    await qtiTest.updateComplete;
+    // Every feedback's outcome names it, so scoping is what separates them.
+    qtiTest.updateOutcomeVariable('FB_PART', 'part-over');
+    qtiTest.updateOutcomeVariable('FB_TEST', 'test-over');
+    qtiTest.updateOutcomeVariable('FB_DURING', 'in-progress');
+  });
+
+  afterEach(() => container.remove());
+
+  it('shows during-feedback on an in-flight processing run', () => {
+    qtiTest.outcomeProcessing();
+
+    expect(feedback('in-progress')?.showStatus).toBe('on');
+  });
+
+  it('leaves atEnd feedback hidden on an in-flight run', () => {
+    qtiTest.outcomeProcessing();
+
+    expect(isHidden('test-over')).toBe(true);
+    expect(isHidden('part-over')).toBe(true);
+  });
+
+  it('shows test-root feedback at the conclusion of the test', () => {
+    qtiTest.outcomeProcessing({ atEnd: true });
+
+    expect(feedback('test-over')?.showStatus).toBe('on');
+  });
+
+  it('does not show part feedback at the conclusion of the test', () => {
+    qtiTest.outcomeProcessing({ atEnd: true });
+
+    expect(isHidden('part-over')).toBe(true);
+  });
+
+  it('shows part feedback at the conclusion of its own part', () => {
+    qtiTest.outcomeProcessing({ atEnd: true, partId: 'P1' });
+
+    expect(feedback('part-over')?.showStatus).toBe('on');
+    expect(isHidden('test-over')).toBe(true);
+  });
+
+  it('runs outcome processing when a part reports completion', () => {
+    const testElement = document.body.querySelector('qti-assessment-test')!;
+
+    testElement.dispatchEvent(new CustomEvent('qti-part-completed', { detail: { partId: 'P1' }, bubbles: true }));
+
+    expect(feedback('part-over')?.showStatus).toBe('on');
+  });
+
+  it('runs outcome processing when the test reports completion', () => {
+    const testElement = document.body.querySelector('qti-assessment-test')!;
+
+    testElement.dispatchEvent(new CustomEvent('qti-test-completed', { bubbles: true }));
+
+    expect(feedback('test-over')?.showStatus).toBe('on');
+  });
+});

--- a/packages/qti-test/src/components/qti-test-feedback/qti-test-feedback.spec.ts
+++ b/packages/qti-test/src/components/qti-test-feedback/qti-test-feedback.spec.ts
@@ -82,37 +82,75 @@ describe('qti-test-feedback access', () => {
     expect(isHidden('part-over')).toBe(true);
   });
 
-  it('shows test-root feedback at the conclusion of the test', () => {
+  it('makes test-root feedback available, but not shown, at the conclusion of the test', async () => {
     qtiTest.outcomeProcessing({ atEnd: true });
+
+    expect(isHidden('test-over')).toBe(true);
+
+    qtiTest.navigateTo('feedback', 'test-over');
+    await feedback('test-over')?.updateComplete;
 
     expect(feedback('test-over')?.showStatus).toBe('on');
   });
 
-  it('does not show part feedback at the conclusion of the test', () => {
+  it('does not make part feedback available at the conclusion of the test', async () => {
     qtiTest.outcomeProcessing({ atEnd: true });
+
+    expect(isHidden('part-over')).toBe(true);
+
+    // Attempting to navigate to it anyway must not show it — it never latched
+    // available, so the navigation target alone isn't enough.
+    qtiTest.navigateTo('feedback', 'part-over');
+    await feedback('part-over')?.updateComplete;
 
     expect(isHidden('part-over')).toBe(true);
   });
 
-  it('shows part feedback at the conclusion of its own part', () => {
+  it('makes part feedback available, but not shown, at the conclusion of its own part', async () => {
     qtiTest.outcomeProcessing({ atEnd: true, partId: 'P1' });
+
+    expect(isHidden('part-over')).toBe(true);
+    expect(isHidden('test-over')).toBe(true);
+
+    qtiTest.navigateTo('feedback', 'part-over');
+    await feedback('part-over')?.updateComplete;
 
     expect(feedback('part-over')?.showStatus).toBe('on');
     expect(isHidden('test-over')).toBe(true);
   });
 
-  it('runs outcome processing when a part reports completion', () => {
+  it('hides atEnd feedback again once the candidate navigates away to a section', async () => {
+    qtiTest.outcomeProcessing({ atEnd: true });
+    qtiTest.navigateTo('feedback', 'test-over');
+    await feedback('test-over')?.updateComplete;
+    expect(feedback('test-over')?.showStatus).toBe('on');
+
+    qtiTest.navigateTo('section', 'S1');
+    await feedback('test-over')?.updateComplete;
+
+    expect(isHidden('test-over')).toBe(true);
+  });
+
+  it('runs outcome processing when a part reports completion, making its feedback available', async () => {
     const testElement = document.body.querySelector('qti-assessment-test')!;
 
     testElement.dispatchEvent(new CustomEvent('qti-part-completed', { detail: { partId: 'P1' }, bubbles: true }));
+    expect(isHidden('part-over')).toBe(true);
+
+    qtiTest.navigateTo('feedback', 'part-over');
+    await feedback('part-over')?.updateComplete;
 
     expect(feedback('part-over')?.showStatus).toBe('on');
   });
 
-  it('runs outcome processing when the test reports completion', () => {
+  it('runs outcome processing when the test reports completion, making its feedback available', async () => {
     const testElement = document.body.querySelector('qti-assessment-test')!;
 
     testElement.dispatchEvent(new CustomEvent('qti-test-completed', { bubbles: true }));
+    expect(isHidden('test-over')).toBe(true);
+
+    qtiTest.navigateTo('feedback', 'test-over');
+    await feedback('test-over')?.updateComplete;
 
     expect(feedback('test-over')?.showStatus).toBe('on');
   });

--- a/packages/qti-test/src/components/qti-test-feedback/qti-test-feedback.stories.ts
+++ b/packages/qti-test/src/components/qti-test-feedback/qti-test-feedback.stories.ts
@@ -1,0 +1,79 @@
+import { expect, waitFor } from 'storybook/test';
+import { html } from 'lit';
+import { getStorybookHelpers } from '@wc-toolkit/storybook-helpers';
+
+import type { QtiTestFeedback } from './qti-test-feedback';
+import type { QtiTest } from '../qti-test/qti-test';
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+
+const { args, argTypes } = getStorybookHelpers('qti-test-feedback');
+
+type Story = StoryObj<QtiTestFeedback & typeof args>;
+
+const meta: Meta<QtiTestFeedback> = {
+  component: 'qti-test-feedback',
+  args,
+  argTypes
+};
+export default meta;
+
+/**
+ * No conformance asset combines real test-level outcome processing with
+ * qti-test-feedback, so the test document is built inline — an empty section
+ * (nothing to attempt), one `during` feedback and one `atEnd` feedback, whose
+ * outcomes the play function sets by hand, the same way qti-test-feedback.spec.ts
+ * does.
+ */
+const assessmentTest = html`
+  <qti-test navigate="item">
+    <test-navigation>
+      <test-container>
+        <qti-assessment-test xmlns="http://www.imsglobal.org/xsd/imsqtiasi_v3p0" identifier="T1" title="Feedback Demo">
+          <qti-outcome-declaration identifier="FB_TEST" cardinality="single" base-type="identifier">
+          </qti-outcome-declaration>
+          <qti-outcome-declaration identifier="FB_DURING" cardinality="single" base-type="identifier">
+          </qti-outcome-declaration>
+          <qti-test-part identifier="P1" navigation-mode="nonlinear" submission-mode="individual">
+            <qti-assessment-section identifier="S1" title="S1" visible="true"> </qti-assessment-section>
+          </qti-test-part>
+          <qti-test-feedback identifier="test-over" outcome-identifier="FB_TEST" access="atEnd" show-hide="show">
+            <p>End of test — hidden until the candidate navigates here.</p>
+          </qti-test-feedback>
+          <qti-test-feedback identifier="in-progress" outcome-identifier="FB_DURING" access="during" show-hide="show">
+            <p>Still going — shown the instant its outcome matches.</p>
+          </qti-test-feedback>
+          <qti-outcome-processing></qti-outcome-processing>
+        </qti-assessment-test>
+      </test-container>
+    </test-navigation>
+  </qti-test>
+`;
+
+export const Default: Story = {
+  render: () => assessmentTest
+};
+
+export const Test: Story = {
+  render: () => assessmentTest,
+  play: async ({ canvasElement }) => {
+    const qtiTest = canvasElement.querySelector('qti-test') as QtiTest;
+    await qtiTest.updateComplete;
+
+    const testOver = canvasElement.querySelector<QtiTestFeedback>('qti-test-feedback[identifier="test-over"]');
+    const inProgress = canvasElement.querySelector<QtiTestFeedback>('qti-test-feedback[identifier="in-progress"]');
+
+    // during-feedback shows the instant its outcome matches.
+    qtiTest.updateOutcomeVariable('FB_DURING', 'in-progress');
+    qtiTest.outcomeProcessing();
+    await waitFor(() => expect(inProgress?.showStatus).toBe('on'));
+
+    // atEnd feedback becomes available but stays hidden until the candidate
+    // navigates to it.
+    qtiTest.updateOutcomeVariable('FB_TEST', 'test-over');
+    qtiTest.outcomeProcessing({ atEnd: true });
+    expect(testOver?.showStatus).not.toBe('on');
+
+    qtiTest.navigateTo('feedback', 'test-over');
+    await waitFor(() => expect(testOver?.showStatus).toBe('on'));
+  }
+};

--- a/packages/qti-test/src/components/qti-test-feedback/qti-test-feedback.ts
+++ b/packages/qti-test/src/components/qti-test-feedback/qti-test-feedback.ts
@@ -1,6 +1,13 @@
+import { consume } from '@lit/context';
 import { css, html } from 'lit';
+import { property, state } from 'lit/decorators.js';
 
+import { testContext } from '@qti-components/base';
 import { QtiModalFeedback } from '@qti-components/elements/elements';
+
+import type { TestContext } from '@qti-components/base';
+
+export type TestFeedbackAccess = 'atEnd' | 'during';
 
 export class QtiTestFeedback extends QtiModalFeedback {
   static override styles = css`
@@ -8,8 +15,63 @@ export class QtiTestFeedback extends QtiModalFeedback {
       color: gray;
     }
   `;
+
+  /**
+   * When the feedback may be presented, per the QTI 3 `access` characteristic.
+   *
+   * - `atEnd` — only at the conclusion of the test, or of the test part the
+   *   feedback sits in.
+   * - `during` — while the test is still in progress, after each instance of
+   *   outcome processing.
+   */
+  @property({ type: String, attribute: 'access' })
+  public access: TestFeedbackAccess = 'atEnd';
+
+  @consume({ context: testContext, subscribe: true })
+  @state()
+  private _testContext?: TestContext;
+
+  /**
+   * Re-evaluate against the *test* context, rather than the item context the
+   * inherited implementation reads.
+   *
+   * `qti-assessment-test` calls this after each outcome-processing run, passing
+   * what that run concluded. `atEnd` feedback responds only to the run that
+   * ended its own scope — the whole test for test-root feedback, or its own
+   * test part for part-scoped feedback — while `during` feedback responds to
+   * every run.
+   */
+  public override checkShowFeedback(
+    outcomeIdentifier: string,
+    trigger: { atEnd?: boolean; partId?: string | null } = {}
+  ): void {
+    if (this.outcomeIdentifier !== outcomeIdentifier) return;
+
+    if (this.access === 'atEnd') {
+      const concludedPartId = trigger.partId ?? null;
+      if (trigger.atEnd !== true || concludedPartId !== this.#ownPartId) return;
+    }
+
+    const matched = this.#outcomeMatches();
+    this.showStatus = (matched && this.showHide === 'show') || (!matched && this.showHide === 'hide') ? 'on' : 'off';
+  }
+
+  /** The test part this feedback belongs to, or null when it is test-root feedback. */
+  get #ownPartId(): string | null {
+    return this.closest('qti-test-part')?.getAttribute('identifier') ?? null;
+  }
+
+  /** Whether this feedback's test-level outcome currently names its identifier. */
+  #outcomeMatches(): boolean {
+    const outcomeVariable = this._testContext?.testOutcomeVariables?.find(v => v.identifier === this.outcomeIdentifier);
+    if (!outcomeVariable) return false;
+    return Array.isArray(outcomeVariable.value)
+      ? outcomeVariable.value.includes(this.identifier)
+      : !!this.identifier && outcomeVariable.value != null && this.identifier === outcomeVariable.value;
+  }
+
   override render() {
-    return html``;
+    return html`<div ?hidden=${this.showStatus !== 'on'}><slot></slot></div>`;
   }
 }
 

--- a/packages/qti-test/src/components/qti-test-feedback/qti-test-feedback.ts
+++ b/packages/qti-test/src/components/qti-test-feedback/qti-test-feedback.ts
@@ -2,12 +2,19 @@ import { consume } from '@lit/context';
 import { css, html } from 'lit';
 import { property, state } from 'lit/decorators.js';
 
-import { testContext } from '@qti-components/base';
+import { sessionContext, testContext } from '@qti-components/base';
 import { QtiModalFeedback } from '@qti-components/elements/elements';
 
-import type { TestContext } from '@qti-components/base';
+import type { PropertyValues } from 'lit';
+import type { SessionContext, TestContext } from '@qti-components/base';
 
 export type TestFeedbackAccess = 'atEnd' | 'during';
+
+export type QtiTestFeedbackAvailabilityChangedEvent = CustomEvent<{
+  identifier: string;
+  partId: string | null;
+  available: boolean;
+}>;
 
 export class QtiTestFeedback extends QtiModalFeedback {
   static override styles = css`
@@ -20,9 +27,11 @@ export class QtiTestFeedback extends QtiModalFeedback {
    * When the feedback may be presented, per the QTI 3 `access` characteristic.
    *
    * - `atEnd` — only at the conclusion of the test, or of the test part the
-   *   feedback sits in.
+   *   feedback sits in. Becoming available only unlocks a test-show-feedback
+   *   button — the feedback itself stays hidden until the candidate navigates
+   *   to it.
    * - `during` — while the test is still in progress, after each instance of
-   *   outcome processing.
+   *   outcome processing. Shows the instant its outcome matches.
    */
   @property({ type: String, attribute: 'access' })
   public access: TestFeedbackAccess = 'atEnd';
@@ -30,6 +39,20 @@ export class QtiTestFeedback extends QtiModalFeedback {
   @consume({ context: testContext, subscribe: true })
   @state()
   private _testContext?: TestContext;
+
+  @consume({ context: sessionContext, subscribe: true })
+  @state()
+  private _sessionContext?: SessionContext;
+
+  /**
+   * For `access="atEnd"`: whether the feedback's outcome has matched and it is
+   * ready to be shown. While available, the feedback stays hidden until a
+   * test-show-feedback button navigates the candidate to it
+   * (`_sessionContext.navFeedbackIdentifier`). `during` feedback ignores this
+   * flag and shows the instant its outcome matches.
+   */
+  @state()
+  private _available = false;
 
   /**
    * Re-evaluate against the *test* context, rather than the item context the
@@ -53,7 +76,40 @@ export class QtiTestFeedback extends QtiModalFeedback {
     }
 
     const matched = this.#outcomeMatches();
-    this.showStatus = (matched && this.showHide === 'show') || (!matched && this.showHide === 'hide') ? 'on' : 'off';
+    const shown = (matched && this.showHide === 'show') || (!matched && this.showHide === 'hide');
+
+    if (this.access === 'during') {
+      this.showStatus = shown ? 'on' : 'off';
+      return;
+    }
+
+    // atEnd: becoming available only unlocks the button; willUpdate derives the
+    // actual showStatus from navigation.
+    this.#setAvailable(shown);
+  }
+
+  /**
+   * Derive atEnd visibility from navigation, and withdraw availability once the
+   * candidate leaves this feedback's own part. Runs on every context tick —
+   * sessionContext changes on every navigation — so it needs no manual
+   * invocation the way checkShowFeedback's outcome re-evaluation does.
+   */
+  protected override willUpdate(_changedProperties: PropertyValues): void {
+    if (this.access !== 'atEnd') return;
+
+    const ownPartId = this.#ownPartId;
+    const activePartId = this._sessionContext?.navPartId ?? null;
+
+    // A part-scoped feedback is the candidate's "end of part" screen; once they
+    // move into another part it should disappear and stop being offered.
+    if (ownPartId && activePartId && activePartId !== ownPartId) {
+      this.#setAvailable(false);
+      this.showStatus = 'off';
+      return;
+    }
+
+    const navTarget = this._sessionContext?.navFeedbackIdentifier ?? null;
+    this.showStatus = this._available && navTarget === this.identifier ? 'on' : 'off';
   }
 
   /** The test part this feedback belongs to, or null when it is test-root feedback. */
@@ -70,6 +126,19 @@ export class QtiTestFeedback extends QtiModalFeedback {
       : !!this.identifier && outcomeVariable.value != null && this.identifier === outcomeVariable.value;
   }
 
+  /** Update availability and announce the change so test-show-feedback can enable. */
+  #setAvailable(available: boolean): void {
+    if (this._available === available) return;
+    this._available = available;
+    this.dispatchEvent(
+      new CustomEvent('qti-test-feedback-availability-changed', {
+        detail: { identifier: this.identifier, partId: this.#ownPartId, available },
+        bubbles: true,
+        composed: true
+      })
+    );
+  }
+
   override render() {
     return html`<div ?hidden=${this.showStatus !== 'on'}><slot></slot></div>`;
   }
@@ -78,5 +147,8 @@ export class QtiTestFeedback extends QtiModalFeedback {
 declare global {
   interface HTMLElementTagNameMap {
     'qti-test-feedback': QtiTestFeedback;
+  }
+  interface GlobalEventHandlersEventMap {
+    'qti-test-feedback-availability-changed': QtiTestFeedbackAvailabilityChangedEvent;
   }
 }

--- a/packages/qti-test/src/components/test-navigation/test-navigation.ts
+++ b/packages/qti-test/src/components/test-navigation/test-navigation.ts
@@ -11,7 +11,8 @@ import { qtiContext } from '@qti-components/base';
 import type { QtiAssessmentItem } from '@qti-components/elements';
 import type { QtiContext } from '@qti-components/base';
 import type { OutcomeVariable } from '@qti-components/base';
-import type { ComputedContext, ComputedItem } from '@qti-components/base';
+import type { ComputedContext, ComputedItem, AvailableFeedback } from '@qti-components/base';
+import type { QtiTestFeedbackAvailabilityChangedEvent } from '../qti-test-feedback/qti-test-feedback';
 import type { PropertyValues } from 'lit';
 import type { QtiAssessmentItemRef } from '../qti-assessment-item-ref/qti-assessment-item-ref';
 import type { QtiAssessmentSection } from '../qti-assessment-section/qti-assessment-section';
@@ -91,6 +92,9 @@ export class TestNavigation extends LitElement {
    */
   #optimality = new Map<string, ItemOptimality>();
 
+  /** atEnd feedbacks that have announced themselves available, keyed by identifier → partId. */
+  #availableFeedbacks = new Map<string, string | null>();
+
   constructor() {
     super();
     this.addEventListener('qti-assessment-test-connected', this.#handleTestConnected.bind(this));
@@ -101,6 +105,32 @@ export class TestNavigation extends LitElement {
 
     this.addEventListener('test-end-attempt', this.#handleTestEndAttempt.bind(this));
     this.addEventListener('test-update-outcome-variable', this.#handleTestUpdateOutcomeVariable.bind(this));
+    this.addEventListener('qti-test-feedback-availability-changed', this.#handleFeedbackAvailabilityChanged.bind(this));
+  }
+
+  /**
+   * Record (or clear) an atEnd feedback's availability and rebuild the computed
+   * context so test-show-feedback can react. Owned here because test-navigation
+   * already provides computedContext to the navigation buttons.
+   */
+  #handleFeedbackAvailabilityChanged(event: QtiTestFeedbackAvailabilityChangedEvent): void {
+    const { identifier, partId, available } = event.detail;
+    if (available) {
+      this.#availableFeedbacks.set(identifier, partId);
+    } else {
+      this.#availableFeedbacks.delete(identifier);
+    }
+    // qti-part-completed/qti-test-completed — announced at the end of this
+    // element's own willUpdate — cascade synchronously through outcome
+    // processing into checkShowFeedback, so this event can arrive while that
+    // willUpdate call is still on the stack. A plain requestUpdate() would be
+    // absorbed into that in-flight cycle, which already read the old list.
+    // Defer to a fresh cycle so computedContext picks up the change.
+    queueMicrotask(() => this.requestUpdate());
+  }
+
+  #availableFeedbacksList(): AvailableFeedback[] {
+    return Array.from(this.#availableFeedbacks, ([identifier, partId]) => ({ identifier, partId }));
   }
 
   /**
@@ -215,6 +245,7 @@ export class TestNavigation extends LitElement {
     this.#optimality.clear();
     this.#endedParts.clear();
     this.#testEnded = false;
+    this.#availableFeedbacks.clear();
     // Set the testIdentifier in qtiContext if not already set
     if (!this.qtiContext.QTI_CONTEXT?.testIdentifier) {
       const currentContext = this.qtiContext.QTI_CONTEXT || {
@@ -423,6 +454,7 @@ export class TestNavigation extends LitElement {
     this.computedContext = {
       ...this.computedContext,
       view: this._sessionContext?.view,
+      availableFeedbacks: this.#availableFeedbacksList(),
       testParts: this.computedContext.testParts.map(testPart => {
         return {
           ...testPart,

--- a/packages/qti-test/src/components/test-navigation/test-navigation.ts
+++ b/packages/qti-test/src/components/test-navigation/test-navigation.ts
@@ -26,6 +26,8 @@ import type { ResponseVariable } from '@qti-components/base';
 
 type CustomEventMap = {
   'test-end-attempt': CustomEvent;
+  'qti-part-completed': CustomEvent<{ partId: string }>;
+  'qti-test-completed': CustomEvent;
 };
 
 declare global {
@@ -74,6 +76,11 @@ export class TestNavigation extends LitElement {
   @property({ type: Boolean, attribute: 'auto-score-items' }) autoScoreItems = false;
 
   #testElement: QtiAssessmentTest;
+
+  /** Test-parts whose end-of-part transition has already been announced. */
+  #endedParts = new Set<string>();
+  /** Whether the end-of-test transition has already been announced. */
+  #testEnded = false;
 
   /**
    * Whether each item's last *ended attempt* reached the optimal outcome, keyed
@@ -204,8 +211,10 @@ export class TestNavigation extends LitElement {
   /* PK: on test connected we can build the computed context */
   #handleTestConnected(event: CustomEvent) {
     this.#testElement = event.detail as QtiAssessmentTest;
-    // A fresh test invalidates the per-test optimality latches.
+    // A fresh test invalidates the per-test optimality and completion latches.
     this.#optimality.clear();
+    this.#endedParts.clear();
+    this.#testEnded = false;
     // Set the testIdentifier in qtiContext if not already set
     if (!this.qtiContext.QTI_CONTEXT?.testIdentifier) {
       const currentContext = this.qtiContext.QTI_CONTEXT || {
@@ -542,6 +551,8 @@ export class TestNavigation extends LitElement {
       })
     };
 
+    this.#announceCompletionTransitions();
+
     this.dispatchEvent(
       new CustomEvent('qti-computed-context-updated', {
         detail: this.computedContext,
@@ -627,6 +638,42 @@ export class TestNavigation extends LitElement {
     if (raw === undefined || raw === null || Array.isArray(raw)) return null;
     const parsed = parseFloat(raw.toString());
     return Number.isNaN(parsed) ? null : parsed;
+  }
+
+  /**
+   * After computedContext has been rebuilt, fire one-shot transition events the
+   * first time each test-part — and the test as a whole — becomes done.
+   * Completion detection belongs here because this element already owns the
+   * per-item view; `test-processing.mixin` listens and runs outcome processing
+   * in response, so `atEnd` feedback gets a chance to evaluate.
+   *
+   * One-shot per test: a part that is done stays done, and re-announcing on
+   * every context rebuild would re-run outcome processing on every keystroke.
+   */
+  #announceCompletionTransitions(): void {
+    const partsWithItems = this.computedContext.testParts.filter(p => p.sections.some(s => s.items.length > 0));
+    for (const part of partsWithItems) {
+      if (this.#endedParts.has(part.identifier)) continue;
+      const allDone = part.sections.flatMap(s => s.items).every((i: ComputedItem) => i.done === true);
+      if (!allDone) continue;
+      this.#endedParts.add(part.identifier);
+      this.dispatchEvent(
+        new CustomEvent('qti-part-completed', {
+          detail: { partId: part.identifier },
+          bubbles: true,
+          composed: true
+        })
+      );
+    }
+
+    if (
+      !this.#testEnded &&
+      partsWithItems.length > 0 &&
+      partsWithItems.every(p => this.#endedParts.has(p.identifier))
+    ) {
+      this.#testEnded = true;
+      this.dispatchEvent(new CustomEvent('qti-test-completed', { bubbles: true, composed: true }));
+    }
   }
 }
 

--- a/packages/qti-test/src/components/test-show-feedback/test-show-feedback.spec.ts
+++ b/packages/qti-test/src/components/test-show-feedback/test-show-feedback.spec.ts
@@ -1,0 +1,122 @@
+import { expect, describe, it, beforeEach, afterEach } from 'vitest';
+
+import '../../register';
+
+import type { TestShowFeedback } from './test-show-feedback';
+import type { ComputedContext } from '@qti-components/base';
+
+const baseContext = (availableFeedbacks: ComputedContext['availableFeedbacks']): ComputedContext => ({
+  view: 'candidate',
+  identifier: 'test',
+  title: 'Test',
+  availableFeedbacks,
+  testParts: []
+});
+
+describe('TestShowFeedback', () => {
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    container.remove();
+  });
+
+  it('should be disabled when there is no computedContext', async () => {
+    const el = document.createElement('test-show-feedback') as TestShowFeedback;
+    container.appendChild(el);
+    await el.updateComplete;
+
+    expect(el).toBeDisabled();
+  });
+
+  it('should be disabled when no feedback is available', async () => {
+    const el = document.createElement('test-show-feedback') as any;
+    container.appendChild(el);
+
+    el.computedContext = baseContext([]);
+    await el.updateComplete;
+
+    expect(el).toBeDisabled();
+  });
+
+  it('should be enabled when a test-root feedback (partId null) is available', async () => {
+    const el = document.createElement('test-show-feedback') as any;
+    container.appendChild(el);
+
+    el.computedContext = baseContext([{ identifier: 'FB_END', partId: null }]);
+    await el.updateComplete;
+
+    expect(el).toBeEnabled();
+  });
+
+  it('should be enabled when an available feedback matches the active test-part', async () => {
+    const el = document.createElement('test-show-feedback') as any;
+    container.appendChild(el);
+
+    el.sessionContext = { navPartId: 'part1' };
+    el.computedContext = baseContext([{ identifier: 'FB_P1', partId: 'part1' }]);
+    await el.updateComplete;
+
+    expect(el).toBeEnabled();
+  });
+
+  it('should be disabled when the available feedback belongs to a different part', async () => {
+    const el = document.createElement('test-show-feedback') as any;
+    container.appendChild(el);
+
+    el.sessionContext = { navPartId: 'part2' };
+    el.computedContext = baseContext([{ identifier: 'FB_P1', partId: 'part1' }]);
+    await el.updateComplete;
+
+    expect(el).toBeDisabled();
+  });
+
+  it('should be disabled while the candidate is already viewing that feedback', async () => {
+    const el = document.createElement('test-show-feedback') as any;
+    container.appendChild(el);
+
+    el.sessionContext = { navFeedbackIdentifier: 'FB_END' };
+    el.computedContext = baseContext([{ identifier: 'FB_END', partId: null }]);
+    await el.updateComplete;
+
+    expect(el).toBeDisabled();
+  });
+
+  it('should dispatch a feedback navigation request with the available identifier on click', async () => {
+    const el = document.createElement('test-show-feedback') as any;
+    container.appendChild(el);
+
+    el.computedContext = baseContext([{ identifier: 'FB_END', partId: null }]);
+    await el.updateComplete;
+
+    let detail: { type: string; id: string } | undefined;
+    el.addEventListener('qti-request-navigation', (e: CustomEvent) => {
+      detail = e.detail;
+    });
+
+    el.click();
+
+    expect(detail).toEqual({ type: 'feedback', id: 'FB_END' });
+  });
+
+  it('should not dispatch navigation when disabled', async () => {
+    const el = document.createElement('test-show-feedback') as any;
+    container.appendChild(el);
+
+    el.computedContext = baseContext([]);
+    await el.updateComplete;
+
+    let fired = false;
+    el.addEventListener('qti-request-navigation', () => {
+      fired = true;
+    });
+
+    el.click();
+
+    expect(fired).toBe(false);
+  });
+});

--- a/packages/qti-test/src/components/test-show-feedback/test-show-feedback.stories.ts
+++ b/packages/qti-test/src/components/test-show-feedback/test-show-feedback.stories.ts
@@ -1,0 +1,83 @@
+import { expect, fireEvent, waitFor } from 'storybook/test';
+import { html } from 'lit';
+import { within } from 'shadow-dom-testing-library';
+import { getStorybookHelpers } from '@wc-toolkit/storybook-helpers';
+
+import type { TestShowFeedback } from './test-show-feedback';
+import type { QtiTest } from '../qti-test/qti-test';
+import type { QtiTestFeedback } from '../qti-test-feedback/qti-test-feedback';
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+
+const { events, args, argTypes, template } = getStorybookHelpers('test-show-feedback');
+
+type Story = StoryObj<TestShowFeedback & typeof args>;
+
+const meta: Meta<TestShowFeedback> = {
+  component: 'test-show-feedback',
+  args,
+  argTypes,
+  parameters: {
+    actions: {
+      handles: events
+    }
+  }
+};
+export default meta;
+
+/**
+ * No conformance asset combines real test-level outcome processing with
+ * qti-test-feedback, so the test document is built inline — an empty section
+ * (nothing to attempt) plus a single `access="atEnd"` feedback whose outcome
+ * the play function sets by hand, the same way qti-test-feedback.spec.ts does.
+ */
+const assessmentTest = (button: unknown) => html`
+  <qti-test navigate="item">
+    <test-navigation>
+      <test-container>
+        <qti-assessment-test xmlns="http://www.imsglobal.org/xsd/imsqtiasi_v3p0" identifier="T1" title="Feedback Demo">
+          <qti-outcome-declaration identifier="FB_TEST" cardinality="single" base-type="identifier">
+          </qti-outcome-declaration>
+          <qti-test-part identifier="P1" navigation-mode="nonlinear" submission-mode="individual">
+            <qti-assessment-section identifier="S1" title="S1" visible="true"> </qti-assessment-section>
+          </qti-test-part>
+          <qti-test-feedback identifier="test-over" outcome-identifier="FB_TEST" access="atEnd" show-hide="show">
+            <p>Great job — you reached the end of the test.</p>
+          </qti-test-feedback>
+          <qti-outcome-processing></qti-outcome-processing>
+        </qti-assessment-test>
+      </test-container>
+      ${button}
+    </test-navigation>
+  </qti-test>
+`;
+
+export const Default: Story = {
+  render: args => assessmentTest(template(args, html`How Did I Do?`))
+};
+
+export const Test: Story = {
+  render: () => assessmentTest(html`<test-show-feedback>How Did I Do?</test-show-feedback>`),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const qtiTest = canvasElement.querySelector('qti-test') as QtiTest;
+    await qtiTest.updateComplete;
+
+    const showFeedbackButton = canvas.getByShadowText('How Did I Do?');
+    const feedback = canvasElement.querySelector<QtiTestFeedback>('qti-test-feedback[identifier="test-over"]');
+    expect(showFeedbackButton).toBeDisabled();
+    expect(feedback?.showStatus).not.toBe('on');
+
+    // The test concludes: its outcome processing names the atEnd feedback.
+    // This makes the feedback *available* — it still does not show yet.
+    qtiTest.updateOutcomeVariable('FB_TEST', 'test-over');
+    qtiTest.outcomeProcessing({ atEnd: true });
+
+    await waitFor(() => expect(showFeedbackButton).toBeEnabled());
+    expect(feedback?.showStatus).not.toBe('on');
+
+    await fireEvent.click(showFeedbackButton);
+
+    await waitFor(() => expect(feedback?.showStatus).toBe('on'));
+    expect(showFeedbackButton).toBeDisabled();
+  }
+};

--- a/packages/qti-test/src/components/test-show-feedback/test-show-feedback.ts
+++ b/packages/qti-test/src/components/test-show-feedback/test-show-feedback.ts
@@ -1,0 +1,105 @@
+import { css, html, LitElement } from 'lit';
+import { property } from 'lit/decorators.js';
+import { consume } from '@lit/context';
+
+import { watch } from '@qti-components/utilities';
+import { computedContext, sessionContext } from '@qti-components/base';
+
+import * as styles from '../styles';
+
+import type { ComputedContext, SessionContext } from '@qti-components/base';
+
+/**
+ * Navigates the candidate to an `access="atEnd"` qti-test-feedback once it has
+ * become available (its end-of-part / end-of-test outcome has matched). The
+ * button is disabled until then, so a host can keep it hidden until enabled.
+ *
+ * Clicking dispatches a `feedback` navigation request, which clears the current
+ * assessment item and shows the feedback. Navigating to any item afterwards (or
+ * moving into a later test-part) hides the feedback again.
+ *
+ * @example
+ * ```html
+ * <test-show-feedback>How Did I Do?</test-show-feedback>
+ * ```
+ */
+export class TestShowFeedback extends LitElement {
+  @property({ type: Boolean, reflect: true, attribute: 'disabled' })
+  public _internalDisabled = true;
+
+  @consume({ context: computedContext, subscribe: true })
+  private computedContext: ComputedContext;
+
+  @consume({ context: sessionContext, subscribe: true })
+  private sessionContext: SessionContext;
+
+  /** Identifier of the feedback to navigate to, set whenever one is available. */
+  #feedbackId: string | null = null;
+
+  @watch('computedContext')
+  _handleComputedContextChange(_oldValue: ComputedContext, newValue: ComputedContext) {
+    if (newValue) this.requestUpdate();
+  }
+
+  static override styles = css`
+    :host {
+      ${styles.btn};
+    }
+    :host([disabled]) {
+      ${styles.dis};
+    }
+  `;
+
+  #internals: ElementInternals;
+
+  constructor() {
+    super();
+
+    this.#internals = this.attachInternals();
+    this.#internals.role = 'button';
+    this.#internals.ariaLabel = 'Show feedback';
+
+    this.addEventListener('click', e => {
+      e.preventDefault();
+      if (!this._internalDisabled && this.#feedbackId) this._requestFeedback(this.#feedbackId);
+    });
+  }
+
+  override willUpdate(_changedProperties: Map<string | number | symbol, unknown>) {
+    // The relevant feedback is one available for the active test-part, or a
+    // test-root feedback (partId null) shown at the end of the whole test.
+    const activePartId = this.sessionContext?.navPartId ?? null;
+    const candidate = this.computedContext?.availableFeedbacks?.find(
+      fb => fb.partId === null || fb.partId === activePartId
+    );
+
+    this.#feedbackId = candidate?.identifier ?? null;
+    // Disabled with no feedback to offer, or while the candidate is already
+    // viewing that feedback — there is nowhere new to navigate.
+    const alreadyViewing = this.#feedbackId === (this.sessionContext?.navFeedbackIdentifier ?? null);
+    this._internalDisabled = !this.#feedbackId || alreadyViewing;
+  }
+
+  protected _requestFeedback(identifier: string): void {
+    this.dispatchEvent(
+      new CustomEvent('qti-request-navigation', {
+        composed: true,
+        bubbles: true,
+        detail: {
+          type: 'feedback',
+          id: identifier
+        }
+      })
+    );
+  }
+
+  override render() {
+    return html`<slot></slot>`;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'test-show-feedback': TestShowFeedback;
+  }
+}

--- a/packages/qti-test/src/elements.ts
+++ b/packages/qti-test/src/elements.ts
@@ -30,6 +30,7 @@ import { TestScoringButtons } from './components/test-scoring-buttons/test-scori
 import { TestScoringFeedback } from './components/test-scoring-feedback/test-scoring-feedback';
 import { TestSectionButtonsStamp } from './components/test-section-buttons-stamp/test-section-buttons-stamp';
 import { TestSectionLink } from './components/test-section-link/test-section-link';
+import { TestShowFeedback } from './components/test-show-feedback/test-show-feedback';
 import { TestStamp } from './components/test-stamp/test-stamp';
 import { TestView } from './components/test-view-toggle/test-view';
 import { TestViewToggle } from './components/test-view-toggle/test-view-toggle';
@@ -59,6 +60,7 @@ export {
   TestScoringFeedback,
   TestSectionButtonsStamp,
   TestSectionLink,
+  TestShowFeedback,
   TestStamp,
   TestTtsNext,
   TestTtsPause,
@@ -95,6 +97,7 @@ export const qtiTestElements = [
   { tag: 'test-scoring-feedback', ctor: TestScoringFeedback },
   { tag: 'test-section-buttons-stamp', ctor: TestSectionButtonsStamp },
   { tag: 'test-section-link', ctor: TestSectionLink },
+  { tag: 'test-show-feedback', ctor: TestShowFeedback },
   { tag: 'test-stamp', ctor: TestStamp },
   { tag: 'test-tts-next', ctor: TestTtsNext },
   { tag: 'test-tts-pause', ctor: TestTtsPause },

--- a/packages/qti-test/src/mixins/test-navigation.mixin.ts
+++ b/packages/qti-test/src/mixins/test-navigation.mixin.ts
@@ -52,7 +52,7 @@ export interface ITestNavigationMixin {
   requestTimeout: number;
   postLoadTransformCallback: PostLoadTransformCallback | null;
   postLoadTestTransformCallback: PostLoadTestTransformCallback | null;
-  navigateTo(type: 'item' | 'section', id?: string): void;
+  navigateTo(type: 'item' | 'section' | 'feedback', id?: string): void;
   getLoadingProgress(): {
     expectedItems: number;
     connectedItems: number;
@@ -108,12 +108,12 @@ export const TestNavigationMixin = <T extends Constructor<TestBaseInterface>>(su
     // ===========================================
 
     /**
-     * Navigate to a specific item or section
-     * @param type - Navigation type ('item' or 'section')
-     * @param id - Target identifier (optional, falls back to first available)
+     * Navigate to a specific item, section, or test-feedback
+     * @param type - Navigation type ('item', 'section' or 'feedback')
+     * @param id - Target identifier (optional for item/section, required for feedback)
      */
-    public navigateTo(type: 'item' | 'section', id?: string): void {
-      const targetId = id || this._getDefaultNavigationId(type);
+    public navigateTo(type: 'item' | 'section' | 'feedback', id?: string): void {
+      const targetId = id || (type === 'feedback' ? undefined : this._getDefaultNavigationId(type));
 
       if (targetId) {
         this.dispatchEvent(
@@ -273,8 +273,17 @@ export const TestNavigationMixin = <T extends Constructor<TestBaseInterface>>(su
     /**
      * Main navigation request handler with proper lifecycle management
      */
-    private async _handleNavigationRequest({ detail }: CustomEvent<{ type: 'item' | 'section'; id: string }>) {
+    private async _handleNavigationRequest({
+      detail
+    }: CustomEvent<{ type: 'item' | 'section' | 'feedback'; id: string }>) {
       if (!detail?.id) return;
+
+      // Feedback isn't an item in the linear sequence — it's the candidate's
+      // end-of-part/test review screen, always reachable once available.
+      if (detail.type === 'feedback') {
+        this._navigateToFeedback(detail.id);
+        return;
+      }
 
       if (this._isLinearNavigationRestricted(detail.type, detail.id)) {
         this._handleNavigationError(new Error('Navigation restricted in linear mode'), detail.type, detail.id);
@@ -337,6 +346,23 @@ export const TestNavigationMixin = <T extends Constructor<TestBaseInterface>>(su
     }
 
     /**
+     * Navigate to a test-feedback: clear the on-screen item (so the candidate
+     * leaves the assessment item) and record which feedback is now showing. The
+     * item/part context is kept so test-prev/test-next can navigate back and the
+     * feedback's own part-scoping keeps working. Navigating to any item/section
+     * later clears navFeedbackIdentifier, which hides the feedback again.
+     */
+    private _navigateToFeedback(feedbackId: string): void {
+      this._clearLoadedItems();
+      this._clearStimulusRef();
+
+      this.sessionContext = {
+        ...this.sessionContext,
+        navFeedbackIdentifier: feedbackId
+      };
+    }
+
+    /**
      * Navigate to section with simple state tracking
      */
     private async _navigateToSection(
@@ -351,7 +377,8 @@ export const TestNavigationMixin = <T extends Constructor<TestBaseInterface>>(su
         ...this.sessionContext,
         navPartId,
         navSectionId: sectionId,
-        navItemRefId: null
+        navItemRefId: null,
+        navFeedbackIdentifier: null
       };
 
       const itemIds = this._getSectionItemIds(sectionId);
@@ -614,7 +641,8 @@ export const TestNavigationMixin = <T extends Constructor<TestBaseInterface>>(su
         ...this.sessionContext,
         navPartId,
         navSectionId,
-        navItemRefId: itemId
+        navItemRefId: itemId,
+        navFeedbackIdentifier: null
       };
     }
 

--- a/packages/qti-test/src/mixins/test-processing.mixin.ts
+++ b/packages/qti-test/src/mixins/test-processing.mixin.ts
@@ -8,7 +8,7 @@ declare class TestProcessingInterface {
   updateOutcomeVariable(identifier: string, value: string | string[] | undefined): void;
   getOutcome(identifier: string): Readonly<OutcomeVariable>;
   getVariable(identifier: string): Readonly<VariableDeclaration<string | string[] | null>>;
-  outcomeProcessing(): boolean;
+  outcomeProcessing(options?: { atEnd?: boolean; partId?: string }): boolean;
 }
 export const TestProcessingMixin = <T extends Constructor<TestBaseInterface>>(superClass: T) => {
   abstract class TestProcessingElement extends superClass implements TestProcessingInterface {
@@ -30,12 +30,39 @@ export const TestProcessingMixin = <T extends Constructor<TestBaseInterface>>(su
           e.stopPropagation();
         }
       );
+
+      // Completion detection lives in test-navigation, which already owns the
+      // per-item view through computedContext. Here we only run outcome
+      // processing when it reports that a part, or the test, has just become
+      // done — which is what gives `atEnd` feedback its chance to evaluate.
+      this.addEventListener('qti-part-completed', (e: CustomEvent<{ partId: string }>) => {
+        this.outcomeProcessing({ atEnd: true, partId: e.detail.partId });
+      });
+      this.addEventListener('qti-test-completed', () => {
+        this.outcomeProcessing({ atEnd: true });
+      });
     }
 
-    outcomeProcessing(): boolean {
-      const outcomeProcessor = this.querySelector('qti-outcome-processing') as unknown as QtiOutcomeProcessing;
+    outcomeProcessing(options: { atEnd?: boolean; partId?: string } = {}): boolean {
+      const outcomeProcessor = this._testElement?.querySelector<QtiOutcomeProcessing>('qti-outcome-processing');
       if (!outcomeProcessor) return false;
-      outcomeProcessor?.process();
+      outcomeProcessor.process();
+
+      // Dispatched from _testElement so qti-assessment-test is the target and
+      // qti-test still sees it by bubbling.
+      //
+      // `atEnd` separates the conclusion-of-test run, which is what
+      // qti-test-feedback access="atEnd" waits for, from in-flight runs.
+      // `partId` scopes which feedback re-evaluates: with one, only feedback
+      // inside the matching qti-test-part; without, only test-root feedback.
+      const target = this._testElement ?? this;
+      target.dispatchEvent(
+        new CustomEvent('qti-test-outcome-changed', {
+          detail: { atEnd: options.atEnd === true, partId: options.partId ?? null },
+          bubbles: true,
+          composed: true
+        })
+      );
       return true;
     }
 


### PR DESCRIPTION
Updated — this PR now carries the `test-show-feedback` button as a second commit, so it covers both halves of the test-feedback story.

The second commit revises the `atEnd` semantics the first one introduced. Concluding a scope now makes an `atEnd` feedback *available* rather than presenting it; the candidate reaches it through a new `<test-show-feedback>` button. A host without that button never shows `atEnd` feedback. `during` feedback is unchanged — it still shows the instant its outcome matches.

What the button slice adds:

- `SessionContext.navFeedbackIdentifier` — which `atEnd` feedback is on screen, or null.
- `ComputedContext.availableFeedbacks` (`{ identifier, partId }[]`), built by `test-navigation` from a new `qti-test-feedback-availability-changed` event that `qti-test-feedback` dispatches when its own availability flips.
- `qti-test-feedback` derives `atEnd` visibility from navigation (available && `navFeedbackIdentifier` matches its identifier) and withdraws availability once the candidate leaves its own test part.
- `test-navigation.mixin` understands a `feedback` navigation type alongside `item`/`section`, via `_navigateToFeedback`, which clears the on-screen item and records the shown feedback. Navigating to any item or section clears `navFeedbackIdentifier` again.
- `<test-show-feedback>` enables once a feedback is available for the active part (or a test-root feedback) and disables again while the candidate is already viewing it.

Registration goes through `elements.ts` and the components barrel, matching the rest of the package — no decorator-based registration.

On testing: the `atEnd` cases in `qti-test-feedback.spec.ts` were rewritten first to the available-then-navigate-then-shown sequence and confirmed failing against the unrevised navigation mixin before the implementation went in. The part-vs-test scoping case also asserts that a wrong-scope feedback never becomes available, so navigating to it cannot show it. There is a dedicated spec for the button, plus Storybook coverage for both `qti-test-feedback` and `test-show-feedback` — those build the test document inline, since no conformance asset combines test-level outcome processing with test feedback.

The third commit harmonises the two changesets so the release notes describe the button-gated behaviour consistently.

`qti-corrections` is unaffected: `TestNavigationCorrection` overrides only `afterAttemptEnded`, so it inherits the additive `test-navigation` changes untouched, and its suite passes unchanged.