### PR TITLE
feat(corrections)!: make /corrections a drop-in alternative to the package root

### DIFF
--- a/.changeset/corrections-entry-point.md
+++ b/.changeset/corrections-entry-point.md
@@ -1,0 +1,19 @@
+---
+'@citolab/qti-components': major
+---
+
+`@citolab/qti-components/corrections` is now a drop-in alternative to the package root. Where the root registers the standard delivery elements, this registers the same set with the correction variants substituted for the tags they cover, plus the correction-only controls:
+
+```html
+<script type="module">
+  import '@citolab/qti-components/corrections';
+</script>
+```
+
+Elements without a correction variant — the processing operators, most test controls, interactions like media and upload — still get their standard constructor, so the page works as a whole.
+
+**Breaking:** that subpath previously only re-exported `@qti-components/corrections` and registered nothing. It still exports everything it did, but importing it now defines custom elements. Anything importing it purely for the mixins, types or constructors should move to the package root.
+
+Importing `@citolab/qti-components` is unchanged.
+
+Registration is first-wins and silently so — every `register.ts` guards with `if (!customElements.get(tag))` — so importing both entry points leaves the correction variants inactive with no error. The corrections entry detects that and warns, naming the tags it could not claim.

--- a/custom-elements.json
+++ b/custom-elements.json
@@ -16495,7 +16495,7 @@
                 "text": "any[] | NodeListOf<QtiAssociableHotspot>"
               },
               "parsedType": {
-                "text": "any[] | { item: {  }, forEach: {  }, entries: {  }, keys: {  }, values: {  }, __@iterator@360: {  }, length: number }"
+                "text": "any[] | { item: {  }, forEach: {  }, entries: {  }, keys: {  }, values: {  }, __@iterator@516: {  }, length: number }"
               }
             },
             {
@@ -47559,6 +47559,78 @@
     },
     {
       "kind": "javascript-module",
+      "path": "packages/qti-processing/src/components/qti-printed-variable/printed-variable-format.ts",
+      "declarations": [
+        {
+          "kind": "function",
+          "name": "applyFormat",
+          "return": {
+            "type": {
+              "text": "string"
+            }
+          },
+          "parameters": [
+            {
+              "name": "format",
+              "type": {
+                "text": "string"
+              }
+            },
+            {
+              "name": "value",
+              "type": {
+                "text": "string"
+              }
+            }
+          ],
+          "description": "Renders `value` through a QTI `format` string. The value is passed as the raw string held in\nthe item context, so integers and floats arrive as `\"5\"` / `\"3.14\"` and are coerced per\nconversion."
+        },
+        {
+          "kind": "function",
+          "name": "toExponential",
+          "return": {
+            "type": {
+              "text": "string"
+            }
+          },
+          "parameters": [
+            {
+              "name": "value",
+              "type": {
+                "text": "number"
+              }
+            },
+            {
+              "name": "precision",
+              "optional": true,
+              "type": {
+                "text": "number"
+              }
+            }
+          ]
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "applyFormat",
+          "declaration": {
+            "name": "applyFormat",
+            "module": "packages/qti-processing/src/components/qti-printed-variable/printed-variable-format.ts"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "toExponential",
+          "declaration": {
+            "name": "toExponential",
+            "module": "packages/qti-processing/src/components/qti-printed-variable/printed-variable-format.ts"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
       "path": "packages/qti-processing/src/components/qti-printed-variable/qti-printed-variable.ts",
       "declarations": [
         {
@@ -47566,6 +47638,59 @@
           "description": "",
           "name": "QtiPrintedVariable",
           "members": [
+            {
+              "kind": "method",
+              "name": "#print",
+              "privacy": "private",
+              "return": {
+                "type": {
+                  "text": "string | null"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "variable",
+                  "type": {
+                    "text": "VariableDeclaration<unknown>"
+                  }
+                }
+              ],
+              "description": "Returns `null` for anything QTI treats as NULL, which prints as nothing."
+            },
+            {
+              "kind": "method",
+              "name": "#printValue",
+              "privacy": "private",
+              "return": {
+                "type": {
+                  "text": "string"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "value",
+                  "type": {
+                    "text": "unknown"
+                  }
+                },
+                {
+                  "name": "baseType",
+                  "optional": true,
+                  "type": {
+                    "text": "BaseType"
+                  }
+                }
+              ]
+            },
+            {
+              "kind": "field",
+              "name": "base",
+              "type": {
+                "text": "number"
+              },
+              "default": "10",
+              "attribute": "base"
+            },
             {
               "kind": "method",
               "name": "calculate",
@@ -47589,26 +47714,162 @@
             },
             {
               "kind": "field",
+              "name": "delimiter",
+              "type": {
+                "text": "string"
+              },
+              "default": "';'",
+              "attribute": "delimiter"
+            },
+            {
+              "kind": "field",
+              "name": "field",
+              "type": {
+                "text": "string | undefined"
+              },
+              "attribute": "field",
+              "parsedType": {
+                "text": "string"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "format",
+              "type": {
+                "text": "string | undefined"
+              },
+              "attribute": "format",
+              "parsedType": {
+                "text": "string"
+              }
+            },
+            {
+              "kind": "field",
               "name": "identifier",
               "type": {
                 "text": "string"
               },
               "attribute": "identifier"
+            },
+            {
+              "kind": "field",
+              "name": "index",
+              "type": {
+                "text": "number | undefined"
+              },
+              "attribute": "index",
+              "parsedType": {
+                "text": "number"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "mappingIndicator",
+              "type": {
+                "text": "string"
+              },
+              "default": "'='",
+              "attribute": "mapping-indicator"
+            },
+            {
+              "kind": "field",
+              "name": "powerForm",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "attribute": "power-form"
             }
           ],
           "attributes": [
             {
-              "name": "identifier",
               "type": {
                 "text": "string"
               },
+              "name": ""
+            },
+            {
+              "type": {
+                "text": "number"
+              },
+              "description": "Number base used when printing an integer variable.",
+              "name": "base",
+              "default": "10",
+              "fieldName": "base"
+            },
+            {
+              "type": {
+                "text": "string"
+              },
+              "description": "Separator between the values of an ordered/multiple/record variable.",
+              "name": "delimiter",
+              "default": "';'",
+              "fieldName": "delimiter"
+            },
+            {
+              "type": {
+                "text": "string | undefined"
+              },
+              "description": "Field of a record variable to print, instead of the whole record.",
+              "name": "field",
+              "fieldName": "field",
+              "parsedType": {
+                "text": "string"
+              }
+            },
+            {
+              "type": {
+                "text": "string | undefined"
+              },
+              "description": "printf-style conversion string, e.g. `%.2f` or `Score: %d`. Applies to each value printed. Takes precedence over `base` and `power-form`.",
+              "name": "format",
+              "fieldName": "format",
+              "parsedType": {
+                "text": "string"
+              }
+            },
+            {
+              "type": {
+                "text": "string"
+              },
+              "description": "Required. Identifier of the variable to print.",
+              "name": "identifier",
               "fieldName": "identifier"
+            },
+            {
+              "type": {
+                "text": "number | undefined"
+              },
+              "description": "1-based index selecting a single value of an ordered variable.",
+              "name": "index",
+              "fieldName": "index",
+              "parsedType": {
+                "text": "number"
+              }
+            },
+            {
+              "name": "mapping-indicator",
+              "type": {
+                "text": "string"
+              },
+              "default": "'='",
+              "fieldName": "mappingIndicator"
+            },
+            {
+              "type": {
+                "text": "boolean"
+              },
+              "description": "Print numeric values in exponential form.",
+              "name": "power-form",
+              "default": "false",
+              "fieldName": "powerForm"
             }
           ],
           "superclass": {
             "name": "LitElement",
             "package": "lit"
           },
+          "summary": "Prints the value of an item variable into the item body.",
           "customElement": true,
           "modulePath": "packages/qti-processing/src/components/qti-printed-variable/qti-printed-variable.ts",
           "definitionPath": "packages/qti-processing/src/components/qti-printed-variable/qti-printed-variable.ts",

--- a/packages/qti-components/custom-elements.json
+++ b/packages/qti-components/custom-elements.json
@@ -2117,9 +2117,9 @@
             "package": "lit"
           },
           "customElement": true,
-          "tagName": "qti-associable-hotspot",
           "modulePath": "packages/interactions/core/src/elements/qti-associable-hotspot/qti-associable-hotspot.ts",
-          "definitionPath": "packages/interactions/core/src/elements/qti-associable-hotspot/qti-associable-hotspot.ts"
+          "definitionPath": "packages/interactions/core/src/elements/qti-associable-hotspot/qti-associable-hotspot.ts",
+          "tagName": "qti-associable-hotspot"
         }
       ],
       "exports": [
@@ -2253,9 +2253,9 @@
             "package": "lit"
           },
           "customElement": true,
-          "tagName": "qti-gap-img",
           "modulePath": "packages/interactions/core/src/elements/qti-gap-img/qti-gap-img.ts",
-          "definitionPath": "packages/interactions/core/src/elements/qti-gap-img/qti-gap-img.ts"
+          "definitionPath": "packages/interactions/core/src/elements/qti-gap-img/qti-gap-img.ts",
+          "tagName": "qti-gap-img"
         }
       ],
       "exports": [
@@ -3280,9 +3280,9 @@
               "name": ""
             }
           ],
-          "tagName": "qti-hotspot-choice",
           "modulePath": "packages/interactions/core/src/elements/qti-hotspot-choice/qti-hotspot-choice.ts",
-          "definitionPath": "packages/interactions/core/src/elements/qti-hotspot-choice/qti-hotspot-choice.ts"
+          "definitionPath": "packages/interactions/core/src/elements/qti-hotspot-choice/qti-hotspot-choice.ts",
+          "tagName": "qti-hotspot-choice"
         }
       ],
       "exports": [
@@ -4158,9 +4158,9 @@
             "package": "lit"
           },
           "customElement": true,
-          "tagName": "qti-prompt",
           "modulePath": "packages/interactions/core/src/elements/qti-prompt/qti-prompt.ts",
-          "definitionPath": "packages/interactions/core/src/elements/qti-prompt/qti-prompt.ts"
+          "definitionPath": "packages/interactions/core/src/elements/qti-prompt/qti-prompt.ts",
+          "tagName": "qti-prompt"
         }
       ],
       "exports": [
@@ -13396,9 +13396,9 @@
             "package": "lit"
           },
           "customElement": true,
-          "tagName": "qti-end-attempt-interaction",
           "modulePath": "packages/interactions/end-attempt-interaction/src/qti-end-attempt-interaction.ts",
-          "definitionPath": "packages/interactions/end-attempt-interaction/src/qti-end-attempt-interaction.ts"
+          "definitionPath": "packages/interactions/end-attempt-interaction/src/qti-end-attempt-interaction.ts",
+          "tagName": "qti-end-attempt-interaction"
         }
       ],
       "exports": [
@@ -16495,7 +16495,7 @@
                 "text": "any[] | NodeListOf<QtiAssociableHotspot>"
               },
               "parsedType": {
-                "text": "any[] | { item: {  }, forEach: {  }, entries: {  }, keys: {  }, values: {  }, __@iterator@515: {  }, length: number }"
+                "text": "any[] | { item: {  }, forEach: {  }, entries: {  }, keys: {  }, values: {  }, __@iterator@443: {  }, length: number }"
               }
             },
             {
@@ -28821,9 +28821,9 @@
             "package": "lit"
           },
           "customElement": true,
-          "tagName": "qti-position-object-interaction",
           "modulePath": "packages/interactions/position-object-interaction/src/qti-position-object-interaction.ts",
-          "definitionPath": "packages/interactions/position-object-interaction/src/qti-position-object-interaction.ts"
+          "definitionPath": "packages/interactions/position-object-interaction/src/qti-position-object-interaction.ts",
+          "tagName": "qti-position-object-interaction"
         }
       ],
       "exports": [
@@ -28915,9 +28915,9 @@
             "package": "lit"
           },
           "customElement": true,
-          "tagName": "qti-position-object-stage",
           "modulePath": "packages/interactions/position-object-interaction/src/qti-position-object-stage.ts",
-          "definitionPath": "packages/interactions/position-object-interaction/src/qti-position-object-stage.ts"
+          "definitionPath": "packages/interactions/position-object-interaction/src/qti-position-object-stage.ts",
+          "tagName": "qti-position-object-stage"
         }
       ],
       "exports": [
@@ -32522,6 +32522,18 @@
           "name": "QtiConditionExpression",
           "members": [
             {
+              "kind": "field",
+              "name": "_testContext",
+              "type": {
+                "text": "TestContext | undefined"
+              },
+              "privacy": "protected",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
+            {
               "kind": "method",
               "name": "calculate",
               "privacy": "public",
@@ -32582,6 +32594,29 @@
               }
             },
             {
+              "kind": "method",
+              "name": "resolveVariable",
+              "privacy": "protected",
+              "return": {
+                "type": {
+                  "text": "VariableDeclaration<string | string[] | null> | null"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "identifier",
+                  "type": {
+                    "text": "string"
+                  }
+                }
+              ],
+              "description": "Resolve a declared variable from the closest available scope: item-level\nfirst, then the test-level outcome variables. So an expression used in an\nassessmentTest's outcome processing can reference a test-level outcome\n(e.g. a total set earlier in the same run) — which the QTI variable\nexpression is specified to do. Returns null when unresolved rather than\nthrowing, so callers degrade gracefully.",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
+            {
               "kind": "field",
               "name": "result",
               "type": {
@@ -32621,6 +32656,14 @@
           "name": "QtiExpression",
           "members": [
             {
+              "kind": "field",
+              "name": "_testContext",
+              "type": {
+                "text": "TestContext | undefined"
+              },
+              "privacy": "protected"
+            },
+            {
               "kind": "method",
               "name": "calculate",
               "privacy": "public",
@@ -32659,6 +32702,25 @@
                 "text": "QtiContext | undefined"
               },
               "privacy": "protected"
+            },
+            {
+              "kind": "method",
+              "name": "resolveVariable",
+              "privacy": "protected",
+              "return": {
+                "type": {
+                  "text": "VariableDeclaration<string | string[] | null> | null"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "identifier",
+                  "type": {
+                    "text": "string"
+                  }
+                }
+              ],
+              "description": "Resolve a declared variable from the closest available scope: item-level\nfirst, then the test-level outcome variables. So an expression used in an\nassessmentTest's outcome processing can reference a test-level outcome\n(e.g. a total set earlier in the same run) — which the QTI variable\nexpression is specified to do. Returns null when unresolved rather than\nthrowing, so callers degrade gracefully."
             },
             {
               "kind": "field",
@@ -34156,9 +34218,9 @@
             "package": "lit"
           },
           "customElement": true,
-          "tagName": "item-correct-response-mode",
           "modulePath": "packages/qti-corrections/src/components/item-correct-response-mode/item-correct-response-mode.ts",
-          "definitionPath": "packages/qti-corrections/src/components/item-correct-response-mode/item-correct-response-mode.ts"
+          "definitionPath": "packages/qti-corrections/src/components/item-correct-response-mode/item-correct-response-mode.ts",
+          "tagName": "item-correct-response-mode"
         }
       ],
       "exports": [
@@ -34336,9 +34398,9 @@
             "package": "lit"
           },
           "customElement": true,
-          "tagName": "item-show-candidate-correction",
           "modulePath": "packages/qti-corrections/src/components/item-show-candidate-correction/item-show-candidate-correction.ts",
-          "definitionPath": "packages/qti-corrections/src/components/item-show-candidate-correction/item-show-candidate-correction.ts"
+          "definitionPath": "packages/qti-corrections/src/components/item-show-candidate-correction/item-show-candidate-correction.ts",
+          "tagName": "item-show-candidate-correction"
         }
       ],
       "exports": [
@@ -34516,9 +34578,9 @@
             "package": "lit"
           },
           "customElement": true,
-          "tagName": "item-show-correct-response",
           "modulePath": "packages/qti-corrections/src/components/item-show-correct-response/item-show-correct-response.ts",
-          "definitionPath": "packages/qti-corrections/src/components/item-show-correct-response/item-show-correct-response.ts"
+          "definitionPath": "packages/qti-corrections/src/components/item-show-correct-response/item-show-correct-response.ts",
+          "tagName": "item-show-correct-response"
         }
       ],
       "exports": [
@@ -36500,9 +36562,9 @@
           },
           "deprecated": "test-show-correct-response is deprecated and will be removed in the future.",
           "customElement": true,
-          "tagName": "test-show-correct-response",
           "modulePath": "packages/qti-corrections/src/components/test-show-correct-response/test-show-correct-response.ts",
-          "definitionPath": "packages/qti-corrections/src/components/test-show-correct-response/test-show-correct-response.ts"
+          "definitionPath": "packages/qti-corrections/src/components/test-show-correct-response/test-show-correct-response.ts",
+          "tagName": "test-show-correct-response"
         }
       ],
       "exports": [
@@ -37129,9 +37191,9 @@
           },
           "summary": "The qti-assessment-item element contains all the other QTI 3 item structures.",
           "customElement": true,
-          "tagName": "qti-assessment-item",
           "modulePath": "packages/qti-elements/src/components/qti-assessment-item/qti-assessment-item.ts",
-          "definitionPath": "packages/qti-elements/src/components/qti-assessment-item/qti-assessment-item.ts"
+          "definitionPath": "packages/qti-elements/src/components/qti-assessment-item/qti-assessment-item.ts",
+          "tagName": "qti-assessment-item"
         }
       ],
       "exports": [
@@ -37222,9 +37284,9 @@
             "package": "lit"
           },
           "customElement": true,
-          "tagName": "qti-assessment-stimulus-ref",
           "modulePath": "packages/qti-elements/src/components/qti-assessment-stimulus-ref/qti-assessment-stimulus-ref.ts",
-          "definitionPath": "packages/qti-elements/src/components/qti-assessment-stimulus-ref/qti-assessment-stimulus-ref.ts"
+          "definitionPath": "packages/qti-elements/src/components/qti-assessment-stimulus-ref/qti-assessment-stimulus-ref.ts",
+          "tagName": "qti-assessment-stimulus-ref"
         },
         {
           "kind": "class",
@@ -37288,9 +37350,9 @@
             "package": "lit"
           },
           "customElement": true,
-          "tagName": "qti-companion-materials-info",
           "modulePath": "packages/qti-elements/src/components/qti-companion-materials-info/qti-companion-materials-info.ts",
-          "definitionPath": "packages/qti-elements/src/components/qti-companion-materials-info/qti-companion-materials-info.ts"
+          "definitionPath": "packages/qti-elements/src/components/qti-companion-materials-info/qti-companion-materials-info.ts",
+          "tagName": "qti-companion-materials-info"
         }
       ],
       "exports": [
@@ -37363,9 +37425,9 @@
             "package": "lit"
           },
           "customElement": true,
-          "tagName": "qti-content-body",
           "modulePath": "packages/qti-elements/src/components/qti-content-body/qti-content-body.ts",
-          "definitionPath": "packages/qti-elements/src/components/qti-content-body/qti-content-body.ts"
+          "definitionPath": "packages/qti-elements/src/components/qti-content-body/qti-content-body.ts",
+          "tagName": "qti-content-body"
         }
       ],
       "exports": [
@@ -37445,9 +37507,9 @@
           },
           "summary": "The qti-context-declaration element declares context variables for an item.",
           "customElement": true,
-          "tagName": "qti-context-declaration",
           "modulePath": "packages/qti-elements/src/components/qti-context-declaration/qti-context-declaration.ts",
-          "definitionPath": "packages/qti-elements/src/components/qti-context-declaration/qti-context-declaration.ts"
+          "definitionPath": "packages/qti-elements/src/components/qti-context-declaration/qti-context-declaration.ts",
+          "tagName": "qti-context-declaration"
         }
       ],
       "exports": [
@@ -37529,9 +37591,9 @@
             "package": "lit"
           },
           "customElement": true,
-          "tagName": "qti-custom-operator",
           "modulePath": "packages/qti-elements/src/components/qti-custom-operator/qti-custom-operator.ts",
-          "definitionPath": "packages/qti-elements/src/components/qti-custom-operator/qti-custom-operator.ts"
+          "definitionPath": "packages/qti-elements/src/components/qti-custom-operator/qti-custom-operator.ts",
+          "tagName": "qti-custom-operator"
         }
       ],
       "exports": [
@@ -38031,9 +38093,9 @@
           },
           "summary": "The qti-item-body node contains the text, graphics, media objects and interactions that describe the item's content and information about how it is structured.",
           "customElement": true,
-          "tagName": "qti-item-body",
           "modulePath": "packages/qti-elements/src/components/qti-item-body/qti-item-body.ts",
-          "definitionPath": "packages/qti-elements/src/components/qti-item-body/qti-item-body.ts"
+          "definitionPath": "packages/qti-elements/src/components/qti-item-body/qti-item-body.ts",
+          "tagName": "qti-item-body"
         }
       ],
       "exports": [
@@ -38646,9 +38708,9 @@
             "package": "lit"
           },
           "customElement": true,
-          "tagName": "qti-response-processing",
           "modulePath": "packages/qti-elements/src/components/qti-response-processing/qti-response-processing.ts",
-          "definitionPath": "packages/qti-elements/src/components/qti-response-processing/qti-response-processing.ts"
+          "definitionPath": "packages/qti-elements/src/components/qti-response-processing/qti-response-processing.ts",
+          "tagName": "qti-response-processing"
         }
       ],
       "exports": [
@@ -38766,9 +38828,9 @@
             "package": "lit"
           },
           "customElement": true,
-          "tagName": "qti-rubric-block",
           "modulePath": "packages/qti-elements/src/components/qti-rubric-block/qti-rubric-block.ts",
-          "definitionPath": "packages/qti-elements/src/components/qti-rubric-block/qti-rubric-block.ts"
+          "definitionPath": "packages/qti-elements/src/components/qti-rubric-block/qti-rubric-block.ts",
+          "tagName": "qti-rubric-block"
         }
       ],
       "exports": [
@@ -38832,9 +38894,9 @@
             "package": "lit"
           },
           "customElement": true,
-          "tagName": "qti-stylesheet",
           "modulePath": "packages/qti-elements/src/components/qti-stylesheet/qti-stylesheet.ts",
-          "definitionPath": "packages/qti-elements/src/components/qti-stylesheet/qti-stylesheet.ts"
+          "definitionPath": "packages/qti-elements/src/components/qti-stylesheet/qti-stylesheet.ts",
+          "tagName": "qti-stylesheet"
         }
       ],
       "exports": [
@@ -38914,9 +38976,9 @@
           },
           "summary": "The qti-template-constraint element is a processing rule available only in Template Processing.",
           "customElement": true,
-          "tagName": "qti-template-constraint",
           "modulePath": "packages/qti-elements/src/components/qti-template-constraint/qti-template-constraint.ts",
-          "definitionPath": "packages/qti-elements/src/components/qti-template-constraint/qti-template-constraint.ts"
+          "definitionPath": "packages/qti-elements/src/components/qti-template-constraint/qti-template-constraint.ts",
+          "tagName": "qti-template-constraint"
         }
       ],
       "exports": [
@@ -39125,9 +39187,9 @@
           },
           "summary": "The qti-template-declaration element declares template variables for item cloning.",
           "customElement": true,
-          "tagName": "qti-template-declaration",
           "modulePath": "packages/qti-elements/src/components/qti-template-declaration/qti-template-declaration.ts",
-          "definitionPath": "packages/qti-elements/src/components/qti-template-declaration/qti-template-declaration.ts"
+          "definitionPath": "packages/qti-elements/src/components/qti-template-declaration/qti-template-declaration.ts",
+          "tagName": "qti-template-declaration"
         }
       ],
       "exports": [
@@ -39196,9 +39258,9 @@
           },
           "summary": "The qti-template-processing element contains template processing rules.",
           "customElement": true,
-          "tagName": "qti-template-processing",
           "modulePath": "packages/qti-elements/src/components/qti-template-processing/qti-template-processing.ts",
-          "definitionPath": "packages/qti-elements/src/components/qti-template-processing/qti-template-processing.ts"
+          "definitionPath": "packages/qti-elements/src/components/qti-template-processing/qti-template-processing.ts",
+          "tagName": "qti-template-processing"
         }
       ],
       "exports": [
@@ -39508,9 +39570,9 @@
             "package": "lit"
           },
           "customElement": true,
-          "tagName": "item-container",
           "modulePath": "packages/qti-item/src/components/item-container/item-container.ts",
-          "definitionPath": "packages/qti-item/src/components/item-container/item-container.ts"
+          "definitionPath": "packages/qti-item/src/components/item-container/item-container.ts",
+          "tagName": "item-container"
         }
       ],
       "exports": [
@@ -39558,9 +39620,9 @@
             "package": "lit"
           },
           "customElement": true,
-          "tagName": "item-print-variables",
           "modulePath": "packages/qti-item/src/components/item-print-variables/item-print-variables.ts",
-          "definitionPath": "packages/qti-item/src/components/item-print-variables/item-print-variables.ts"
+          "definitionPath": "packages/qti-item/src/components/item-print-variables/item-print-variables.ts",
+          "tagName": "item-print-variables"
         }
       ],
       "exports": [
@@ -39695,9 +39757,9 @@
             "package": "lit"
           },
           "customElement": true,
-          "tagName": "qti-item",
           "modulePath": "packages/qti-item/src/components/qti-item/qti-item.ts",
-          "definitionPath": "packages/qti-item/src/components/qti-item/qti-item.ts"
+          "definitionPath": "packages/qti-item/src/components/qti-item/qti-item.ts",
+          "tagName": "qti-item"
         }
       ],
       "exports": [
@@ -40341,6 +40403,18 @@
           "name": "QtiAnyN",
           "members": [
             {
+              "kind": "field",
+              "name": "_testContext",
+              "type": {
+                "text": "TestContext | undefined"
+              },
+              "privacy": "protected",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
+            {
               "kind": "method",
               "name": "calculate",
               "privacy": "public",
@@ -40419,6 +40493,29 @@
               }
             },
             {
+              "kind": "method",
+              "name": "resolveVariable",
+              "privacy": "protected",
+              "return": {
+                "type": {
+                  "text": "VariableDeclaration<string | string[] | null> | null"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "identifier",
+                  "type": {
+                    "text": "string"
+                  }
+                }
+              ],
+              "description": "Resolve a declared variable from the closest available scope: item-level\nfirst, then the test-level outcome variables. So an expression used in an\nassessmentTest's outcome processing can reference a test-level outcome\n(e.g. a total set earlier in the same run) — which the QTI variable\nexpression is specified to do. Returns null when unresolved rather than\nthrowing, so callers degrade gracefully.",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
+            {
               "kind": "field",
               "name": "result",
               "type": {
@@ -40485,6 +40582,18 @@
           "description": "",
           "name": "QtiBaseValue",
           "members": [
+            {
+              "kind": "field",
+              "name": "_testContext",
+              "type": {
+                "text": "TestContext | undefined"
+              },
+              "privacy": "protected",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
             {
               "kind": "field",
               "name": "baseType",
@@ -40555,6 +40664,29 @@
                 "text": "QtiContext | undefined"
               },
               "privacy": "protected",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
+            {
+              "kind": "method",
+              "name": "resolveVariable",
+              "privacy": "protected",
+              "return": {
+                "type": {
+                  "text": "VariableDeclaration<string | string[] | null> | null"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "identifier",
+                  "type": {
+                    "text": "string"
+                  }
+                }
+              ],
+              "description": "Resolve a declared variable from the closest available scope: item-level\nfirst, then the test-level outcome variables. So an expression used in an\nassessmentTest's outcome processing can reference a test-level outcome\n(e.g. a total set earlier in the same run) — which the QTI variable\nexpression is specified to do. Returns null when unresolved rather than\nthrowing, so callers degrade gracefully.",
               "inheritedFrom": {
                 "name": "QtiExpression",
                 "module": "packages/qti-base/src/abstract/qti-expression.ts"
@@ -40825,6 +40957,18 @@
           "name": "QtiContainerSize",
           "members": [
             {
+              "kind": "field",
+              "name": "_testContext",
+              "type": {
+                "text": "TestContext | undefined"
+              },
+              "privacy": "protected",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
+            {
               "kind": "method",
               "name": "calculate",
               "privacy": "public",
@@ -40888,6 +41032,29 @@
               }
             },
             {
+              "kind": "method",
+              "name": "resolveVariable",
+              "privacy": "protected",
+              "return": {
+                "type": {
+                  "text": "VariableDeclaration<string | string[] | null> | null"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "identifier",
+                  "type": {
+                    "text": "string"
+                  }
+                }
+              ],
+              "description": "Resolve a declared variable from the closest available scope: item-level\nfirst, then the test-level outcome variables. So an expression used in an\nassessmentTest's outcome processing can reference a test-level outcome\n(e.g. a total set earlier in the same run) — which the QTI variable\nexpression is specified to do. Returns null when unresolved rather than\nthrowing, so callers degrade gracefully.",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
+            {
               "kind": "field",
               "name": "result",
               "type": {
@@ -40939,6 +41106,18 @@
           "description": "",
           "name": "QtiContains",
           "members": [
+            {
+              "kind": "field",
+              "name": "_testContext",
+              "type": {
+                "text": "TestContext | undefined"
+              },
+              "privacy": "protected",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
             {
               "kind": "method",
               "name": "calculate",
@@ -41003,6 +41182,29 @@
               }
             },
             {
+              "kind": "method",
+              "name": "resolveVariable",
+              "privacy": "protected",
+              "return": {
+                "type": {
+                  "text": "VariableDeclaration<string | string[] | null> | null"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "identifier",
+                  "type": {
+                    "text": "string"
+                  }
+                }
+              ],
+              "description": "Resolve a declared variable from the closest available scope: item-level\nfirst, then the test-level outcome variables. So an expression used in an\nassessmentTest's outcome processing can reference a test-level outcome\n(e.g. a total set earlier in the same run) — which the QTI variable\nexpression is specified to do. Returns null when unresolved rather than\nthrowing, so callers degrade gracefully.",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
+            {
               "kind": "field",
               "name": "result",
               "type": {
@@ -41053,6 +41255,18 @@
           "description": "",
           "name": "QtiCorrect",
           "members": [
+            {
+              "kind": "field",
+              "name": "_testContext",
+              "type": {
+                "text": "TestContext | undefined"
+              },
+              "privacy": "protected",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
             {
               "kind": "method",
               "name": "calculate",
@@ -41122,6 +41336,29 @@
               }
             },
             {
+              "kind": "method",
+              "name": "resolveVariable",
+              "privacy": "protected",
+              "return": {
+                "type": {
+                  "text": "VariableDeclaration<string | string[] | null> | null"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "identifier",
+                  "type": {
+                    "text": "string"
+                  }
+                }
+              ],
+              "description": "Resolve a declared variable from the closest available scope: item-level\nfirst, then the test-level outcome variables. So an expression used in an\nassessmentTest's outcome processing can reference a test-level outcome\n(e.g. a total set earlier in the same run) — which the QTI variable\nexpression is specified to do. Returns null when unresolved rather than\nthrowing, so callers degrade gracefully.",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
+            {
               "kind": "field",
               "name": "result",
               "type": {
@@ -41179,7 +41416,11 @@
               "type": {
                 "text": "TestContext | undefined"
               },
-              "privacy": "protected"
+              "privacy": "protected",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
             },
             {
               "kind": "method",
@@ -41254,6 +41495,29 @@
               }
             },
             {
+              "kind": "method",
+              "name": "resolveVariable",
+              "privacy": "protected",
+              "return": {
+                "type": {
+                  "text": "VariableDeclaration<string | string[] | null> | null"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "identifier",
+                  "type": {
+                    "text": "string"
+                  }
+                }
+              ],
+              "description": "Resolve a declared variable from the closest available scope: item-level\nfirst, then the test-level outcome variables. So an expression used in an\nassessmentTest's outcome processing can reference a test-level outcome\n(e.g. a total set earlier in the same run) — which the QTI variable\nexpression is specified to do. Returns null when unresolved rather than\nthrowing, so callers degrade gracefully.",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
+            {
               "kind": "field",
               "name": "result",
               "type": {
@@ -41315,6 +41579,18 @@
           "description": "",
           "name": "QtiDelete",
           "members": [
+            {
+              "kind": "field",
+              "name": "_testContext",
+              "type": {
+                "text": "TestContext | undefined"
+              },
+              "privacy": "protected",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
             {
               "kind": "method",
               "name": "calculate",
@@ -41379,6 +41655,29 @@
               }
             },
             {
+              "kind": "method",
+              "name": "resolveVariable",
+              "privacy": "protected",
+              "return": {
+                "type": {
+                  "text": "VariableDeclaration<string | string[] | null> | null"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "identifier",
+                  "type": {
+                    "text": "string"
+                  }
+                }
+              ],
+              "description": "Resolve a declared variable from the closest available scope: item-level\nfirst, then the test-level outcome variables. So an expression used in an\nassessmentTest's outcome processing can reference a test-level outcome\n(e.g. a total set earlier in the same run) — which the QTI variable\nexpression is specified to do. Returns null when unresolved rather than\nthrowing, so callers degrade gracefully.",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
+            {
               "kind": "field",
               "name": "result",
               "type": {
@@ -41430,6 +41729,18 @@
           "description": "",
           "name": "QtiDivide",
           "members": [
+            {
+              "kind": "field",
+              "name": "_testContext",
+              "type": {
+                "text": "TestContext | undefined"
+              },
+              "privacy": "protected",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
             {
               "kind": "method",
               "name": "#collectNumericValues",
@@ -41512,6 +41823,29 @@
               }
             },
             {
+              "kind": "method",
+              "name": "resolveVariable",
+              "privacy": "protected",
+              "return": {
+                "type": {
+                  "text": "VariableDeclaration<string | string[] | null> | null"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "identifier",
+                  "type": {
+                    "text": "string"
+                  }
+                }
+              ],
+              "description": "Resolve a declared variable from the closest available scope: item-level\nfirst, then the test-level outcome variables. So an expression used in an\nassessmentTest's outcome processing can reference a test-level outcome\n(e.g. a total set earlier in the same run) — which the QTI variable\nexpression is specified to do. Returns null when unresolved rather than\nthrowing, so callers degrade gracefully.",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
+            {
               "kind": "field",
               "name": "result",
               "type": {
@@ -41563,6 +41897,18 @@
           "description": "",
           "name": "QtiDurationGte",
           "members": [
+            {
+              "kind": "field",
+              "name": "_testContext",
+              "type": {
+                "text": "TestContext | undefined"
+              },
+              "privacy": "protected",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
             {
               "kind": "method",
               "name": "#getDurationValues",
@@ -41649,6 +41995,29 @@
                 "text": "QtiContext | undefined"
               },
               "privacy": "protected",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
+            {
+              "kind": "method",
+              "name": "resolveVariable",
+              "privacy": "protected",
+              "return": {
+                "type": {
+                  "text": "VariableDeclaration<string | string[] | null> | null"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "identifier",
+                  "type": {
+                    "text": "string"
+                  }
+                }
+              ],
+              "description": "Resolve a declared variable from the closest available scope: item-level\nfirst, then the test-level outcome variables. So an expression used in an\nassessmentTest's outcome processing can reference a test-level outcome\n(e.g. a total set earlier in the same run) — which the QTI variable\nexpression is specified to do. Returns null when unresolved rather than\nthrowing, so callers degrade gracefully.",
               "inheritedFrom": {
                 "name": "QtiExpression",
                 "module": "packages/qti-base/src/abstract/qti-expression.ts"
@@ -41706,6 +42075,18 @@
           "name": "QtiDurationLt",
           "members": [
             {
+              "kind": "field",
+              "name": "_testContext",
+              "type": {
+                "text": "TestContext | undefined"
+              },
+              "privacy": "protected",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
+            {
               "kind": "method",
               "name": "#getDurationValues",
               "privacy": "private",
@@ -41797,6 +42178,29 @@
               }
             },
             {
+              "kind": "method",
+              "name": "resolveVariable",
+              "privacy": "protected",
+              "return": {
+                "type": {
+                  "text": "VariableDeclaration<string | string[] | null> | null"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "identifier",
+                  "type": {
+                    "text": "string"
+                  }
+                }
+              ],
+              "description": "Resolve a declared variable from the closest available scope: item-level\nfirst, then the test-level outcome variables. So an expression used in an\nassessmentTest's outcome processing can reference a test-level outcome\n(e.g. a total set earlier in the same run) — which the QTI variable\nexpression is specified to do. Returns null when unresolved rather than\nthrowing, so callers degrade gracefully.",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
+            {
               "kind": "field",
               "name": "result",
               "type": {
@@ -41848,6 +42252,18 @@
           "description": "",
           "name": "QtiEqualRounded",
           "members": [
+            {
+              "kind": "field",
+              "name": "_testContext",
+              "type": {
+                "text": "TestContext | undefined"
+              },
+              "privacy": "protected",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
             {
               "kind": "method",
               "name": "calculate",
@@ -41911,6 +42327,29 @@
                 "text": "QtiContext | undefined"
               },
               "privacy": "protected",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
+            {
+              "kind": "method",
+              "name": "resolveVariable",
+              "privacy": "protected",
+              "return": {
+                "type": {
+                  "text": "VariableDeclaration<string | string[] | null> | null"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "identifier",
+                  "type": {
+                    "text": "string"
+                  }
+                }
+              ],
+              "description": "Resolve a declared variable from the closest available scope: item-level\nfirst, then the test-level outcome variables. So an expression used in an\nassessmentTest's outcome processing can reference a test-level outcome\n(e.g. a total set earlier in the same run) — which the QTI variable\nexpression is specified to do. Returns null when unresolved rather than\nthrowing, so callers degrade gracefully.",
               "inheritedFrom": {
                 "name": "QtiExpression",
                 "module": "packages/qti-base/src/abstract/qti-expression.ts"
@@ -41994,6 +42433,18 @@
           "name": "QtiEqual",
           "members": [
             {
+              "kind": "field",
+              "name": "_testContext",
+              "type": {
+                "text": "TestContext | undefined"
+              },
+              "privacy": "protected",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
+            {
               "kind": "method",
               "name": "calculate",
               "privacy": "public",
@@ -42051,6 +42502,29 @@
                 "text": "QtiContext | undefined"
               },
               "privacy": "protected",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
+            {
+              "kind": "method",
+              "name": "resolveVariable",
+              "privacy": "protected",
+              "return": {
+                "type": {
+                  "text": "VariableDeclaration<string | string[] | null> | null"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "identifier",
+                  "type": {
+                    "text": "string"
+                  }
+                }
+              ],
+              "description": "Resolve a declared variable from the closest available scope: item-level\nfirst, then the test-level outcome variables. So an expression used in an\nassessmentTest's outcome processing can reference a test-level outcome\n(e.g. a total set earlier in the same run) — which the QTI variable\nexpression is specified to do. Returns null when unresolved rather than\nthrowing, so callers degrade gracefully.",
               "inheritedFrom": {
                 "name": "QtiExpression",
                 "module": "packages/qti-base/src/abstract/qti-expression.ts"
@@ -42134,6 +42608,18 @@
           "name": "QtiFieldValue",
           "members": [
             {
+              "kind": "field",
+              "name": "_testContext",
+              "type": {
+                "text": "TestContext | undefined"
+              },
+              "privacy": "protected",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
+            {
               "kind": "method",
               "name": "calculate",
               "privacy": "public",
@@ -42197,6 +42683,29 @@
               }
             },
             {
+              "kind": "method",
+              "name": "resolveVariable",
+              "privacy": "protected",
+              "return": {
+                "type": {
+                  "text": "VariableDeclaration<string | string[] | null> | null"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "identifier",
+                  "type": {
+                    "text": "string"
+                  }
+                }
+              ],
+              "description": "Resolve a declared variable from the closest available scope: item-level\nfirst, then the test-level outcome variables. So an expression used in an\nassessmentTest's outcome processing can reference a test-level outcome\n(e.g. a total set earlier in the same run) — which the QTI variable\nexpression is specified to do. Returns null when unresolved rather than\nthrowing, so callers degrade gracefully.",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
+            {
               "kind": "field",
               "name": "result",
               "type": {
@@ -42248,6 +42757,18 @@
           "description": "",
           "name": "QtiGcd",
           "members": [
+            {
+              "kind": "field",
+              "name": "_testContext",
+              "type": {
+                "text": "TestContext | undefined"
+              },
+              "privacy": "protected",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
             {
               "kind": "method",
               "name": "#calculateGcd",
@@ -42356,6 +42877,29 @@
               }
             },
             {
+              "kind": "method",
+              "name": "resolveVariable",
+              "privacy": "protected",
+              "return": {
+                "type": {
+                  "text": "VariableDeclaration<string | string[] | null> | null"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "identifier",
+                  "type": {
+                    "text": "string"
+                  }
+                }
+              ],
+              "description": "Resolve a declared variable from the closest available scope: item-level\nfirst, then the test-level outcome variables. So an expression used in an\nassessmentTest's outcome processing can reference a test-level outcome\n(e.g. a total set earlier in the same run) — which the QTI variable\nexpression is specified to do. Returns null when unresolved rather than\nthrowing, so callers degrade gracefully.",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
+            {
               "kind": "field",
               "name": "result",
               "type": {
@@ -42407,6 +42951,18 @@
           "description": "",
           "name": "QtiGt",
           "members": [
+            {
+              "kind": "field",
+              "name": "_testContext",
+              "type": {
+                "text": "TestContext | undefined"
+              },
+              "privacy": "protected",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
             {
               "kind": "method",
               "name": "calculate",
@@ -42471,6 +43027,29 @@
               }
             },
             {
+              "kind": "method",
+              "name": "resolveVariable",
+              "privacy": "protected",
+              "return": {
+                "type": {
+                  "text": "VariableDeclaration<string | string[] | null> | null"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "identifier",
+                  "type": {
+                    "text": "string"
+                  }
+                }
+              ],
+              "description": "Resolve a declared variable from the closest available scope: item-level\nfirst, then the test-level outcome variables. So an expression used in an\nassessmentTest's outcome processing can reference a test-level outcome\n(e.g. a total set earlier in the same run) — which the QTI variable\nexpression is specified to do. Returns null when unresolved rather than\nthrowing, so callers degrade gracefully.",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
+            {
               "kind": "field",
               "name": "result",
               "type": {
@@ -42521,6 +43100,18 @@
           "description": "",
           "name": "QtiGte",
           "members": [
+            {
+              "kind": "field",
+              "name": "_testContext",
+              "type": {
+                "text": "TestContext | undefined"
+              },
+              "privacy": "protected",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
             {
               "kind": "method",
               "name": "calculate",
@@ -42585,6 +43176,29 @@
               }
             },
             {
+              "kind": "method",
+              "name": "resolveVariable",
+              "privacy": "protected",
+              "return": {
+                "type": {
+                  "text": "VariableDeclaration<string | string[] | null> | null"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "identifier",
+                  "type": {
+                    "text": "string"
+                  }
+                }
+              ],
+              "description": "Resolve a declared variable from the closest available scope: item-level\nfirst, then the test-level outcome variables. So an expression used in an\nassessmentTest's outcome processing can reference a test-level outcome\n(e.g. a total set earlier in the same run) — which the QTI variable\nexpression is specified to do. Returns null when unresolved rather than\nthrowing, so callers degrade gracefully.",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
+            {
               "kind": "field",
               "name": "result",
               "type": {
@@ -42635,6 +43249,18 @@
           "description": "",
           "name": "QtiIndex",
           "members": [
+            {
+              "kind": "field",
+              "name": "_testContext",
+              "type": {
+                "text": "TestContext | undefined"
+              },
+              "privacy": "protected",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
             {
               "kind": "method",
               "name": "#lookupVariableValue",
@@ -42725,6 +43351,29 @@
               }
             },
             {
+              "kind": "method",
+              "name": "resolveVariable",
+              "privacy": "protected",
+              "return": {
+                "type": {
+                  "text": "VariableDeclaration<string | string[] | null> | null"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "identifier",
+                  "type": {
+                    "text": "string"
+                  }
+                }
+              ],
+              "description": "Resolve a declared variable from the closest available scope: item-level\nfirst, then the test-level outcome variables. So an expression used in an\nassessmentTest's outcome processing can reference a test-level outcome\n(e.g. a total set earlier in the same run) — which the QTI variable\nexpression is specified to do. Returns null when unresolved rather than\nthrowing, so callers degrade gracefully.",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
+            {
               "kind": "field",
               "name": "result",
               "type": {
@@ -42785,6 +43434,18 @@
           "description": "",
           "name": "QtiInside",
           "members": [
+            {
+              "kind": "field",
+              "name": "_testContext",
+              "type": {
+                "text": "TestContext | undefined"
+              },
+              "privacy": "protected",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
             {
               "kind": "method",
               "name": "#isInsideCircle",
@@ -42990,6 +43651,29 @@
               }
             },
             {
+              "kind": "method",
+              "name": "resolveVariable",
+              "privacy": "protected",
+              "return": {
+                "type": {
+                  "text": "VariableDeclaration<string | string[] | null> | null"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "identifier",
+                  "type": {
+                    "text": "string"
+                  }
+                }
+              ],
+              "description": "Resolve a declared variable from the closest available scope: item-level\nfirst, then the test-level outcome variables. So an expression used in an\nassessmentTest's outcome processing can reference a test-level outcome\n(e.g. a total set earlier in the same run) — which the QTI variable\nexpression is specified to do. Returns null when unresolved rather than\nthrowing, so callers degrade gracefully.",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
+            {
               "kind": "field",
               "name": "result",
               "type": {
@@ -43068,6 +43752,18 @@
           "name": "QtiIntegerDivide",
           "members": [
             {
+              "kind": "field",
+              "name": "_testContext",
+              "type": {
+                "text": "TestContext | undefined"
+              },
+              "privacy": "protected",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
+            {
               "kind": "method",
               "name": "#collectIntegerValues",
               "privacy": "private",
@@ -43143,6 +43839,29 @@
                 "text": "QtiContext | undefined"
               },
               "privacy": "protected",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
+            {
+              "kind": "method",
+              "name": "resolveVariable",
+              "privacy": "protected",
+              "return": {
+                "type": {
+                  "text": "VariableDeclaration<string | string[] | null> | null"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "identifier",
+                  "type": {
+                    "text": "string"
+                  }
+                }
+              ],
+              "description": "Resolve a declared variable from the closest available scope: item-level\nfirst, then the test-level outcome variables. So an expression used in an\nassessmentTest's outcome processing can reference a test-level outcome\n(e.g. a total set earlier in the same run) — which the QTI variable\nexpression is specified to do. Returns null when unresolved rather than\nthrowing, so callers degrade gracefully.",
               "inheritedFrom": {
                 "name": "QtiExpression",
                 "module": "packages/qti-base/src/abstract/qti-expression.ts"
@@ -43201,6 +43920,18 @@
           "name": "QtiIntegerModulus",
           "members": [
             {
+              "kind": "field",
+              "name": "_testContext",
+              "type": {
+                "text": "TestContext | undefined"
+              },
+              "privacy": "protected",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
+            {
               "kind": "method",
               "name": "#collectIntegerValues",
               "privacy": "private",
@@ -43282,6 +44013,29 @@
               }
             },
             {
+              "kind": "method",
+              "name": "resolveVariable",
+              "privacy": "protected",
+              "return": {
+                "type": {
+                  "text": "VariableDeclaration<string | string[] | null> | null"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "identifier",
+                  "type": {
+                    "text": "string"
+                  }
+                }
+              ],
+              "description": "Resolve a declared variable from the closest available scope: item-level\nfirst, then the test-level outcome variables. So an expression used in an\nassessmentTest's outcome processing can reference a test-level outcome\n(e.g. a total set earlier in the same run) — which the QTI variable\nexpression is specified to do. Returns null when unresolved rather than\nthrowing, so callers degrade gracefully.",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
+            {
               "kind": "field",
               "name": "result",
               "type": {
@@ -43333,6 +44087,18 @@
           "description": "",
           "name": "QtiIntegerToFloat",
           "members": [
+            {
+              "kind": "field",
+              "name": "_testContext",
+              "type": {
+                "text": "TestContext | undefined"
+              },
+              "privacy": "protected",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
             {
               "kind": "method",
               "name": "calculate",
@@ -43397,6 +44163,29 @@
               }
             },
             {
+              "kind": "method",
+              "name": "resolveVariable",
+              "privacy": "protected",
+              "return": {
+                "type": {
+                  "text": "VariableDeclaration<string | string[] | null> | null"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "identifier",
+                  "type": {
+                    "text": "string"
+                  }
+                }
+              ],
+              "description": "Resolve a declared variable from the closest available scope: item-level\nfirst, then the test-level outcome variables. So an expression used in an\nassessmentTest's outcome processing can reference a test-level outcome\n(e.g. a total set earlier in the same run) — which the QTI variable\nexpression is specified to do. Returns null when unresolved rather than\nthrowing, so callers degrade gracefully.",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
+            {
               "kind": "field",
               "name": "result",
               "type": {
@@ -43448,6 +44237,18 @@
           "description": "",
           "name": "QtiIsNull",
           "members": [
+            {
+              "kind": "field",
+              "name": "_testContext",
+              "type": {
+                "text": "TestContext | undefined"
+              },
+              "privacy": "protected",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
             {
               "kind": "method",
               "name": "calculate",
@@ -43512,6 +44313,29 @@
               }
             },
             {
+              "kind": "method",
+              "name": "resolveVariable",
+              "privacy": "protected",
+              "return": {
+                "type": {
+                  "text": "VariableDeclaration<string | string[] | null> | null"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "identifier",
+                  "type": {
+                    "text": "string"
+                  }
+                }
+              ],
+              "description": "Resolve a declared variable from the closest available scope: item-level\nfirst, then the test-level outcome variables. So an expression used in an\nassessmentTest's outcome processing can reference a test-level outcome\n(e.g. a total set earlier in the same run) — which the QTI variable\nexpression is specified to do. Returns null when unresolved rather than\nthrowing, so callers degrade gracefully.",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
+            {
               "kind": "field",
               "name": "result",
               "type": {
@@ -43563,6 +44387,18 @@
           "description": "",
           "name": "QtiLcm",
           "members": [
+            {
+              "kind": "field",
+              "name": "_testContext",
+              "type": {
+                "text": "TestContext | undefined"
+              },
+              "privacy": "protected",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
             {
               "kind": "method",
               "name": "#collectIntegerValues",
@@ -43687,6 +44523,29 @@
                 "text": "QtiContext | undefined"
               },
               "privacy": "protected",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
+            {
+              "kind": "method",
+              "name": "resolveVariable",
+              "privacy": "protected",
+              "return": {
+                "type": {
+                  "text": "VariableDeclaration<string | string[] | null> | null"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "identifier",
+                  "type": {
+                    "text": "string"
+                  }
+                }
+              ],
+              "description": "Resolve a declared variable from the closest available scope: item-level\nfirst, then the test-level outcome variables. So an expression used in an\nassessmentTest's outcome processing can reference a test-level outcome\n(e.g. a total set earlier in the same run) — which the QTI variable\nexpression is specified to do. Returns null when unresolved rather than\nthrowing, so callers degrade gracefully.",
               "inheritedFrom": {
                 "name": "QtiExpression",
                 "module": "packages/qti-base/src/abstract/qti-expression.ts"
@@ -43841,6 +44700,18 @@
           "name": "QtiLt",
           "members": [
             {
+              "kind": "field",
+              "name": "_testContext",
+              "type": {
+                "text": "TestContext | undefined"
+              },
+              "privacy": "protected",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
+            {
               "kind": "method",
               "name": "calculate",
               "privacy": "public",
@@ -43904,6 +44775,29 @@
               }
             },
             {
+              "kind": "method",
+              "name": "resolveVariable",
+              "privacy": "protected",
+              "return": {
+                "type": {
+                  "text": "VariableDeclaration<string | string[] | null> | null"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "identifier",
+                  "type": {
+                    "text": "string"
+                  }
+                }
+              ],
+              "description": "Resolve a declared variable from the closest available scope: item-level\nfirst, then the test-level outcome variables. So an expression used in an\nassessmentTest's outcome processing can reference a test-level outcome\n(e.g. a total set earlier in the same run) — which the QTI variable\nexpression is specified to do. Returns null when unresolved rather than\nthrowing, so callers degrade gracefully.",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
+            {
               "kind": "field",
               "name": "result",
               "type": {
@@ -43954,6 +44848,18 @@
           "description": "",
           "name": "QtiLte",
           "members": [
+            {
+              "kind": "field",
+              "name": "_testContext",
+              "type": {
+                "text": "TestContext | undefined"
+              },
+              "privacy": "protected",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
             {
               "kind": "method",
               "name": "calculate",
@@ -44018,6 +44924,29 @@
               }
             },
             {
+              "kind": "method",
+              "name": "resolveVariable",
+              "privacy": "protected",
+              "return": {
+                "type": {
+                  "text": "VariableDeclaration<string | string[] | null> | null"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "identifier",
+                  "type": {
+                    "text": "string"
+                  }
+                }
+              ],
+              "description": "Resolve a declared variable from the closest available scope: item-level\nfirst, then the test-level outcome variables. So an expression used in an\nassessmentTest's outcome processing can reference a test-level outcome\n(e.g. a total set earlier in the same run) — which the QTI variable\nexpression is specified to do. Returns null when unresolved rather than\nthrowing, so callers degrade gracefully.",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
+            {
               "kind": "field",
               "name": "result",
               "type": {
@@ -44068,6 +44997,18 @@
           "description": "",
           "name": "QtiMapResponsePoint",
           "members": [
+            {
+              "kind": "field",
+              "name": "_testContext",
+              "type": {
+                "text": "TestContext | undefined"
+              },
+              "privacy": "protected",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
             {
               "kind": "method",
               "name": "calculate",
@@ -44134,6 +45075,29 @@
                 "text": "QtiContext | undefined"
               },
               "privacy": "protected",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
+            {
+              "kind": "method",
+              "name": "resolveVariable",
+              "privacy": "protected",
+              "return": {
+                "type": {
+                  "text": "VariableDeclaration<string | string[] | null> | null"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "identifier",
+                  "type": {
+                    "text": "string"
+                  }
+                }
+              ],
+              "description": "Resolve a declared variable from the closest available scope: item-level\nfirst, then the test-level outcome variables. So an expression used in an\nassessmentTest's outcome processing can reference a test-level outcome\n(e.g. a total set earlier in the same run) — which the QTI variable\nexpression is specified to do. Returns null when unresolved rather than\nthrowing, so callers degrade gracefully.",
               "inheritedFrom": {
                 "name": "QtiExpression",
                 "module": "packages/qti-base/src/abstract/qti-expression.ts"
@@ -44200,6 +45164,18 @@
           "name": "QtiMapResponse",
           "members": [
             {
+              "kind": "field",
+              "name": "_testContext",
+              "type": {
+                "text": "TestContext | undefined"
+              },
+              "privacy": "protected",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
+            {
               "kind": "method",
               "name": "calculate",
               "privacy": "public",
@@ -44265,6 +45241,29 @@
                 "text": "QtiContext | undefined"
               },
               "privacy": "protected",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
+            {
+              "kind": "method",
+              "name": "resolveVariable",
+              "privacy": "protected",
+              "return": {
+                "type": {
+                  "text": "VariableDeclaration<string | string[] | null> | null"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "identifier",
+                  "type": {
+                    "text": "string"
+                  }
+                }
+              ],
+              "description": "Resolve a declared variable from the closest available scope: item-level\nfirst, then the test-level outcome variables. So an expression used in an\nassessmentTest's outcome processing can reference a test-level outcome\n(e.g. a total set earlier in the same run) — which the QTI variable\nexpression is specified to do. Returns null when unresolved rather than\nthrowing, so callers degrade gracefully.",
               "inheritedFrom": {
                 "name": "QtiExpression",
                 "module": "packages/qti-base/src/abstract/qti-expression.ts"
@@ -44337,6 +45336,18 @@
           "description": "",
           "name": "QtiMatch",
           "members": [
+            {
+              "kind": "field",
+              "name": "_testContext",
+              "type": {
+                "text": "TestContext | undefined"
+              },
+              "privacy": "protected",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
             {
               "kind": "method",
               "name": "calculate",
@@ -44424,6 +45435,29 @@
               }
             },
             {
+              "kind": "method",
+              "name": "resolveVariable",
+              "privacy": "protected",
+              "return": {
+                "type": {
+                  "text": "VariableDeclaration<string | string[] | null> | null"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "identifier",
+                  "type": {
+                    "text": "string"
+                  }
+                }
+              ],
+              "description": "Resolve a declared variable from the closest available scope: item-level\nfirst, then the test-level outcome variables. So an expression used in an\nassessmentTest's outcome processing can reference a test-level outcome\n(e.g. a total set earlier in the same run) — which the QTI variable\nexpression is specified to do. Returns null when unresolved rather than\nthrowing, so callers degrade gracefully.",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
+            {
               "kind": "field",
               "name": "result",
               "type": {
@@ -44475,6 +45509,18 @@
           "description": "",
           "name": "QtiMathOperator",
           "members": [
+            {
+              "kind": "field",
+              "name": "_testContext",
+              "type": {
+                "text": "TestContext | undefined"
+              },
+              "privacy": "protected",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
             {
               "kind": "method",
               "name": "#performOperation",
@@ -44572,6 +45618,29 @@
               }
             },
             {
+              "kind": "method",
+              "name": "resolveVariable",
+              "privacy": "protected",
+              "return": {
+                "type": {
+                  "text": "VariableDeclaration<string | string[] | null> | null"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "identifier",
+                  "type": {
+                    "text": "string"
+                  }
+                }
+              ],
+              "description": "Resolve a declared variable from the closest available scope: item-level\nfirst, then the test-level outcome variables. So an expression used in an\nassessmentTest's outcome processing can reference a test-level outcome\n(e.g. a total set earlier in the same run) — which the QTI variable\nexpression is specified to do. Returns null when unresolved rather than\nthrowing, so callers degrade gracefully.",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
+            {
               "kind": "field",
               "name": "result",
               "type": {
@@ -44634,6 +45703,18 @@
           "name": "QtiMax",
           "members": [
             {
+              "kind": "field",
+              "name": "_testContext",
+              "type": {
+                "text": "TestContext | undefined"
+              },
+              "privacy": "protected",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
+            {
               "kind": "method",
               "name": "#collectNumericValues",
               "privacy": "private",
@@ -44709,6 +45790,29 @@
                 "text": "QtiContext | undefined"
               },
               "privacy": "protected",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
+            {
+              "kind": "method",
+              "name": "resolveVariable",
+              "privacy": "protected",
+              "return": {
+                "type": {
+                  "text": "VariableDeclaration<string | string[] | null> | null"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "identifier",
+                  "type": {
+                    "text": "string"
+                  }
+                }
+              ],
+              "description": "Resolve a declared variable from the closest available scope: item-level\nfirst, then the test-level outcome variables. So an expression used in an\nassessmentTest's outcome processing can reference a test-level outcome\n(e.g. a total set earlier in the same run) — which the QTI variable\nexpression is specified to do. Returns null when unresolved rather than\nthrowing, so callers degrade gracefully.",
               "inheritedFrom": {
                 "name": "QtiExpression",
                 "module": "packages/qti-base/src/abstract/qti-expression.ts"
@@ -44767,6 +45871,18 @@
           "name": "QtiMember",
           "members": [
             {
+              "kind": "field",
+              "name": "_testContext",
+              "type": {
+                "text": "TestContext | undefined"
+              },
+              "privacy": "protected",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
+            {
               "kind": "method",
               "name": "calculate",
               "privacy": "public",
@@ -44830,6 +45946,29 @@
               }
             },
             {
+              "kind": "method",
+              "name": "resolveVariable",
+              "privacy": "protected",
+              "return": {
+                "type": {
+                  "text": "VariableDeclaration<string | string[] | null> | null"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "identifier",
+                  "type": {
+                    "text": "string"
+                  }
+                }
+              ],
+              "description": "Resolve a declared variable from the closest available scope: item-level\nfirst, then the test-level outcome variables. So an expression used in an\nassessmentTest's outcome processing can reference a test-level outcome\n(e.g. a total set earlier in the same run) — which the QTI variable\nexpression is specified to do. Returns null when unresolved rather than\nthrowing, so callers degrade gracefully.",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
+            {
               "kind": "field",
               "name": "result",
               "type": {
@@ -44880,6 +46019,18 @@
           "description": "",
           "name": "QtiMin",
           "members": [
+            {
+              "kind": "field",
+              "name": "_testContext",
+              "type": {
+                "text": "TestContext | undefined"
+              },
+              "privacy": "protected",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
             {
               "kind": "method",
               "name": "#collectNumericValues",
@@ -44962,6 +46113,29 @@
               }
             },
             {
+              "kind": "method",
+              "name": "resolveVariable",
+              "privacy": "protected",
+              "return": {
+                "type": {
+                  "text": "VariableDeclaration<string | string[] | null> | null"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "identifier",
+                  "type": {
+                    "text": "string"
+                  }
+                }
+              ],
+              "description": "Resolve a declared variable from the closest available scope: item-level\nfirst, then the test-level outcome variables. So an expression used in an\nassessmentTest's outcome processing can reference a test-level outcome\n(e.g. a total set earlier in the same run) — which the QTI variable\nexpression is specified to do. Returns null when unresolved rather than\nthrowing, so callers degrade gracefully.",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
+            {
               "kind": "field",
               "name": "result",
               "type": {
@@ -45013,6 +46187,18 @@
           "description": "",
           "name": "QtiMultiple",
           "members": [
+            {
+              "kind": "field",
+              "name": "_testContext",
+              "type": {
+                "text": "TestContext | undefined"
+              },
+              "privacy": "protected",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
             {
               "kind": "method",
               "name": "calculate",
@@ -45077,6 +46263,29 @@
               }
             },
             {
+              "kind": "method",
+              "name": "resolveVariable",
+              "privacy": "protected",
+              "return": {
+                "type": {
+                  "text": "VariableDeclaration<string | string[] | null> | null"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "identifier",
+                  "type": {
+                    "text": "string"
+                  }
+                }
+              ],
+              "description": "Resolve a declared variable from the closest available scope: item-level\nfirst, then the test-level outcome variables. So an expression used in an\nassessmentTest's outcome processing can reference a test-level outcome\n(e.g. a total set earlier in the same run) — which the QTI variable\nexpression is specified to do. Returns null when unresolved rather than\nthrowing, so callers degrade gracefully.",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
+            {
               "kind": "field",
               "name": "result",
               "type": {
@@ -45127,6 +46336,18 @@
           "description": "",
           "name": "QtiNot",
           "members": [
+            {
+              "kind": "field",
+              "name": "_testContext",
+              "type": {
+                "text": "TestContext | undefined"
+              },
+              "privacy": "protected",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
             {
               "kind": "method",
               "name": "calculate",
@@ -45191,6 +46412,29 @@
               }
             },
             {
+              "kind": "method",
+              "name": "resolveVariable",
+              "privacy": "protected",
+              "return": {
+                "type": {
+                  "text": "VariableDeclaration<string | string[] | null> | null"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "identifier",
+                  "type": {
+                    "text": "string"
+                  }
+                }
+              ],
+              "description": "Resolve a declared variable from the closest available scope: item-level\nfirst, then the test-level outcome variables. So an expression used in an\nassessmentTest's outcome processing can reference a test-level outcome\n(e.g. a total set earlier in the same run) — which the QTI variable\nexpression is specified to do. Returns null when unresolved rather than\nthrowing, so callers degrade gracefully.",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
+            {
               "kind": "field",
               "name": "result",
               "type": {
@@ -45242,6 +46486,18 @@
           "description": "",
           "name": "QtiNull",
           "members": [
+            {
+              "kind": "field",
+              "name": "_testContext",
+              "type": {
+                "text": "TestContext | undefined"
+              },
+              "privacy": "protected",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
             {
               "kind": "method",
               "name": "calculate",
@@ -45306,6 +46562,29 @@
               }
             },
             {
+              "kind": "method",
+              "name": "resolveVariable",
+              "privacy": "protected",
+              "return": {
+                "type": {
+                  "text": "VariableDeclaration<string | string[] | null> | null"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "identifier",
+                  "type": {
+                    "text": "string"
+                  }
+                }
+              ],
+              "description": "Resolve a declared variable from the closest available scope: item-level\nfirst, then the test-level outcome variables. So an expression used in an\nassessmentTest's outcome processing can reference a test-level outcome\n(e.g. a total set earlier in the same run) — which the QTI variable\nexpression is specified to do. Returns null when unresolved rather than\nthrowing, so callers degrade gracefully.",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
+            {
               "kind": "field",
               "name": "result",
               "type": {
@@ -45357,6 +46636,18 @@
           "description": "",
           "name": "QtiOr",
           "members": [
+            {
+              "kind": "field",
+              "name": "_testContext",
+              "type": {
+                "text": "TestContext | undefined"
+              },
+              "privacy": "protected",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
             {
               "kind": "method",
               "name": "calculate",
@@ -45421,6 +46712,29 @@
               }
             },
             {
+              "kind": "method",
+              "name": "resolveVariable",
+              "privacy": "protected",
+              "return": {
+                "type": {
+                  "text": "VariableDeclaration<string | string[] | null> | null"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "identifier",
+                  "type": {
+                    "text": "string"
+                  }
+                }
+              ],
+              "description": "Resolve a declared variable from the closest available scope: item-level\nfirst, then the test-level outcome variables. So an expression used in an\nassessmentTest's outcome processing can reference a test-level outcome\n(e.g. a total set earlier in the same run) — which the QTI variable\nexpression is specified to do. Returns null when unresolved rather than\nthrowing, so callers degrade gracefully.",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
+            {
               "kind": "field",
               "name": "result",
               "type": {
@@ -45472,6 +46786,18 @@
           "description": "",
           "name": "QtiOrdered",
           "members": [
+            {
+              "kind": "field",
+              "name": "_testContext",
+              "type": {
+                "text": "TestContext | undefined"
+              },
+              "privacy": "protected",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
             {
               "kind": "method",
               "name": "calculate",
@@ -45530,6 +46856,29 @@
                 "text": "QtiContext | undefined"
               },
               "privacy": "protected",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
+            {
+              "kind": "method",
+              "name": "resolveVariable",
+              "privacy": "protected",
+              "return": {
+                "type": {
+                  "text": "VariableDeclaration<string | string[] | null> | null"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "identifier",
+                  "type": {
+                    "text": "string"
+                  }
+                }
+              ],
+              "description": "Resolve a declared variable from the closest available scope: item-level\nfirst, then the test-level outcome variables. So an expression used in an\nassessmentTest's outcome processing can reference a test-level outcome\n(e.g. a total set earlier in the same run) — which the QTI variable\nexpression is specified to do. Returns null when unresolved rather than\nthrowing, so callers degrade gracefully.",
               "inheritedFrom": {
                 "name": "QtiExpression",
                 "module": "packages/qti-base/src/abstract/qti-expression.ts"
@@ -45899,6 +47248,18 @@
           "name": "QtiPatternMatch",
           "members": [
             {
+              "kind": "field",
+              "name": "_testContext",
+              "type": {
+                "text": "TestContext | undefined"
+              },
+              "privacy": "protected",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
+            {
               "kind": "method",
               "name": "calculate",
               "privacy": "public",
@@ -45971,6 +47332,29 @@
               }
             },
             {
+              "kind": "method",
+              "name": "resolveVariable",
+              "privacy": "protected",
+              "return": {
+                "type": {
+                  "text": "VariableDeclaration<string | string[] | null> | null"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "identifier",
+                  "type": {
+                    "text": "string"
+                  }
+                }
+              ],
+              "description": "Resolve a declared variable from the closest available scope: item-level\nfirst, then the test-level outcome variables. So an expression used in an\nassessmentTest's outcome processing can reference a test-level outcome\n(e.g. a total set earlier in the same run) — which the QTI variable\nexpression is specified to do. Returns null when unresolved rather than\nthrowing, so callers degrade gracefully.",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
+            {
               "kind": "field",
               "name": "result",
               "type": {
@@ -46032,6 +47416,18 @@
           "description": "",
           "name": "QtiPower",
           "members": [
+            {
+              "kind": "field",
+              "name": "_testContext",
+              "type": {
+                "text": "TestContext | undefined"
+              },
+              "privacy": "protected",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
             {
               "kind": "method",
               "name": "calculate",
@@ -46096,6 +47492,29 @@
               }
             },
             {
+              "kind": "method",
+              "name": "resolveVariable",
+              "privacy": "protected",
+              "return": {
+                "type": {
+                  "text": "VariableDeclaration<string | string[] | null> | null"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "identifier",
+                  "type": {
+                    "text": "string"
+                  }
+                }
+              ],
+              "description": "Resolve a declared variable from the closest available scope: item-level\nfirst, then the test-level outcome variables. So an expression used in an\nassessmentTest's outcome processing can reference a test-level outcome\n(e.g. a total set earlier in the same run) — which the QTI variable\nexpression is specified to do. Returns null when unresolved rather than\nthrowing, so callers degrade gracefully.",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
+            {
               "kind": "field",
               "name": "result",
               "type": {
@@ -46140,6 +47559,78 @@
     },
     {
       "kind": "javascript-module",
+      "path": "packages/qti-processing/src/components/qti-printed-variable/printed-variable-format.ts",
+      "declarations": [
+        {
+          "kind": "function",
+          "name": "applyFormat",
+          "return": {
+            "type": {
+              "text": "string"
+            }
+          },
+          "parameters": [
+            {
+              "name": "format",
+              "type": {
+                "text": "string"
+              }
+            },
+            {
+              "name": "value",
+              "type": {
+                "text": "string"
+              }
+            }
+          ],
+          "description": "Renders `value` through a QTI `format` string. The value is passed as the raw string held in\nthe item context, so integers and floats arrive as `\"5\"` / `\"3.14\"` and are coerced per\nconversion."
+        },
+        {
+          "kind": "function",
+          "name": "toExponential",
+          "return": {
+            "type": {
+              "text": "string"
+            }
+          },
+          "parameters": [
+            {
+              "name": "value",
+              "type": {
+                "text": "number"
+              }
+            },
+            {
+              "name": "precision",
+              "optional": true,
+              "type": {
+                "text": "number"
+              }
+            }
+          ]
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "applyFormat",
+          "declaration": {
+            "name": "applyFormat",
+            "module": "packages/qti-processing/src/components/qti-printed-variable/printed-variable-format.ts"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "toExponential",
+          "declaration": {
+            "name": "toExponential",
+            "module": "packages/qti-processing/src/components/qti-printed-variable/printed-variable-format.ts"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
       "path": "packages/qti-processing/src/components/qti-printed-variable/qti-printed-variable.ts",
       "declarations": [
         {
@@ -46147,6 +47638,59 @@
           "description": "",
           "name": "QtiPrintedVariable",
           "members": [
+            {
+              "kind": "method",
+              "name": "#print",
+              "privacy": "private",
+              "return": {
+                "type": {
+                  "text": "string | null"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "variable",
+                  "type": {
+                    "text": "VariableDeclaration<unknown>"
+                  }
+                }
+              ],
+              "description": "Returns `null` for anything QTI treats as NULL, which prints as nothing."
+            },
+            {
+              "kind": "method",
+              "name": "#printValue",
+              "privacy": "private",
+              "return": {
+                "type": {
+                  "text": "string"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "value",
+                  "type": {
+                    "text": "unknown"
+                  }
+                },
+                {
+                  "name": "baseType",
+                  "optional": true,
+                  "type": {
+                    "text": "BaseType"
+                  }
+                }
+              ]
+            },
+            {
+              "kind": "field",
+              "name": "base",
+              "type": {
+                "text": "number"
+              },
+              "default": "10",
+              "attribute": "base"
+            },
             {
               "kind": "method",
               "name": "calculate",
@@ -46170,30 +47714,166 @@
             },
             {
               "kind": "field",
+              "name": "delimiter",
+              "type": {
+                "text": "string"
+              },
+              "default": "';'",
+              "attribute": "delimiter"
+            },
+            {
+              "kind": "field",
+              "name": "field",
+              "type": {
+                "text": "string | undefined"
+              },
+              "attribute": "field",
+              "parsedType": {
+                "text": "string"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "format",
+              "type": {
+                "text": "string | undefined"
+              },
+              "attribute": "format",
+              "parsedType": {
+                "text": "string"
+              }
+            },
+            {
+              "kind": "field",
               "name": "identifier",
               "type": {
                 "text": "string"
               },
               "attribute": "identifier"
+            },
+            {
+              "kind": "field",
+              "name": "index",
+              "type": {
+                "text": "number | undefined"
+              },
+              "attribute": "index",
+              "parsedType": {
+                "text": "number"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "mappingIndicator",
+              "type": {
+                "text": "string"
+              },
+              "default": "'='",
+              "attribute": "mapping-indicator"
+            },
+            {
+              "kind": "field",
+              "name": "powerForm",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "attribute": "power-form"
             }
           ],
           "attributes": [
             {
-              "name": "identifier",
               "type": {
                 "text": "string"
               },
+              "name": ""
+            },
+            {
+              "type": {
+                "text": "number"
+              },
+              "description": "Number base used when printing an integer variable.",
+              "name": "base",
+              "default": "10",
+              "fieldName": "base"
+            },
+            {
+              "type": {
+                "text": "string"
+              },
+              "description": "Separator between the values of an ordered/multiple/record variable.",
+              "name": "delimiter",
+              "default": "';'",
+              "fieldName": "delimiter"
+            },
+            {
+              "type": {
+                "text": "string | undefined"
+              },
+              "description": "Field of a record variable to print, instead of the whole record.",
+              "name": "field",
+              "fieldName": "field",
+              "parsedType": {
+                "text": "string"
+              }
+            },
+            {
+              "type": {
+                "text": "string | undefined"
+              },
+              "description": "printf-style conversion string, e.g. `%.2f` or `Score: %d`. Applies to each value printed. Takes precedence over `base` and `power-form`.",
+              "name": "format",
+              "fieldName": "format",
+              "parsedType": {
+                "text": "string"
+              }
+            },
+            {
+              "type": {
+                "text": "string"
+              },
+              "description": "Required. Identifier of the variable to print.",
+              "name": "identifier",
               "fieldName": "identifier"
+            },
+            {
+              "type": {
+                "text": "number | undefined"
+              },
+              "description": "1-based index selecting a single value of an ordered variable.",
+              "name": "index",
+              "fieldName": "index",
+              "parsedType": {
+                "text": "number"
+              }
+            },
+            {
+              "name": "mapping-indicator",
+              "type": {
+                "text": "string"
+              },
+              "default": "'='",
+              "fieldName": "mappingIndicator"
+            },
+            {
+              "type": {
+                "text": "boolean"
+              },
+              "description": "Print numeric values in exponential form.",
+              "name": "power-form",
+              "default": "false",
+              "fieldName": "powerForm"
             }
           ],
           "superclass": {
             "name": "LitElement",
             "package": "lit"
           },
+          "summary": "Prints the value of an item variable into the item body.",
           "customElement": true,
-          "tagName": "qti-printed-variable",
           "modulePath": "packages/qti-processing/src/components/qti-printed-variable/qti-printed-variable.ts",
-          "definitionPath": "packages/qti-processing/src/components/qti-printed-variable/qti-printed-variable.ts"
+          "definitionPath": "packages/qti-processing/src/components/qti-printed-variable/qti-printed-variable.ts",
+          "tagName": "qti-printed-variable"
         }
       ],
       "exports": [
@@ -46224,6 +47904,18 @@
           "description": "",
           "name": "QtiProduct",
           "members": [
+            {
+              "kind": "field",
+              "name": "_testContext",
+              "type": {
+                "text": "TestContext | undefined"
+              },
+              "privacy": "protected",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
             {
               "kind": "method",
               "name": "calculate",
@@ -46288,6 +47980,29 @@
               }
             },
             {
+              "kind": "method",
+              "name": "resolveVariable",
+              "privacy": "protected",
+              "return": {
+                "type": {
+                  "text": "VariableDeclaration<string | string[] | null> | null"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "identifier",
+                  "type": {
+                    "text": "string"
+                  }
+                }
+              ],
+              "description": "Resolve a declared variable from the closest available scope: item-level\nfirst, then the test-level outcome variables. So an expression used in an\nassessmentTest's outcome processing can reference a test-level outcome\n(e.g. a total set earlier in the same run) — which the QTI variable\nexpression is specified to do. Returns null when unresolved rather than\nthrowing, so callers degrade gracefully.",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
+            {
               "kind": "field",
               "name": "result",
               "type": {
@@ -46339,6 +48054,18 @@
           "description": "",
           "name": "QtiRandomInteger",
           "members": [
+            {
+              "kind": "field",
+              "name": "_testContext",
+              "type": {
+                "text": "TestContext | undefined"
+              },
+              "privacy": "protected",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
             {
               "kind": "method",
               "name": "calculate",
@@ -46435,6 +48162,29 @@
               }
             },
             {
+              "kind": "method",
+              "name": "resolveVariable",
+              "privacy": "protected",
+              "return": {
+                "type": {
+                  "text": "VariableDeclaration<string | string[] | null> | null"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "identifier",
+                  "type": {
+                    "text": "string"
+                  }
+                }
+              ],
+              "description": "Resolve a declared variable from the closest available scope: item-level\nfirst, then the test-level outcome variables. So an expression used in an\nassessmentTest's outcome processing can reference a test-level outcome\n(e.g. a total set earlier in the same run) — which the QTI variable\nexpression is specified to do. Returns null when unresolved rather than\nthrowing, so callers degrade gracefully.",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
+            {
               "kind": "field",
               "name": "result",
               "type": {
@@ -46522,6 +48272,18 @@
           "name": "QtiRandom",
           "members": [
             {
+              "kind": "field",
+              "name": "_testContext",
+              "type": {
+                "text": "TestContext | undefined"
+              },
+              "privacy": "protected",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
+            {
               "kind": "method",
               "name": "calculate",
               "privacy": "public",
@@ -46585,6 +48347,29 @@
               }
             },
             {
+              "kind": "method",
+              "name": "resolveVariable",
+              "privacy": "protected",
+              "return": {
+                "type": {
+                  "text": "VariableDeclaration<string | string[] | null> | null"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "identifier",
+                  "type": {
+                    "text": "string"
+                  }
+                }
+              ],
+              "description": "Resolve a declared variable from the closest available scope: item-level\nfirst, then the test-level outcome variables. So an expression used in an\nassessmentTest's outcome processing can reference a test-level outcome\n(e.g. a total set earlier in the same run) — which the QTI variable\nexpression is specified to do. Returns null when unresolved rather than\nthrowing, so callers degrade gracefully.",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
+            {
               "kind": "field",
               "name": "result",
               "type": {
@@ -46635,6 +48420,18 @@
           "description": "",
           "name": "QtiRepeat",
           "members": [
+            {
+              "kind": "field",
+              "name": "_testContext",
+              "type": {
+                "text": "TestContext | undefined"
+              },
+              "privacy": "protected",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
             {
               "kind": "method",
               "name": "#resolveRepeatCount",
@@ -46730,6 +48527,29 @@
                 "text": "QtiContext | undefined"
               },
               "privacy": "protected",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
+            {
+              "kind": "method",
+              "name": "resolveVariable",
+              "privacy": "protected",
+              "return": {
+                "type": {
+                  "text": "VariableDeclaration<string | string[] | null> | null"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "identifier",
+                  "type": {
+                    "text": "string"
+                  }
+                }
+              ],
+              "description": "Resolve a declared variable from the closest available scope: item-level\nfirst, then the test-level outcome variables. So an expression used in an\nassessmentTest's outcome processing can reference a test-level outcome\n(e.g. a total set earlier in the same run) — which the QTI variable\nexpression is specified to do. Returns null when unresolved rather than\nthrowing, so callers degrade gracefully.",
               "inheritedFrom": {
                 "name": "QtiExpression",
                 "module": "packages/qti-base/src/abstract/qti-expression.ts"
@@ -47110,6 +48930,18 @@
           "name": "QtiRoundTo",
           "members": [
             {
+              "kind": "field",
+              "name": "_testContext",
+              "type": {
+                "text": "TestContext | undefined"
+              },
+              "privacy": "protected",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
+            {
               "kind": "method",
               "name": "#roundToDecimalPlaces",
               "privacy": "private",
@@ -47232,6 +49064,29 @@
               }
             },
             {
+              "kind": "method",
+              "name": "resolveVariable",
+              "privacy": "protected",
+              "return": {
+                "type": {
+                  "text": "VariableDeclaration<string | string[] | null> | null"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "identifier",
+                  "type": {
+                    "text": "string"
+                  }
+                }
+              ],
+              "description": "Resolve a declared variable from the closest available scope: item-level\nfirst, then the test-level outcome variables. So an expression used in an\nassessmentTest's outcome processing can reference a test-level outcome\n(e.g. a total set earlier in the same run) — which the QTI variable\nexpression is specified to do. Returns null when unresolved rather than\nthrowing, so callers degrade gracefully.",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
+            {
               "kind": "field",
               "name": "result",
               "type": {
@@ -47317,6 +49172,18 @@
           "name": "QtiRound",
           "members": [
             {
+              "kind": "field",
+              "name": "_testContext",
+              "type": {
+                "text": "TestContext | undefined"
+              },
+              "privacy": "protected",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
+            {
               "kind": "method",
               "name": "calculate",
               "privacy": "public",
@@ -47374,6 +49241,29 @@
                 "text": "QtiContext | undefined"
               },
               "privacy": "protected",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
+            {
+              "kind": "method",
+              "name": "resolveVariable",
+              "privacy": "protected",
+              "return": {
+                "type": {
+                  "text": "VariableDeclaration<string | string[] | null> | null"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "identifier",
+                  "type": {
+                    "text": "string"
+                  }
+                }
+              ],
+              "description": "Resolve a declared variable from the closest available scope: item-level\nfirst, then the test-level outcome variables. So an expression used in an\nassessmentTest's outcome processing can reference a test-level outcome\n(e.g. a total set earlier in the same run) — which the QTI variable\nexpression is specified to do. Returns null when unresolved rather than\nthrowing, so callers degrade gracefully.",
               "inheritedFrom": {
                 "name": "QtiExpression",
                 "module": "packages/qti-base/src/abstract/qti-expression.ts"
@@ -47445,9 +49335,9 @@
             "package": "lit"
           },
           "customElement": true,
-          "tagName": "qti-rule",
           "modulePath": "packages/qti-processing/src/components/qti-rule/qti-rule.ts",
-          "definitionPath": "packages/qti-processing/src/components/qti-rule/qti-rule.ts"
+          "definitionPath": "packages/qti-processing/src/components/qti-rule/qti-rule.ts",
+          "tagName": "qti-rule"
         }
       ],
       "exports": [
@@ -47877,6 +49767,18 @@
           "name": "QtiStatsOperator",
           "members": [
             {
+              "kind": "field",
+              "name": "_testContext",
+              "type": {
+                "text": "TestContext | undefined"
+              },
+              "privacy": "protected",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
+            {
               "kind": "method",
               "name": "#collectNumericValues",
               "privacy": "private",
@@ -47985,6 +49887,29 @@
               }
             },
             {
+              "kind": "method",
+              "name": "resolveVariable",
+              "privacy": "protected",
+              "return": {
+                "type": {
+                  "text": "VariableDeclaration<string | string[] | null> | null"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "identifier",
+                  "type": {
+                    "text": "string"
+                  }
+                }
+              ],
+              "description": "Resolve a declared variable from the closest available scope: item-level\nfirst, then the test-level outcome variables. So an expression used in an\nassessmentTest's outcome processing can reference a test-level outcome\n(e.g. a total set earlier in the same run) — which the QTI variable\nexpression is specified to do. Returns null when unresolved rather than\nthrowing, so callers degrade gracefully.",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
+            {
               "kind": "field",
               "name": "result",
               "type": {
@@ -48046,6 +49971,18 @@
           "description": "",
           "name": "QtiStringMatch",
           "members": [
+            {
+              "kind": "field",
+              "name": "_testContext",
+              "type": {
+                "text": "TestContext | undefined"
+              },
+              "privacy": "protected",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
             {
               "kind": "method",
               "name": "calculate",
@@ -48113,6 +50050,29 @@
                 "text": "QtiContext | undefined"
               },
               "privacy": "protected",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
+            {
+              "kind": "method",
+              "name": "resolveVariable",
+              "privacy": "protected",
+              "return": {
+                "type": {
+                  "text": "VariableDeclaration<string | string[] | null> | null"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "identifier",
+                  "type": {
+                    "text": "string"
+                  }
+                }
+              ],
+              "description": "Resolve a declared variable from the closest available scope: item-level\nfirst, then the test-level outcome variables. So an expression used in an\nassessmentTest's outcome processing can reference a test-level outcome\n(e.g. a total set earlier in the same run) — which the QTI variable\nexpression is specified to do. Returns null when unresolved rather than\nthrowing, so callers degrade gracefully.",
               "inheritedFrom": {
                 "name": "QtiExpression",
                 "module": "packages/qti-base/src/abstract/qti-expression.ts"
@@ -48180,6 +50140,18 @@
           "name": "QtiSubstring",
           "members": [
             {
+              "kind": "field",
+              "name": "_testContext",
+              "type": {
+                "text": "TestContext | undefined"
+              },
+              "privacy": "protected",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
+            {
               "kind": "method",
               "name": "calculate",
               "privacy": "public",
@@ -48246,6 +50218,29 @@
                 "text": "QtiContext | undefined"
               },
               "privacy": "protected",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
+            {
+              "kind": "method",
+              "name": "resolveVariable",
+              "privacy": "protected",
+              "return": {
+                "type": {
+                  "text": "VariableDeclaration<string | string[] | null> | null"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "identifier",
+                  "type": {
+                    "text": "string"
+                  }
+                }
+              ],
+              "description": "Resolve a declared variable from the closest available scope: item-level\nfirst, then the test-level outcome variables. So an expression used in an\nassessmentTest's outcome processing can reference a test-level outcome\n(e.g. a total set earlier in the same run) — which the QTI variable\nexpression is specified to do. Returns null when unresolved rather than\nthrowing, so callers degrade gracefully.",
               "inheritedFrom": {
                 "name": "QtiExpression",
                 "module": "packages/qti-base/src/abstract/qti-expression.ts"
@@ -48438,6 +50433,18 @@
           "name": "QtiSum",
           "members": [
             {
+              "kind": "field",
+              "name": "_testContext",
+              "type": {
+                "text": "TestContext | undefined"
+              },
+              "privacy": "protected",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
+            {
               "kind": "method",
               "name": "calculate",
               "privacy": "public",
@@ -48495,6 +50502,29 @@
                 "text": "QtiContext | undefined"
               },
               "privacy": "protected",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
+            {
+              "kind": "method",
+              "name": "resolveVariable",
+              "privacy": "protected",
+              "return": {
+                "type": {
+                  "text": "VariableDeclaration<string | string[] | null> | null"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "identifier",
+                  "type": {
+                    "text": "string"
+                  }
+                }
+              ],
+              "description": "Resolve a declared variable from the closest available scope: item-level\nfirst, then the test-level outcome variables. So an expression used in an\nassessmentTest's outcome processing can reference a test-level outcome\n(e.g. a total set earlier in the same run) — which the QTI variable\nexpression is specified to do. Returns null when unresolved rather than\nthrowing, so callers degrade gracefully.",
               "inheritedFrom": {
                 "name": "QtiExpression",
                 "module": "packages/qti-base/src/abstract/qti-expression.ts"
@@ -48573,6 +50603,18 @@
           "name": "QtiTruncate",
           "members": [
             {
+              "kind": "field",
+              "name": "_testContext",
+              "type": {
+                "text": "TestContext | undefined"
+              },
+              "privacy": "protected",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
+            {
               "kind": "method",
               "name": "calculate",
               "privacy": "public",
@@ -48636,6 +50678,29 @@
               }
             },
             {
+              "kind": "method",
+              "name": "resolveVariable",
+              "privacy": "protected",
+              "return": {
+                "type": {
+                  "text": "VariableDeclaration<string | string[] | null> | null"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "identifier",
+                  "type": {
+                    "text": "string"
+                  }
+                }
+              ],
+              "description": "Resolve a declared variable from the closest available scope: item-level\nfirst, then the test-level outcome variables. So an expression used in an\nassessmentTest's outcome processing can reference a test-level outcome\n(e.g. a total set earlier in the same run) — which the QTI variable\nexpression is specified to do. Returns null when unresolved rather than\nthrowing, so callers degrade gracefully.",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
+            {
               "kind": "field",
               "name": "result",
               "type": {
@@ -48687,6 +50752,18 @@
           "description": "",
           "name": "QtiVariable",
           "members": [
+            {
+              "kind": "field",
+              "name": "_testContext",
+              "type": {
+                "text": "TestContext | undefined"
+              },
+              "privacy": "protected",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
             {
               "kind": "method",
               "name": "calculate",
@@ -48745,6 +50822,29 @@
                 "text": "QtiContext | undefined"
               },
               "privacy": "protected",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
+            {
+              "kind": "method",
+              "name": "resolveVariable",
+              "privacy": "protected",
+              "return": {
+                "type": {
+                  "text": "VariableDeclaration<string | string[] | null> | null"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "identifier",
+                  "type": {
+                    "text": "string"
+                  }
+                }
+              ],
+              "description": "Resolve a declared variable from the closest available scope: item-level\nfirst, then the test-level outcome variables. So an expression used in an\nassessmentTest's outcome processing can reference a test-level outcome\n(e.g. a total set earlier in the same run) — which the QTI variable\nexpression is specified to do. Returns null when unresolved rather than\nthrowing, so callers degrade gracefully.",
               "inheritedFrom": {
                 "name": "QtiExpression",
                 "module": "packages/qti-base/src/abstract/qti-expression.ts"
@@ -49735,9 +51835,9 @@
             "package": "lit"
           },
           "customElement": true,
-          "tagName": "qti-assessment-item-ref",
           "modulePath": "packages/qti-test/src/components/qti-assessment-item-ref/qti-assessment-item-ref.ts",
-          "definitionPath": "packages/qti-test/src/components/qti-assessment-item-ref/qti-assessment-item-ref.ts"
+          "definitionPath": "packages/qti-test/src/components/qti-assessment-item-ref/qti-assessment-item-ref.ts",
+          "tagName": "qti-assessment-item-ref"
         }
       ],
       "exports": [
@@ -49925,9 +52025,9 @@
             "package": "lit"
           },
           "customElement": true,
-          "tagName": "qti-assessment-section",
           "modulePath": "packages/qti-test/src/components/qti-assessment-section/qti-assessment-section.ts",
-          "definitionPath": "packages/qti-test/src/components/qti-assessment-section/qti-assessment-section.ts"
+          "definitionPath": "packages/qti-test/src/components/qti-assessment-section/qti-assessment-section.ts",
+          "tagName": "qti-assessment-section"
         }
       ],
       "exports": [
@@ -50021,9 +52121,9 @@
             "package": "lit"
           },
           "customElement": true,
-          "tagName": "qti-assessment-test",
           "modulePath": "packages/qti-test/src/components/qti-assessment-test/qti-assessment-test.ts",
-          "definitionPath": "packages/qti-test/src/components/qti-assessment-test/qti-assessment-test.ts"
+          "definitionPath": "packages/qti-test/src/components/qti-assessment-test/qti-assessment-test.ts",
+          "tagName": "qti-assessment-test"
         }
       ],
       "exports": [
@@ -50190,9 +52290,9 @@
           },
           "summary": "The qti-item-session-control element contains configurations relating to flow of test sessions.",
           "customElement": true,
-          "tagName": "qti-item-session-control",
           "modulePath": "packages/qti-test/src/components/qti-item-session-control/qti-item-session-control.ts",
-          "definitionPath": "packages/qti-test/src/components/qti-item-session-control/qti-item-session-control.ts"
+          "definitionPath": "packages/qti-test/src/components/qti-item-session-control/qti-item-session-control.ts",
+          "tagName": "qti-item-session-control"
         }
       ],
       "exports": [
@@ -50237,9 +52337,9 @@
             "package": "lit"
           },
           "customElement": true,
-          "tagName": "qti-outcome-processing",
           "modulePath": "packages/qti-test/src/components/qti-outcome-processing/qti-outcome-processing.ts",
-          "definitionPath": "packages/qti-test/src/components/qti-outcome-processing/qti-outcome-processing.ts"
+          "definitionPath": "packages/qti-test/src/components/qti-outcome-processing/qti-outcome-processing.ts",
+          "tagName": "qti-outcome-processing"
         },
         {
           "kind": "class",
@@ -50656,9 +52756,9 @@
             "package": "lit"
           },
           "customElement": true,
-          "tagName": "qti-test-part",
           "modulePath": "packages/qti-test/src/components/qti-test-part/qti-test-part.ts",
-          "definitionPath": "packages/qti-test/src/components/qti-test-part/qti-test-part.ts"
+          "definitionPath": "packages/qti-test/src/components/qti-test-part/qti-test-part.ts",
+          "tagName": "qti-test-part"
         }
       ],
       "exports": [
@@ -50695,7 +52795,11 @@
               "type": {
                 "text": "TestContext | undefined"
               },
-              "privacy": "public"
+              "privacy": "protected",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
             },
             {
               "kind": "field",
@@ -50763,6 +52867,29 @@
                 "text": "QtiContext | undefined"
               },
               "privacy": "protected",
+              "inheritedFrom": {
+                "name": "QtiExpression",
+                "module": "packages/qti-base/src/abstract/qti-expression.ts"
+              }
+            },
+            {
+              "kind": "method",
+              "name": "resolveVariable",
+              "privacy": "protected",
+              "return": {
+                "type": {
+                  "text": "VariableDeclaration<string | string[] | null> | null"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "identifier",
+                  "type": {
+                    "text": "string"
+                  }
+                }
+              ],
+              "description": "Resolve a declared variable from the closest available scope: item-level\nfirst, then the test-level outcome variables. So an expression used in an\nassessmentTest's outcome processing can reference a test-level outcome\n(e.g. a total set earlier in the same run) — which the QTI variable\nexpression is specified to do. Returns null when unresolved rather than\nthrowing, so callers degrade gracefully.",
               "inheritedFrom": {
                 "name": "QtiExpression",
                 "module": "packages/qti-base/src/abstract/qti-expression.ts"
@@ -50884,9 +53011,9 @@
             "package": "lit"
           },
           "customElement": true,
-          "tagName": "qti-test",
           "modulePath": "packages/qti-test/src/components/qti-test/qti-test.ts",
-          "definitionPath": "packages/qti-test/src/components/qti-test/qti-test.ts"
+          "definitionPath": "packages/qti-test/src/components/qti-test/qti-test.ts",
+          "tagName": "qti-test"
         }
       ],
       "exports": [
@@ -50981,9 +53108,9 @@
             "package": "lit"
           },
           "customElement": true,
-          "tagName": "test-check-item",
           "modulePath": "packages/qti-test/src/components/test-check-item/test-check-item.ts",
-          "definitionPath": "packages/qti-test/src/components/test-check-item/test-check-item.ts"
+          "definitionPath": "packages/qti-test/src/components/test-check-item/test-check-item.ts",
+          "tagName": "test-check-item"
         }
       ],
       "exports": [
@@ -51153,9 +53280,9 @@
             "package": "lit"
           },
           "customElement": true,
-          "tagName": "test-container",
           "modulePath": "packages/qti-test/src/components/test-container/test-container.ts",
-          "definitionPath": "packages/qti-test/src/components/test-container/test-container.ts"
+          "definitionPath": "packages/qti-test/src/components/test-container/test-container.ts",
+          "tagName": "test-container"
         }
       ],
       "exports": [
@@ -51252,9 +53379,9 @@
             "package": "lit"
           },
           "customElement": true,
-          "tagName": "test-end-attempt",
           "modulePath": "packages/qti-test/src/components/test-end-attempt/test-end-attempt.ts",
-          "definitionPath": "packages/qti-test/src/components/test-end-attempt/test-end-attempt.ts"
+          "definitionPath": "packages/qti-test/src/components/test-end-attempt/test-end-attempt.ts",
+          "tagName": "test-end-attempt"
         }
       ],
       "exports": [
@@ -51337,9 +53464,9 @@
             "package": "lit"
           },
           "customElement": true,
-          "tagName": "test-item-link",
           "modulePath": "packages/qti-test/src/components/test-item-link/test-item-link.ts",
-          "definitionPath": "packages/qti-test/src/components/test-item-link/test-item-link.ts"
+          "definitionPath": "packages/qti-test/src/components/test-item-link/test-item-link.ts",
+          "tagName": "test-item-link"
         }
       ],
       "exports": [
@@ -51688,9 +53815,9 @@
             "package": "lit"
           },
           "customElement": true,
-          "tagName": "test-item-to-speech",
           "modulePath": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts",
-          "definitionPath": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts"
+          "definitionPath": "packages/qti-test/src/components/test-item-to-speech/test-item-to-speech.ts",
+          "tagName": "test-item-to-speech"
         },
         {
           "kind": "class",
@@ -52509,9 +54636,9 @@
             "package": "lit"
           },
           "customElement": true,
-          "tagName": "test-navigation",
           "modulePath": "packages/qti-test/src/components/test-navigation/test-navigation.ts",
-          "definitionPath": "packages/qti-test/src/components/test-navigation/test-navigation.ts"
+          "definitionPath": "packages/qti-test/src/components/test-navigation/test-navigation.ts",
+          "tagName": "test-navigation"
         }
       ],
       "exports": [
@@ -52672,9 +54799,9 @@
             "package": "lit"
           },
           "customElement": true,
-          "tagName": "test-next",
           "modulePath": "packages/qti-test/src/components/test-next/test-next.ts",
-          "definitionPath": "packages/qti-test/src/components/test-next/test-next.ts"
+          "definitionPath": "packages/qti-test/src/components/test-next/test-next.ts",
+          "tagName": "test-next"
         }
       ],
       "exports": [
@@ -52746,9 +54873,9 @@
           },
           "deprecated": "test-paging-buttons-stamp is deprecated and will be removed in the future.",
           "customElement": true,
-          "tagName": "test-paging-buttons-stamp",
           "modulePath": "packages/qti-test/src/components/test-paging-buttons-stamp/test-paging-buttons-stamp.ts",
-          "definitionPath": "packages/qti-test/src/components/test-paging-buttons-stamp/test-paging-buttons-stamp.ts"
+          "definitionPath": "packages/qti-test/src/components/test-paging-buttons-stamp/test-paging-buttons-stamp.ts",
+          "tagName": "test-paging-buttons-stamp"
         }
       ],
       "exports": [
@@ -52885,9 +55012,9 @@
             "package": "lit"
           },
           "customElement": true,
-          "tagName": "test-prev",
           "modulePath": "packages/qti-test/src/components/test-prev/test-prev.ts",
-          "definitionPath": "packages/qti-test/src/components/test-prev/test-prev.ts"
+          "definitionPath": "packages/qti-test/src/components/test-prev/test-prev.ts",
+          "tagName": "test-prev"
         }
       ],
       "exports": [
@@ -52935,9 +55062,9 @@
             "package": "lit"
           },
           "customElement": true,
-          "tagName": "test-print-context",
           "modulePath": "packages/qti-test/src/components/test-print-context/test-print-context.ts",
-          "definitionPath": "packages/qti-test/src/components/test-print-context/test-print-context.ts"
+          "definitionPath": "packages/qti-test/src/components/test-print-context/test-print-context.ts",
+          "tagName": "test-print-context"
         }
       ],
       "exports": [
@@ -52985,9 +55112,9 @@
             "package": "lit"
           },
           "customElement": true,
-          "tagName": "test-print-item-variables",
           "modulePath": "packages/qti-test/src/components/test-print-item-variables/test-print-item-variables.ts",
-          "definitionPath": "packages/qti-test/src/components/test-print-item-variables/test-print-item-variables.ts"
+          "definitionPath": "packages/qti-test/src/components/test-print-item-variables/test-print-item-variables.ts",
+          "tagName": "test-print-item-variables"
         }
       ],
       "exports": [
@@ -53100,9 +55227,9 @@
             "package": "lit"
           },
           "customElement": true,
-          "tagName": "test-scoring-buttons",
           "modulePath": "packages/qti-test/src/components/test-scoring-buttons/test-scoring-buttons.ts",
-          "definitionPath": "packages/qti-test/src/components/test-scoring-buttons/test-scoring-buttons.ts"
+          "definitionPath": "packages/qti-test/src/components/test-scoring-buttons/test-scoring-buttons.ts",
+          "tagName": "test-scoring-buttons"
         }
       ],
       "exports": [
@@ -53176,9 +55303,9 @@
             "package": "lit"
           },
           "customElement": true,
-          "tagName": "test-scoring-feedback",
           "modulePath": "packages/qti-test/src/components/test-scoring-feedback/test-scoring-feedback.ts",
-          "definitionPath": "packages/qti-test/src/components/test-scoring-feedback/test-scoring-feedback.ts"
+          "definitionPath": "packages/qti-test/src/components/test-scoring-feedback/test-scoring-feedback.ts",
+          "tagName": "test-scoring-feedback"
         }
       ],
       "exports": [
@@ -53250,9 +55377,9 @@
           },
           "deprecated": "test-section-buttons-stamp is deprecated and will be removed in the future.",
           "customElement": true,
-          "tagName": "test-section-buttons-stamp",
           "modulePath": "packages/qti-test/src/components/test-section-buttons-stamp/test-section-buttons-stamp.ts",
-          "definitionPath": "packages/qti-test/src/components/test-section-buttons-stamp/test-section-buttons-stamp.ts"
+          "definitionPath": "packages/qti-test/src/components/test-section-buttons-stamp/test-section-buttons-stamp.ts",
+          "tagName": "test-section-buttons-stamp"
         }
       ],
       "exports": [
@@ -53330,9 +55457,9 @@
             "package": "lit"
           },
           "customElement": true,
-          "tagName": "test-section-link",
           "modulePath": "packages/qti-test/src/components/test-section-link/test-section-link.ts",
-          "definitionPath": "packages/qti-test/src/components/test-section-link/test-section-link.ts"
+          "definitionPath": "packages/qti-test/src/components/test-section-link/test-section-link.ts",
+          "tagName": "test-section-link"
         }
       ],
       "exports": [
@@ -53504,9 +55631,9 @@
             "package": "lit"
           },
           "customElement": true,
-          "tagName": "test-view-toggle",
           "modulePath": "packages/qti-test/src/components/test-view-toggle/test-view-toggle.ts",
-          "definitionPath": "packages/qti-test/src/components/test-view-toggle/test-view-toggle.ts"
+          "definitionPath": "packages/qti-test/src/components/test-view-toggle/test-view-toggle.ts",
+          "tagName": "test-view-toggle"
         }
       ],
       "exports": [
@@ -53637,9 +55764,9 @@
             "package": "lit"
           },
           "customElement": true,
-          "tagName": "test-view",
           "modulePath": "packages/qti-test/src/components/test-view-toggle/test-view.ts",
-          "definitionPath": "packages/qti-test/src/components/test-view-toggle/test-view.ts"
+          "definitionPath": "packages/qti-test/src/components/test-view-toggle/test-view.ts",
+          "tagName": "test-view"
         }
       ],
       "exports": [

--- a/packages/qti-components/src/corrections.spec.ts
+++ b/packages/qti-components/src/corrections.spec.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+
+import { qtiCorrectionElements } from '@qti-components/corrections/elements';
+import { qtiInteractionElements } from '@qti-components/interactions/elements';
+
+/**
+ * The correction entry point has to win the race for its tags, and the way it loses is silent.
+ *
+ * Every `register.ts` in the workspace guards with `if (!customElements.get(tag))`, so if the
+ * standard constructors reach the global registry first the correction variants are skipped
+ * without an error — the page renders, and simply never shows a correct answer. Code splitting is
+ * what would cause that: if tsup ever puts one of the element-registering `register.js` modules
+ * into a chunk that `dist/corrections.js` imports, the standard set evaluates first and this
+ * entry is dead on arrival.
+ *
+ * Importing the module for its side effect is the whole test. It runs in its own browser context,
+ * so the global registry it mutates is not shared with other spec files.
+ */
+import './corrections';
+
+describe('@citolab/qti-components/corrections', () => {
+  it('registers the correction constructor for every tag it overrides', () => {
+    const wrong = qtiCorrectionElements.filter(({ tag, ctor }) => customElements.get(tag) !== ctor);
+
+    expect(wrong.map(({ tag }) => tag)).toEqual([]);
+  });
+
+  it('registers the standard constructor for interactions that have no correction variant', () => {
+    const overridden = new Set<string>(qtiCorrectionElements.map(({ tag }) => tag));
+    const untouched = qtiInteractionElements.filter(({ tag }) => !overridden.has(tag));
+
+    // Guards the assertion itself: if corrections ever covered every interaction this would
+    // pass vacuously.
+    expect(untouched.length).toBeGreaterThan(0);
+
+    const wrong = untouched.filter(({ tag, ctor }) => customElements.get(tag) !== ctor);
+    expect(wrong.map(({ tag }) => tag)).toEqual([]);
+  });
+});

--- a/packages/qti-components/src/corrections.ts
+++ b/packages/qti-components/src/corrections.ts
@@ -1,1 +1,81 @@
+/**
+ * Correction-mode entry point: the standard delivery elements with the correction variants
+ * substituted, registered globally.
+ *
+ *   <script type="module">import '@citolab/qti-components/corrections';</script>
+ *
+ * The sibling of the package root. `@citolab/qti-components` registers the standard elements;
+ * this registers the same set with the correction variants winning for the tags they cover, plus
+ * the correction-only controls (`item-show-correct-response`, `test-show-correct-response`,
+ * `item-correct-response-mode`, `item-show-candidate-correction`). Import ONE of the two.
+ *
+ * Why substitution rather than "corrections on top": the correction classes are keyed by the
+ * STANDARD tag names — `QtiChoiceInteractionCorrection` is `ChoiceCorrectionMixin(
+ * QtiChoiceInteraction)` registered as `qti-choice-interaction`. A registry holds one constructor
+ * per tag, so this is a replacement, never an addition. Everything without a correction variant —
+ * the processing operators, most test controls, interactions like media and upload — still gets
+ * its standard constructor, because a page needs those to work at all.
+ *
+ * Every import below is a `/elements` subpath, deliberately. The package ROOTS run their
+ * `register.ts` on evaluation and would define the standard constructors before this file gets to
+ * choose; `/elements` exports the `{ tag, ctor }` arrays and defines nothing.
+ */
+import { qtiBaseElements } from '@qti-components/base/elements';
+import { qtiContentElements } from '@qti-components/elements/elements';
+import { qtiItemElements } from '@qti-components/item/elements';
+import { qtiProcessingElements } from '@qti-components/processing/elements';
+import { qtiTestElements } from '@qti-components/test/elements';
+import { qtiInteractionElements } from '@qti-components/interactions/elements';
+import { qtiCorrectionElements } from '@qti-components/corrections/elements';
+
+const standardElements = [
+  ...qtiBaseElements,
+  ...qtiProcessingElements,
+  ...qtiContentElements,
+  ...qtiItemElements,
+  ...qtiTestElements,
+  ...qtiInteractionElements
+];
+
+// Keyed as `string`, not the inferred literal union: the lookup below is driven by the standard
+// tag lists, most of whose tags have no correction variant.
+const correctionByTag = new Map<string, CustomElementConstructor>(
+  qtiCorrectionElements.map(({ tag, ctor }) => [tag, ctor])
+);
+
+/**
+ * Registration is first-wins and silent — every `register.ts` in the workspace guards with
+ * `if (!customElements.get(tag))` so that a module graph holding two copies of a package does not
+ * throw `NotSupportedError` on the second define.
+ *
+ * That guard makes the failure mode here invisible: if anything already pulled in
+ * `@citolab/qti-components` (or a package root) the standard constructor holds the tag, this file
+ * skips it, and the page renders correctly EXCEPT that nothing ever shows a correct answer.
+ * Nothing throws and nothing logs. So say it out loud.
+ */
+const alreadyTaken = qtiCorrectionElements
+  .filter(({ tag, ctor }) => {
+    const registered = customElements.get(tag);
+    return registered !== undefined && registered !== ctor;
+  })
+  .map(({ tag }) => tag);
+
+if (alreadyTaken.length > 0) {
+  console.warn(
+    `[@citolab/qti-components/corrections] ${alreadyTaken.length} tag(s) were already registered ` +
+      `by another entry point, so the correction variants for them are inactive: ` +
+      `${alreadyTaken.join(', ')}. Import EITHER '@citolab/qti-components' OR ` +
+      `'@citolab/qti-components/corrections', not both.`
+  );
+}
+
+for (const { tag, ctor } of standardElements) {
+  if (!customElements.get(tag)) customElements.define(tag, correctionByTag.get(tag) ?? ctor);
+}
+
+// The correction-only controls, which replace no standard tag.
+for (const { tag, ctor } of qtiCorrectionElements) {
+  if (!customElements.get(tag)) customElements.define(tag, ctor);
+}
+
 export * from '@qti-components/corrections';

--- a/packages/qti-components/tsup.config.ts
+++ b/packages/qti-components/tsup.config.ts
@@ -95,7 +95,7 @@ export default defineConfig(async () => {
     clean: false, // handled by our npm script
     outDir: 'dist',
     format: 'esm',
-    entry: ['./src/**/*.ts'],
+    entry: ['./src/**/*.ts', '!./src/**/*.spec.ts'],
     external: litExternal,
     noExternal: bundledDependencies,
     splitting: true,


### PR DESCRIPTION
## What

`@citolab/qti-components/corrections` becomes a drop-in alternative to the package root. Where the root registers the standard delivery elements, this registers the same set with the correction variants substituted for the tags they cover, plus the correction-only controls (`item-show-correct-response`, `test-show-correct-response`, `item-correct-response-mode`, `item-show-candidate-correction`).

```html
<script type="module">
  import '@citolab/qti-components/corrections';
</script>
```

Import **one** of the two entry points, never both.

## Why substitution, not "corrections on top"

The correction classes are keyed by the *standard* tag names — `QtiChoiceInteractionCorrection` is `ChoiceCorrectionMixin(QtiChoiceInteraction)` registered as `qti-choice-interaction`. A registry holds one constructor per tag, so this is a replacement by construction. Elements with no correction variant (the processing operators, most test controls, interactions like media and upload) still get their standard constructor, because a page needs those to work at all.

Every import in the entry is an `/elements` subpath deliberately: the package roots run their `register.ts` on evaluation and would define the standard constructors before this file gets to choose. `/elements` exports the `{ tag, ctor }` arrays and defines nothing.

## The silent failure mode

Registration across the workspace is first-wins and silent — every `register.ts` guards with `if (!customElements.get(tag))` so a module graph holding two copies of a package doesn't throw `NotSupportedError` on the second define.

That guard makes this entry's failure invisible: if anything already pulled in `@citolab/qti-components` or a package root, the standard constructor holds the tag, this file skips it, and the page renders correctly **except** that nothing ever shows a correct answer. Nothing throws, nothing logs. So the entry now detects it and `console.warn`s, naming the tags it could not claim.

The new spec covers the other route to the same outcome: if tsup ever puts a registering `register.js` into a chunk that `dist/corrections.js` imports, the standard set evaluates first and this entry is dead on arrival. Importing the module for its side effect is the whole test.

## Also in here

- **`tsup.config.ts`**: the npm build's entry glob was `./src/**/*.ts`, so the new `corrections.spec.ts` got bundled into `dist` — a spec module, its `.d.ts`, and a 1.18 MB sourcemap, all headed for npm. Now excludes `**/*.spec.ts`. Verified: a clean rebuild produces no spec output.
- **`custom-elements.json`**: regenerated. Picks up the inherited `resolveVariable` / `_testContext` members from #198, which weren't committed at the time.

## Breaking

That subpath previously only re-exported `@qti-components/corrections` and registered nothing. It still exports everything it did, but importing it now defines custom elements. Anything importing it purely for the mixins, types or constructors should move to the package root. Importing `@citolab/qti-components` is unchanged.

Changeset included, marked `major`.

## Testing

- `corrections.spec.ts` — 2 passed
- VRT suite — 17 passed (pre-commit hook)
- eslint, prettier, `lint:vocab` — clean
- Clean rebuild of `@citolab/qti-components` — no spec files in `dist`