### PR TITLE
fix(msw): stop reformatting the generated worker

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -13,3 +13,7 @@ QTI-Components.code-workspace
 
 # Justfile uses tab-indented recipe bodies; prettier strips them
 Justfile
+
+# Written by msw's postinstall on every install, in msw's own style, and asks not
+# to be modified. Formatting it makes every subsequent install dirty the tree.
+public/mockServiceWorker.js

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,14 @@
 - Type check: `pnpm tsc`
 - Lint: `pnpm lint`
 
+## Committed Generated Files
+
+`public/mockServiceWorker.js` is written by msw's postinstall on every `pnpm install`, in msw's
+own style, and is committed byte-for-byte as msw produces it — `.prettierignore` lists it so
+nothing reformats it. Commit whatever `pnpm install` writes and never tidy it by hand: a diff
+there means the msw version moved, and a reformatted copy makes every subsequent install dirty
+the working tree.
+
 ## Coding And Testing Defaults
 
 - Prefer small, focused changes with clear file-level intent.

--- a/custom-elements.json
+++ b/custom-elements.json
@@ -16495,7 +16495,7 @@
                 "text": "any[] | NodeListOf<QtiAssociableHotspot>"
               },
               "parsedType": {
-                "text": "any[] | { item: {  }, forEach: {  }, entries: {  }, keys: {  }, values: {  }, __@iterator@360: {  }, length: number }"
+                "text": "any[] | { item: {  }, forEach: {  }, entries: {  }, keys: {  }, values: {  }, __@iterator@549: {  }, length: number }"
               }
             },
             {

--- a/public/mockServiceWorker.js
+++ b/public/mockServiceWorker.js
@@ -7,42 +7,42 @@
  * - Please do NOT modify this file.
  */
 
-const PACKAGE_VERSION = '2.15.0';
-const INTEGRITY_CHECKSUM = '03cb67ac84128e63d7cd722a6e5b7f1e';
-const IS_MOCKED_RESPONSE = Symbol('isMockedResponse');
-const activeClientIds = new Set();
+const PACKAGE_VERSION = '2.15.0'
+const INTEGRITY_CHECKSUM = '03cb67ac84128e63d7cd722a6e5b7f1e'
+const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
+const activeClientIds = new Set()
 
 addEventListener('install', function () {
-  self.skipWaiting();
-});
+  self.skipWaiting()
+})
 
 addEventListener('activate', function (event) {
-  event.waitUntil(self.clients.claim());
-});
+  event.waitUntil(self.clients.claim())
+})
 
 addEventListener('message', async function (event) {
-  const clientId = Reflect.get(event.source || {}, 'id');
+  const clientId = Reflect.get(event.source || {}, 'id')
 
   if (!clientId || !self.clients) {
-    return;
+    return
   }
 
-  const client = await self.clients.get(clientId);
+  const client = await self.clients.get(clientId)
 
   if (!client) {
-    return;
+    return
   }
 
   const allClients = await self.clients.matchAll({
-    type: 'window'
-  });
+    type: 'window',
+  })
 
   switch (event.data) {
     case 'KEEPALIVE_REQUEST': {
       sendToClient(client, {
-        type: 'KEEPALIVE_RESPONSE'
-      });
-      break;
+        type: 'KEEPALIVE_RESPONSE',
+      })
+      break
     }
 
     case 'INTEGRITY_CHECK_REQUEST': {
@@ -50,68 +50,71 @@ addEventListener('message', async function (event) {
         type: 'INTEGRITY_CHECK_RESPONSE',
         payload: {
           packageVersion: PACKAGE_VERSION,
-          checksum: INTEGRITY_CHECKSUM
-        }
-      });
-      break;
+          checksum: INTEGRITY_CHECKSUM,
+        },
+      })
+      break
     }
 
     case 'MOCK_ACTIVATE': {
-      activeClientIds.add(clientId);
+      activeClientIds.add(clientId)
 
       sendToClient(client, {
         type: 'MOCKING_ENABLED',
         payload: {
           client: {
             id: client.id,
-            frameType: client.frameType
-          }
-        }
-      });
-      break;
+            frameType: client.frameType,
+          },
+        },
+      })
+      break
     }
 
     case 'CLIENT_CLOSED': {
-      activeClientIds.delete(clientId);
+      activeClientIds.delete(clientId)
 
-      const remainingClients = allClients.filter(client => {
-        return client.id !== clientId;
-      });
+      const remainingClients = allClients.filter((client) => {
+        return client.id !== clientId
+      })
 
       // Unregister itself when there are no more clients
       if (remainingClients.length === 0) {
-        self.registration.unregister();
+        self.registration.unregister()
       }
 
-      break;
+      break
     }
   }
-});
+})
 
 addEventListener('fetch', function (event) {
-  const requestInterceptedAt = Date.now();
+  const requestInterceptedAt = Date.now()
 
   // Bypass navigation requests.
   if (event.request.mode === 'navigate') {
-    return;
+    return
   }
 
   // Opening the DevTools triggers the "only-if-cached" request
   // that cannot be handled by the worker. Bypass such requests.
-  if (event.request.cache === 'only-if-cached' && event.request.mode !== 'same-origin') {
-    return;
+  if (
+    event.request.cache === 'only-if-cached' &&
+    event.request.mode !== 'same-origin'
+  ) {
+    return
   }
 
   // Bypass all requests when there are no active clients.
   // Prevents the self-unregistered worked from handling requests
   // after it's been terminated (still remains active until the next reload).
   if (activeClientIds.size === 0) {
-    return;
+    return
   }
 
-  const requestId = crypto.randomUUID();
-  event.respondWith(handleRequest(event, requestId, requestInterceptedAt));
-});
+  const requestId = crypto.randomUUID()
+  event.respondWith(handleRequest(event, requestId, requestInterceptedAt))
+})
 
 /**
  * @param {FetchEvent} event
@@ -119,25 +122,33 @@ addEventListener('fetch', function (event) {
  * @param {number} requestInterceptedAt
  */
 async function handleRequest(event, requestId, requestInterceptedAt) {
-  const client = await resolveMainClient(event);
-  const requestCloneForEvents = event.request.clone();
-  const response = await getResponse(event, client, requestId, requestInterceptedAt);
+  const client = await resolveMainClient(event)
+  const requestCloneForEvents = event.request.clone()
+  const response = await getResponse(
+    event,
+    client,
+    requestId,
+    requestInterceptedAt,
+  )
 
   // Send back the response clone for the "response:*" life-cycle events.
   // Ensure MSW is active and ready to handle the message, otherwise
   // this message will pend indefinitely.
   if (client && activeClientIds.has(client.id)) {
-    const serializedRequest = await serializeRequest(requestCloneForEvents);
+    const serializedRequest = await serializeRequest(requestCloneForEvents)
 
     // Omit the body of server-sent event stream responses.
     // Cloning such responses would prevent client-side stream cancelations
     // from reaching the original stream (a teed stream only cancels its
     // source once both of its branches cancel) and would buffer the
     // entire stream into the unconsumed clone indefinitely.
-    const isEventStreamResponse = response.headers.get('content-type')?.toLowerCase().startsWith('text/event-stream');
+    const isEventStreamResponse = response.headers
+      .get('content-type')
+      ?.toLowerCase()
+      .startsWith('text/event-stream')
 
     // Clone the response so both the client and the library could consume it.
-    const responseClone = isEventStreamResponse ? null : response.clone();
+    const responseClone = isEventStreamResponse ? null : response.clone()
 
     sendToClient(
       client,
@@ -147,22 +158,24 @@ async function handleRequest(event, requestId, requestInterceptedAt) {
           isMockedResponse: IS_MOCKED_RESPONSE in response,
           request: {
             id: requestId,
-            ...serializedRequest
+            ...serializedRequest,
           },
           response: {
             type: response.type,
             status: response.status,
             statusText: response.statusText,
             headers: Object.fromEntries(response.headers.entries()),
-            body: responseClone ? responseClone.body : null
-          }
-        }
+            body: responseClone ? responseClone.body : null,
+          },
+        },
       },
-      responseClone && responseClone.body ? [serializedRequest.body, responseClone.body] : []
-    );
+      responseClone && responseClone.body
+        ? [serializedRequest.body, responseClone.body]
+        : [],
+    )
   }
 
-  return response;
+  return response
 }
 
 /**
@@ -174,30 +187,30 @@ async function handleRequest(event, requestId, requestInterceptedAt) {
  * @returns {Promise<Client | undefined>}
  */
 async function resolveMainClient(event) {
-  const client = await self.clients.get(event.clientId);
+  const client = await self.clients.get(event.clientId)
 
   if (activeClientIds.has(event.clientId)) {
-    return client;
+    return client
   }
 
   if (client?.frameType === 'top-level') {
-    return client;
+    return client
   }
 
   const allClients = await self.clients.matchAll({
-    type: 'window'
-  });
+    type: 'window',
+  })
 
   return allClients
-    .filter(client => {
+    .filter((client) => {
       // Get only those clients that are currently visible.
-      return client.visibilityState === 'visible';
+      return client.visibilityState === 'visible'
     })
-    .find(client => {
+    .find((client) => {
       // Find the client ID that's recorded in the
       // set of clients that have registered the worker.
-      return activeClientIds.has(client.id);
-    });
+      return activeClientIds.has(client.id)
+    })
 }
 
 /**
@@ -210,34 +223,36 @@ async function resolveMainClient(event) {
 async function getResponse(event, client, requestId, requestInterceptedAt) {
   // Clone the request because it might've been already used
   // (i.e. its body has been read and sent to the client).
-  const requestClone = event.request.clone();
+  const requestClone = event.request.clone()
 
   function passthrough() {
     // Cast the request headers to a new Headers instance
     // so the headers can be manipulated with.
-    const headers = new Headers(requestClone.headers);
+    const headers = new Headers(requestClone.headers)
 
     // Remove the "accept" header value that marked this request as passthrough.
     // This prevents request alteration and also keeps it compliant with the
     // user-defined CORS policies.
-    const acceptHeader = headers.get('accept');
+    const acceptHeader = headers.get('accept')
     if (acceptHeader) {
-      const values = acceptHeader.split(',').map(value => value.trim());
-      const filteredValues = values.filter(value => value !== 'msw/passthrough');
+      const values = acceptHeader.split(',').map((value) => value.trim())
+      const filteredValues = values.filter(
+        (value) => value !== 'msw/passthrough',
+      )
 
       if (filteredValues.length > 0) {
-        headers.set('accept', filteredValues.join(', '));
+        headers.set('accept', filteredValues.join(', '))
       } else {
-        headers.delete('accept');
+        headers.delete('accept')
       }
     }
 
-    return fetch(requestClone, { headers });
+    return fetch(requestClone, { headers })
   }
 
   // Bypass mocking when the client is not active.
   if (!client) {
-    return passthrough();
+    return passthrough()
   }
 
   // Bypass initial page load requests (i.e. static assets).
@@ -245,11 +260,11 @@ async function getResponse(event, client, requestId, requestInterceptedAt) {
   // means that MSW hasn't dispatched the "MOCK_ACTIVATE" event yet
   // and is not ready to handle requests.
   if (!activeClientIds.has(client.id)) {
-    return passthrough();
+    return passthrough()
   }
 
   // Notify the client that a request has been intercepted.
-  const serializedRequest = await serializeRequest(event.request);
+  const serializedRequest = await serializeRequest(event.request)
   const clientMessage = await sendToClient(
     client,
     {
@@ -257,23 +272,23 @@ async function getResponse(event, client, requestId, requestInterceptedAt) {
       payload: {
         id: requestId,
         interceptedAt: requestInterceptedAt,
-        ...serializedRequest
-      }
+        ...serializedRequest,
+      },
     },
-    [serializedRequest.body]
-  );
+    [serializedRequest.body],
+  )
 
   switch (clientMessage.type) {
     case 'MOCK_RESPONSE': {
-      return respondWithMock(clientMessage.data);
+      return respondWithMock(clientMessage.data)
     }
 
     case 'PASSTHROUGH': {
-      return passthrough();
+      return passthrough()
     }
   }
 
-  return passthrough();
+  return passthrough()
 }
 
 /**
@@ -284,18 +299,21 @@ async function getResponse(event, client, requestId, requestInterceptedAt) {
  */
 function sendToClient(client, message, transferrables = []) {
   return new Promise((resolve, reject) => {
-    const channel = new MessageChannel();
+    const channel = new MessageChannel()
 
-    channel.port1.onmessage = event => {
+    channel.port1.onmessage = (event) => {
       if (event.data && event.data.error) {
-        return reject(event.data.error);
+        return reject(event.data.error)
       }
 
-      resolve(event.data);
-    };
+      resolve(event.data)
+    }
 
-    client.postMessage(message, [channel.port2, ...transferrables.filter(Boolean)]);
-  });
+    client.postMessage(message, [
+      channel.port2,
+      ...transferrables.filter(Boolean),
+    ])
+  })
 }
 
 /**
@@ -308,17 +326,17 @@ function respondWithMock(response) {
   // instance will have status code set to 0. Since it's not possible to create
   // a Response instance with status code 0, handle that use-case separately.
   if (response.status === 0) {
-    return Response.error();
+    return Response.error()
   }
 
-  const mockedResponse = new Response(response.body, response);
+  const mockedResponse = new Response(response.body, response)
 
   Reflect.defineProperty(mockedResponse, IS_MOCKED_RESPONSE, {
     value: true,
-    enumerable: true
-  });
+    enumerable: true,
+  })
 
-  return mockedResponse;
+  return mockedResponse
 }
 
 /**
@@ -338,6 +356,6 @@ async function serializeRequest(request) {
     referrer: request.referrer,
     referrerPolicy: request.referrerPolicy,
     body: await request.arrayBuffer(),
-    keepalive: request.keepalive
-  };
+    keepalive: request.keepalive,
+  }
 }


### PR DESCRIPTION
msw postinstall rewrites public/mockServiceWorker.js on every pnpm install, in msw own semicolon-less style. The committed copy is run through prettier, so every install leaves the working tree dirty and every contributor has to remember not to stage the file.

Ignore the worker in .prettierignore and commit it exactly as msw generates it, which is how msw asks for it to be treated ("Please do NOT modify this file").

The diff is formatting only. PACKAGE_VERSION (2.15.0) and INTEGRITY_CHECKSUM (03cb67ac84128e63d7cd722a6e5b7f1e) are unchanged, and running prettier over msw output reproduces the previously committed file byte for byte — verified both directions before making the swap.

eslint already ignores public/**, and lint-staged prettier --write honours .prettierignore for explicitly named paths, so nothing reformats the file at commit time either.