### PR TITLE
chore(deps): declare shared runtime deps through a pnpm catalog

### DIFF
--- a/.changeset/pnpm-catalog-lit-singleton.md
+++ b/.changeset/pnpm-catalog-lit-singleton.md
@@ -1,0 +1,37 @@
+---
+'@citolab/qti-components': patch
+---
+
+Declare the shared runtime dependencies through a pnpm catalog, so Lit cannot drift out of
+alignment again.
+
+`lit` was hand-written in 62 places across 34 manifests at two different ranges — `^3.3.1` in every
+`peerDependencies` block, `^3.3.3` in every `devDependencies` block — and `@citolab/qti-components`
+declared `^3.3.3` as a hard `dependency`. A consumer pinned to 3.3.1 or 3.3.2 could satisfy the
+parts and not the umbrella, which is how a package manager ends up installing a second copy of Lit.
+Two copies mean two `ReactiveElement` base classes (`instanceof` fails across them) and two
+`@lit/context` registries; because the contexts in `@qti-components/base` are keyed with a unique
+`Symbol()` rather than `Symbol.for`, every `@consume` then silently never resolves — no error, no
+log.
+
+`lit`, `@lit/context` and `@heximal/templates` now live in the `catalog:` block of
+`pnpm-workspace.yaml`, and every manifest references them as `"catalog:"`. The peer and dev ranges
+are unified on `^3.3.1`, the wider of the two: it still installs 3.3.3 locally, and narrowing it
+would exclude consumers the sibling packages already accept.
+
+The only change to a published manifest is `@citolab/qti-components`'s `dependencies.lit`, which
+widens from `^3.3.3` to `^3.3.1` to match its own parts. Every other packed manifest is byte
+identical — `pnpm pack` and `pnpm publish` resolve `catalog:` back to the real range in
+`dependencies`, `devDependencies` and `peerDependencies` alike. No resolved version changes.
+
+Two pieces of tooling had to move with it, because **npm does not understand the `catalog:`
+protocol and copies the literal string through**:
+
+- `tools/testing/consumer-types.mjs` now packs with `pnpm pack` instead of `npm pack`, and asserts
+  the packed manifest contains no leftover `catalog:` or `workspace:` range.
+- The pkg.pr.new prerelease workflow now passes `--pnpm`. pkg-pr-new shells out to `<pm> pack` and
+  that pm defaults to npm, so without the flag every prerelease tarball would have declared
+  `"lit": "catalog:"` — not a version range — and failed to install downstream.
+
+The `storybook` override also moves to the catalog, retiring the deprecated `$storybook`
+version-reference syntax that publint was warning about.

--- a/.github/workflows/prerelease-pkgr.yml
+++ b/.github/workflows/prerelease-pkgr.yml
@@ -53,5 +53,13 @@ jobs:
         run: pnpm run build
 
       # Use the installed binary (pnpm exec), NOT pnpm dlx / npx — required in CI.
+      #
+      # `--pnpm` is load-bearing, not a preference. pkg-pr-new packs each package by shelling out
+      # to `<pm> pack`, and that pm defaults to npm — only `--pnpm` flips it (the separate
+      # `--packageManager` flag is validated but never reaches the pack call). Workspace manifests
+      # declare their shared runtime deps as `"lit": "catalog:"`, which pnpm resolves to a real
+      # range while packing and npm copies through verbatim. Packed by npm, every prerelease
+      # tarball would declare `"lit": "catalog:"` — not a version range — and fail to install in
+      # QTI-Editor, which consumes this channel.
       - name: Publish prereleases to pkg.pr.new
-        run: pnpm exec pkg-pr-new publish './packages/*' './packages/interactions/*'
+        run: pnpm exec pkg-pr-new publish --pnpm './packages/*' './packages/interactions/*'

--- a/apps/e2e/package.json
+++ b/apps/e2e/package.json
@@ -6,8 +6,8 @@
   "type": "module",
   "dependencies": {
     "@citolab/qti-components": "workspace:^",
-    "@heximal/templates": "^0.1.5",
-    "@lit/context": "^1.1.6",
-    "lit": "^3.3.3"
+    "@heximal/templates": "catalog:",
+    "@lit/context": "catalog:",
+    "lit": "catalog:"
   }
 }

--- a/custom-elements.json
+++ b/custom-elements.json
@@ -16495,7 +16495,7 @@
                 "text": "any[] | NodeListOf<QtiAssociableHotspot>"
               },
               "parsedType": {
-                "text": "any[] | { item: {  }, forEach: {  }, entries: {  }, keys: {  }, values: {  }, __@iterator@361: {  }, length: number }"
+                "text": "any[] | { item: {  }, forEach: {  }, entries: {  }, keys: {  }, values: {  }, __@iterator@518: {  }, length: number }"
               }
             },
             {

--- a/packages/interactions/associate-interaction/package.json
+++ b/packages/interactions/associate-interaction/package.json
@@ -9,8 +9,8 @@
     "@qti-components/utilities": "workspace:^"
   },
   "devDependencies": {
-    "@lit/context": "^1.1.6",
-    "lit": "^3.3.3"
+    "@lit/context": "catalog:",
+    "lit": "catalog:"
   },
   "keywords": [
     "interactions",
@@ -20,8 +20,8 @@
   "license": "GPL-3.0-only",
   "main": "dist/index.js",
   "peerDependencies": {
-    "@lit/context": "^1.1.6",
-    "lit": "^3.3.1"
+    "@lit/context": "catalog:",
+    "lit": "catalog:"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/interactions/choice-interaction/package.json
+++ b/packages/interactions/choice-interaction/package.json
@@ -9,8 +9,8 @@
     "@qti-components/utilities": "workspace:^"
   },
   "devDependencies": {
-    "@lit/context": "^1.1.6",
-    "lit": "^3.3.3"
+    "@lit/context": "catalog:",
+    "lit": "catalog:"
   },
   "keywords": [
     "interactions",
@@ -20,8 +20,8 @@
   "license": "GPL-3.0-only",
   "main": "dist/index.js",
   "peerDependencies": {
-    "@lit/context": "^1.1.6",
-    "lit": "^3.3.1"
+    "@lit/context": "catalog:",
+    "lit": "catalog:"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/interactions/core/package.json
+++ b/packages/interactions/core/package.json
@@ -9,8 +9,8 @@
     "observable-polyfill": "^0.0.29"
   },
   "devDependencies": {
-    "@lit/context": "^1.1.6",
-    "lit": "^3.3.3"
+    "@lit/context": "catalog:",
+    "lit": "catalog:"
   },
   "keywords": [
     "interactions",
@@ -20,8 +20,8 @@
   "license": "GPL-3.0-only",
   "main": "dist/index.js",
   "peerDependencies": {
-    "@lit/context": "^1.1.6",
-    "lit": "^3.3.1"
+    "@lit/context": "catalog:",
+    "lit": "catalog:"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/interactions/custom-interaction/package.json
+++ b/packages/interactions/custom-interaction/package.json
@@ -9,8 +9,8 @@
     "@qti-components/utilities": "workspace:^"
   },
   "devDependencies": {
-    "@lit/context": "^1.1.6",
-    "lit": "^3.3.3"
+    "@lit/context": "catalog:",
+    "lit": "catalog:"
   },
   "keywords": [
     "interactions",
@@ -20,8 +20,8 @@
   "license": "GPL-3.0-only",
   "main": "dist/index.js",
   "peerDependencies": {
-    "@lit/context": "^1.1.6",
-    "lit": "^3.3.1"
+    "@lit/context": "catalog:",
+    "lit": "catalog:"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/interactions/end-attempt-interaction/package.json
+++ b/packages/interactions/end-attempt-interaction/package.json
@@ -9,8 +9,8 @@
     "@qti-components/utilities": "workspace:^"
   },
   "devDependencies": {
-    "@lit/context": "^1.1.6",
-    "lit": "^3.3.3"
+    "@lit/context": "catalog:",
+    "lit": "catalog:"
   },
   "keywords": [
     "interactions",
@@ -20,8 +20,8 @@
   "license": "GPL-3.0-only",
   "main": "dist/index.js",
   "peerDependencies": {
-    "@lit/context": "^1.1.6",
-    "lit": "^3.3.1"
+    "@lit/context": "catalog:",
+    "lit": "catalog:"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/interactions/extended-text-interaction/package.json
+++ b/packages/interactions/extended-text-interaction/package.json
@@ -9,8 +9,8 @@
     "@qti-components/utilities": "workspace:^"
   },
   "devDependencies": {
-    "@lit/context": "^1.1.6",
-    "lit": "^3.3.3"
+    "@lit/context": "catalog:",
+    "lit": "catalog:"
   },
   "keywords": [
     "interactions",
@@ -20,8 +20,8 @@
   "license": "GPL-3.0-only",
   "main": "dist/index.js",
   "peerDependencies": {
-    "@lit/context": "^1.1.6",
-    "lit": "^3.3.1"
+    "@lit/context": "catalog:",
+    "lit": "catalog:"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/interactions/gap-match-interaction/package.json
+++ b/packages/interactions/gap-match-interaction/package.json
@@ -9,8 +9,8 @@
     "@qti-components/utilities": "workspace:^"
   },
   "devDependencies": {
-    "@lit/context": "^1.1.6",
-    "lit": "^3.3.3"
+    "@lit/context": "catalog:",
+    "lit": "catalog:"
   },
   "keywords": [
     "interactions",
@@ -20,8 +20,8 @@
   "license": "GPL-3.0-only",
   "main": "dist/index.js",
   "peerDependencies": {
-    "@lit/context": "^1.1.6",
-    "lit": "^3.3.1"
+    "@lit/context": "catalog:",
+    "lit": "catalog:"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/interactions/graphic-associate-interaction/package.json
+++ b/packages/interactions/graphic-associate-interaction/package.json
@@ -9,8 +9,8 @@
     "@qti-components/utilities": "workspace:^"
   },
   "devDependencies": {
-    "@lit/context": "^1.1.6",
-    "lit": "^3.3.3"
+    "@lit/context": "catalog:",
+    "lit": "catalog:"
   },
   "keywords": [
     "interactions",
@@ -20,8 +20,8 @@
   "license": "GPL-3.0-only",
   "main": "dist/index.js",
   "peerDependencies": {
-    "@lit/context": "^1.1.6",
-    "lit": "^3.3.1"
+    "@lit/context": "catalog:",
+    "lit": "catalog:"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/interactions/graphic-gap-match-interaction/package.json
+++ b/packages/interactions/graphic-gap-match-interaction/package.json
@@ -9,8 +9,8 @@
     "@qti-components/utilities": "workspace:^"
   },
   "devDependencies": {
-    "@lit/context": "^1.1.6",
-    "lit": "^3.3.3"
+    "@lit/context": "catalog:",
+    "lit": "catalog:"
   },
   "keywords": [
     "interactions",
@@ -20,8 +20,8 @@
   "license": "GPL-3.0-only",
   "main": "dist/index.js",
   "peerDependencies": {
-    "@lit/context": "^1.1.6",
-    "lit": "^3.3.1"
+    "@lit/context": "catalog:",
+    "lit": "catalog:"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/interactions/graphic-order-interaction/package.json
+++ b/packages/interactions/graphic-order-interaction/package.json
@@ -9,8 +9,8 @@
     "@qti-components/utilities": "workspace:^"
   },
   "devDependencies": {
-    "@lit/context": "^1.1.6",
-    "lit": "^3.3.3"
+    "@lit/context": "catalog:",
+    "lit": "catalog:"
   },
   "keywords": [
     "interactions",
@@ -20,8 +20,8 @@
   "license": "GPL-3.0-only",
   "main": "dist/index.js",
   "peerDependencies": {
-    "@lit/context": "^1.1.6",
-    "lit": "^3.3.1"
+    "@lit/context": "catalog:",
+    "lit": "catalog:"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/interactions/hotspot-interaction/package.json
+++ b/packages/interactions/hotspot-interaction/package.json
@@ -9,8 +9,8 @@
     "@qti-components/utilities": "workspace:^"
   },
   "devDependencies": {
-    "@lit/context": "^1.1.6",
-    "lit": "^3.3.3"
+    "@lit/context": "catalog:",
+    "lit": "catalog:"
   },
   "keywords": [
     "interactions",
@@ -20,8 +20,8 @@
   "license": "GPL-3.0-only",
   "main": "dist/index.js",
   "peerDependencies": {
-    "@lit/context": "^1.1.6",
-    "lit": "^3.3.1"
+    "@lit/context": "catalog:",
+    "lit": "catalog:"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/interactions/hottext-interaction/package.json
+++ b/packages/interactions/hottext-interaction/package.json
@@ -9,8 +9,8 @@
     "@qti-components/utilities": "workspace:^"
   },
   "devDependencies": {
-    "@lit/context": "^1.1.6",
-    "lit": "^3.3.3"
+    "@lit/context": "catalog:",
+    "lit": "catalog:"
   },
   "keywords": [
     "interactions",
@@ -20,8 +20,8 @@
   "license": "GPL-3.0-only",
   "main": "dist/index.js",
   "peerDependencies": {
-    "@lit/context": "^1.1.6",
-    "lit": "^3.3.1"
+    "@lit/context": "catalog:",
+    "lit": "catalog:"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/interactions/inline-choice-interaction/package.json
+++ b/packages/interactions/inline-choice-interaction/package.json
@@ -9,8 +9,8 @@
     "@qti-components/utilities": "workspace:^"
   },
   "devDependencies": {
-    "@lit/context": "^1.1.6",
-    "lit": "^3.3.3"
+    "@lit/context": "catalog:",
+    "lit": "catalog:"
   },
   "keywords": [
     "interactions",
@@ -20,8 +20,8 @@
   "license": "GPL-3.0-only",
   "main": "dist/index.js",
   "peerDependencies": {
-    "@lit/context": "^1.1.6",
-    "lit": "^3.3.1"
+    "@lit/context": "catalog:",
+    "lit": "catalog:"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/interactions/match-interaction/package.json
+++ b/packages/interactions/match-interaction/package.json
@@ -9,8 +9,8 @@
     "@qti-components/utilities": "workspace:^"
   },
   "devDependencies": {
-    "@lit/context": "^1.1.6",
-    "lit": "^3.3.3"
+    "@lit/context": "catalog:",
+    "lit": "catalog:"
   },
   "keywords": [
     "interactions",
@@ -20,8 +20,8 @@
   "license": "GPL-3.0-only",
   "main": "dist/index.js",
   "peerDependencies": {
-    "@lit/context": "^1.1.6",
-    "lit": "^3.3.1"
+    "@lit/context": "catalog:",
+    "lit": "catalog:"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/interactions/media-interaction/package.json
+++ b/packages/interactions/media-interaction/package.json
@@ -9,8 +9,8 @@
     "@qti-components/utilities": "workspace:^"
   },
   "devDependencies": {
-    "@lit/context": "^1.1.6",
-    "lit": "^3.3.3"
+    "@lit/context": "catalog:",
+    "lit": "catalog:"
   },
   "keywords": [
     "interactions",
@@ -20,8 +20,8 @@
   "license": "GPL-3.0-only",
   "main": "dist/index.js",
   "peerDependencies": {
-    "@lit/context": "^1.1.6",
-    "lit": "^3.3.1"
+    "@lit/context": "catalog:",
+    "lit": "catalog:"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/interactions/order-interaction/package.json
+++ b/packages/interactions/order-interaction/package.json
@@ -9,8 +9,8 @@
     "@qti-components/utilities": "workspace:^"
   },
   "devDependencies": {
-    "@lit/context": "^1.1.6",
-    "lit": "^3.3.3"
+    "@lit/context": "catalog:",
+    "lit": "catalog:"
   },
   "keywords": [
     "interactions",
@@ -20,8 +20,8 @@
   "license": "GPL-3.0-only",
   "main": "dist/index.js",
   "peerDependencies": {
-    "@lit/context": "^1.1.6",
-    "lit": "^3.3.1"
+    "@lit/context": "catalog:",
+    "lit": "catalog:"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/interactions/portable-custom-interaction/package.json
+++ b/packages/interactions/portable-custom-interaction/package.json
@@ -9,8 +9,8 @@
     "@qti-components/utilities": "workspace:^"
   },
   "devDependencies": {
-    "@lit/context": "^1.1.6",
-    "lit": "^3.3.3"
+    "@lit/context": "catalog:",
+    "lit": "catalog:"
   },
   "keywords": [
     "interactions",
@@ -20,8 +20,8 @@
   "license": "GPL-3.0-only",
   "main": "dist/index.js",
   "peerDependencies": {
-    "@lit/context": "^1.1.6",
-    "lit": "^3.3.1"
+    "@lit/context": "catalog:",
+    "lit": "catalog:"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/interactions/position-object-interaction/package.json
+++ b/packages/interactions/position-object-interaction/package.json
@@ -9,8 +9,8 @@
     "@qti-components/utilities": "workspace:^"
   },
   "devDependencies": {
-    "@lit/context": "^1.1.6",
-    "lit": "^3.3.3"
+    "@lit/context": "catalog:",
+    "lit": "catalog:"
   },
   "keywords": [
     "interactions",
@@ -20,8 +20,8 @@
   "license": "GPL-3.0-only",
   "main": "dist/index.js",
   "peerDependencies": {
-    "@lit/context": "^1.1.6",
-    "lit": "^3.3.1"
+    "@lit/context": "catalog:",
+    "lit": "catalog:"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/interactions/select-point-interaction/package.json
+++ b/packages/interactions/select-point-interaction/package.json
@@ -9,8 +9,8 @@
     "@qti-components/utilities": "workspace:^"
   },
   "devDependencies": {
-    "@lit/context": "^1.1.6",
-    "lit": "^3.3.3"
+    "@lit/context": "catalog:",
+    "lit": "catalog:"
   },
   "keywords": [
     "interactions",
@@ -20,8 +20,8 @@
   "license": "GPL-3.0-only",
   "main": "dist/index.js",
   "peerDependencies": {
-    "@lit/context": "^1.1.6",
-    "lit": "^3.3.1"
+    "@lit/context": "catalog:",
+    "lit": "catalog:"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/interactions/slider-interaction/package.json
+++ b/packages/interactions/slider-interaction/package.json
@@ -9,8 +9,8 @@
     "@qti-components/utilities": "workspace:^"
   },
   "devDependencies": {
-    "@lit/context": "^1.1.6",
-    "lit": "^3.3.3"
+    "@lit/context": "catalog:",
+    "lit": "catalog:"
   },
   "keywords": [
     "interactions",
@@ -20,8 +20,8 @@
   "license": "GPL-3.0-only",
   "main": "dist/index.js",
   "peerDependencies": {
-    "@lit/context": "^1.1.6",
-    "lit": "^3.3.1"
+    "@lit/context": "catalog:",
+    "lit": "catalog:"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/interactions/text-entry-interaction/package.json
+++ b/packages/interactions/text-entry-interaction/package.json
@@ -9,8 +9,8 @@
     "@qti-components/utilities": "workspace:^"
   },
   "devDependencies": {
-    "@lit/context": "^1.1.6",
-    "lit": "^3.3.3"
+    "@lit/context": "catalog:",
+    "lit": "catalog:"
   },
   "keywords": [
     "interactions",
@@ -20,8 +20,8 @@
   "license": "GPL-3.0-only",
   "main": "dist/index.js",
   "peerDependencies": {
-    "@lit/context": "^1.1.6",
-    "lit": "^3.3.1"
+    "@lit/context": "catalog:",
+    "lit": "catalog:"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/interactions/upload-interaction/package.json
+++ b/packages/interactions/upload-interaction/package.json
@@ -9,8 +9,8 @@
     "@qti-components/utilities": "workspace:^"
   },
   "devDependencies": {
-    "@lit/context": "^1.1.6",
-    "lit": "^3.3.3"
+    "@lit/context": "catalog:",
+    "lit": "catalog:"
   },
   "keywords": [
     "interactions",
@@ -20,8 +20,8 @@
   "license": "GPL-3.0-only",
   "main": "dist/index.js",
   "peerDependencies": {
-    "@lit/context": "^1.1.6",
-    "lit": "^3.3.1"
+    "@lit/context": "catalog:",
+    "lit": "catalog:"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/qti-base/package.json
+++ b/packages/qti-base/package.json
@@ -7,8 +7,8 @@
     "@qti-components/utilities": "workspace:^"
   },
   "devDependencies": {
-    "@lit/context": "^1.1.6",
-    "lit": "^3.3.3"
+    "@lit/context": "catalog:",
+    "lit": "catalog:"
   },
   "keywords": [
     "qti",
@@ -32,8 +32,8 @@
     "./*": "./dist/*"
   },
   "peerDependencies": {
-    "@lit/context": "^1.1.6",
-    "lit": "^3.3.1"
+    "@lit/context": "catalog:",
+    "lit": "catalog:"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/qti-components/package.json
+++ b/packages/qti-components/package.json
@@ -4,9 +4,9 @@
   "version": "9.0.0",
   "author": "",
   "dependencies": {
-    "@heximal/templates": "^0.1.5",
-    "@lit/context": "^1.1.6",
-    "lit": "^3.3.3"
+    "@heximal/templates": "catalog:",
+    "@lit/context": "catalog:",
+    "lit": "catalog:"
   },
   "devDependencies": {
     "@qti-components/base": "workspace:^",

--- a/packages/qti-corrections/package.json
+++ b/packages/qti-corrections/package.json
@@ -30,8 +30,8 @@
     "@qti-components/utilities": "workspace:^"
   },
   "devDependencies": {
-    "@lit/context": "^1.1.6",
-    "lit": "^3.3.3"
+    "@lit/context": "catalog:",
+    "lit": "catalog:"
   },
   "keywords": [
     "qti",
@@ -41,8 +41,8 @@
   "license": "GPL-3.0-only",
   "main": "dist/index.js",
   "peerDependencies": {
-    "@lit/context": "^1.1.6",
-    "lit": "^3.3.1"
+    "@lit/context": "catalog:",
+    "lit": "catalog:"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/qti-elements/package.json
+++ b/packages/qti-elements/package.json
@@ -9,8 +9,8 @@
     "@qti-components/utilities": "workspace:^"
   },
   "devDependencies": {
-    "@lit/context": "^1.1.6",
-    "lit": "^3.3.3"
+    "@lit/context": "catalog:",
+    "lit": "catalog:"
   },
   "keywords": [
     "elements",
@@ -34,8 +34,8 @@
     "./*": "./dist/*"
   },
   "peerDependencies": {
-    "@lit/context": "^1.1.6",
-    "lit": "^3.3.1"
+    "@lit/context": "catalog:",
+    "lit": "catalog:"
   },
   "scripts": {
     "attw": "attw --profile esm-only --pack",

--- a/packages/qti-interactions/package.json
+++ b/packages/qti-interactions/package.json
@@ -29,10 +29,10 @@
     "@qti-components/upload-interaction": "workspace:^"
   },
   "devDependencies": {
-    "@lit/context": "^1.1.6",
+    "@lit/context": "catalog:",
     "@qti-components/theme": "workspace:^",
     "@qti-components/transformers": "workspace:^",
-    "lit": "^3.3.3"
+    "lit": "catalog:"
   },
   "exports": {
     ".": {
@@ -63,8 +63,8 @@
   "license": "GPL-3.0-only",
   "main": "dist/index.js",
   "peerDependencies": {
-    "@lit/context": "^1.1.6",
-    "lit": "^3.3.1"
+    "@lit/context": "catalog:",
+    "lit": "catalog:"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/qti-item/package.json
+++ b/packages/qti-item/package.json
@@ -12,9 +12,9 @@
     "@qti-components/utilities": "workspace:^"
   },
   "devDependencies": {
-    "@lit/context": "^1.1.6",
+    "@lit/context": "catalog:",
     "@qti-components/theme": "workspace:^",
-    "lit": "^3.3.3"
+    "lit": "catalog:"
   },
   "keywords": [
     "item",
@@ -38,8 +38,8 @@
     "./*": "./dist/*"
   },
   "peerDependencies": {
-    "@lit/context": "^1.1.6",
-    "lit": "^3.3.1"
+    "@lit/context": "catalog:",
+    "lit": "catalog:"
   },
   "scripts": {
     "attw": "attw --profile esm-only --pack",

--- a/packages/qti-processing/package.json
+++ b/packages/qti-processing/package.json
@@ -8,8 +8,8 @@
     "@qti-components/utilities": "workspace:^"
   },
   "devDependencies": {
-    "@lit/context": "^1.1.6",
-    "lit": "^3.3.3"
+    "@lit/context": "catalog:",
+    "lit": "catalog:"
   },
   "keywords": [
     "processing",
@@ -33,8 +33,8 @@
     "./*": "./dist/*"
   },
   "peerDependencies": {
-    "@lit/context": "^1.1.6",
-    "lit": "^3.3.1"
+    "@lit/context": "catalog:",
+    "lit": "catalog:"
   },
   "scripts": {
     "attw": "attw --profile esm-only --pack",

--- a/packages/qti-test/package.json
+++ b/packages/qti-test/package.json
@@ -13,9 +13,9 @@
     "@qti-components/utilities": "workspace:^"
   },
   "devDependencies": {
-    "@heximal/templates": "^0.1.5",
-    "@lit/context": "^1.1.6",
-    "lit": "^3.3.3"
+    "@heximal/templates": "catalog:",
+    "@lit/context": "catalog:",
+    "lit": "catalog:"
   },
   "keywords": [
     "qti",
@@ -39,9 +39,9 @@
     "./*": "./dist/*"
   },
   "peerDependencies": {
-    "@heximal/templates": "^0.1.5",
-    "@lit/context": "^1.1.6",
-    "lit": "^3.3.1"
+    "@heximal/templates": "catalog:",
+    "@lit/context": "catalog:",
+    "lit": "catalog:"
   },
   "scripts": {
     "attw": "attw --profile esm-only --pack",

--- a/packages/qti-utilities/package.json
+++ b/packages/qti-utilities/package.json
@@ -4,7 +4,7 @@
   "version": "1.3.3",
   "author": "",
   "devDependencies": {
-    "lit": "^3.3.3"
+    "lit": "catalog:"
   },
   "keywords": [
     "qti",
@@ -13,7 +13,7 @@
   "license": "GPL-3.0-only",
   "main": "dist/index.js",
   "peerDependencies": {
-    "lit": "^3.3.1"
+    "lit": "catalog:"
   },
   "publishConfig": {
     "access": "public"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,18 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+catalogs:
+  default:
+    '@heximal/templates':
+      specifier: ^0.1.5
+      version: 0.1.5
+    '@lit/context':
+      specifier: ^1.1.6
+      version: 1.1.6
+    lit:
+      specifier: ^3.3.1
+      version: 3.3.3
+
 overrides:
   storybook: ^10.6.0
   caniuse-lite: 1.0.30001805
@@ -292,13 +304,13 @@ importers:
         specifier: workspace:^
         version: link:../../packages/qti-components
       '@heximal/templates':
-        specifier: ^0.1.5
+        specifier: 'catalog:'
         version: 0.1.5
       '@lit/context':
-        specifier: ^1.1.6
+        specifier: 'catalog:'
         version: 1.1.6
       lit:
-        specifier: ^3.3.3
+        specifier: 'catalog:'
         version: 3.3.3
 
   packages/interactions/associate-interaction:
@@ -314,10 +326,10 @@ importers:
         version: link:../../qti-utilities
     devDependencies:
       '@lit/context':
-        specifier: ^1.1.6
+        specifier: 'catalog:'
         version: 1.1.6
       lit:
-        specifier: ^3.3.3
+        specifier: 'catalog:'
         version: 3.3.3
 
   packages/interactions/choice-interaction:
@@ -333,10 +345,10 @@ importers:
         version: link:../../qti-utilities
     devDependencies:
       '@lit/context':
-        specifier: ^1.1.6
+        specifier: 'catalog:'
         version: 1.1.6
       lit:
-        specifier: ^3.3.3
+        specifier: 'catalog:'
         version: 3.3.3
 
   packages/interactions/core:
@@ -352,10 +364,10 @@ importers:
         version: 0.0.29
     devDependencies:
       '@lit/context':
-        specifier: ^1.1.6
+        specifier: 'catalog:'
         version: 1.1.6
       lit:
-        specifier: ^3.3.3
+        specifier: 'catalog:'
         version: 3.3.3
 
   packages/interactions/custom-interaction:
@@ -371,10 +383,10 @@ importers:
         version: link:../../qti-utilities
     devDependencies:
       '@lit/context':
-        specifier: ^1.1.6
+        specifier: 'catalog:'
         version: 1.1.6
       lit:
-        specifier: ^3.3.3
+        specifier: 'catalog:'
         version: 3.3.3
 
   packages/interactions/end-attempt-interaction:
@@ -390,10 +402,10 @@ importers:
         version: link:../../qti-utilities
     devDependencies:
       '@lit/context':
-        specifier: ^1.1.6
+        specifier: 'catalog:'
         version: 1.1.6
       lit:
-        specifier: ^3.3.3
+        specifier: 'catalog:'
         version: 3.3.3
 
   packages/interactions/extended-text-interaction:
@@ -409,10 +421,10 @@ importers:
         version: link:../../qti-utilities
     devDependencies:
       '@lit/context':
-        specifier: ^1.1.6
+        specifier: 'catalog:'
         version: 1.1.6
       lit:
-        specifier: ^3.3.3
+        specifier: 'catalog:'
         version: 3.3.3
 
   packages/interactions/gap-match-interaction:
@@ -428,10 +440,10 @@ importers:
         version: link:../../qti-utilities
     devDependencies:
       '@lit/context':
-        specifier: ^1.1.6
+        specifier: 'catalog:'
         version: 1.1.6
       lit:
-        specifier: ^3.3.3
+        specifier: 'catalog:'
         version: 3.3.3
 
   packages/interactions/graphic-associate-interaction:
@@ -447,10 +459,10 @@ importers:
         version: link:../../qti-utilities
     devDependencies:
       '@lit/context':
-        specifier: ^1.1.6
+        specifier: 'catalog:'
         version: 1.1.6
       lit:
-        specifier: ^3.3.3
+        specifier: 'catalog:'
         version: 3.3.3
 
   packages/interactions/graphic-gap-match-interaction:
@@ -466,10 +478,10 @@ importers:
         version: link:../../qti-utilities
     devDependencies:
       '@lit/context':
-        specifier: ^1.1.6
+        specifier: 'catalog:'
         version: 1.1.6
       lit:
-        specifier: ^3.3.3
+        specifier: 'catalog:'
         version: 3.3.3
 
   packages/interactions/graphic-order-interaction:
@@ -485,10 +497,10 @@ importers:
         version: link:../../qti-utilities
     devDependencies:
       '@lit/context':
-        specifier: ^1.1.6
+        specifier: 'catalog:'
         version: 1.1.6
       lit:
-        specifier: ^3.3.3
+        specifier: 'catalog:'
         version: 3.3.3
 
   packages/interactions/hotspot-interaction:
@@ -504,10 +516,10 @@ importers:
         version: link:../../qti-utilities
     devDependencies:
       '@lit/context':
-        specifier: ^1.1.6
+        specifier: 'catalog:'
         version: 1.1.6
       lit:
-        specifier: ^3.3.3
+        specifier: 'catalog:'
         version: 3.3.3
 
   packages/interactions/hottext-interaction:
@@ -523,10 +535,10 @@ importers:
         version: link:../../qti-utilities
     devDependencies:
       '@lit/context':
-        specifier: ^1.1.6
+        specifier: 'catalog:'
         version: 1.1.6
       lit:
-        specifier: ^3.3.3
+        specifier: 'catalog:'
         version: 3.3.3
 
   packages/interactions/inline-choice-interaction:
@@ -542,10 +554,10 @@ importers:
         version: link:../../qti-utilities
     devDependencies:
       '@lit/context':
-        specifier: ^1.1.6
+        specifier: 'catalog:'
         version: 1.1.6
       lit:
-        specifier: ^3.3.3
+        specifier: 'catalog:'
         version: 3.3.3
 
   packages/interactions/match-interaction:
@@ -561,10 +573,10 @@ importers:
         version: link:../../qti-utilities
     devDependencies:
       '@lit/context':
-        specifier: ^1.1.6
+        specifier: 'catalog:'
         version: 1.1.6
       lit:
-        specifier: ^3.3.3
+        specifier: 'catalog:'
         version: 3.3.3
 
   packages/interactions/media-interaction:
@@ -580,10 +592,10 @@ importers:
         version: link:../../qti-utilities
     devDependencies:
       '@lit/context':
-        specifier: ^1.1.6
+        specifier: 'catalog:'
         version: 1.1.6
       lit:
-        specifier: ^3.3.3
+        specifier: 'catalog:'
         version: 3.3.3
 
   packages/interactions/order-interaction:
@@ -599,10 +611,10 @@ importers:
         version: link:../../qti-utilities
     devDependencies:
       '@lit/context':
-        specifier: ^1.1.6
+        specifier: 'catalog:'
         version: 1.1.6
       lit:
-        specifier: ^3.3.3
+        specifier: 'catalog:'
         version: 3.3.3
 
   packages/interactions/portable-custom-interaction:
@@ -618,10 +630,10 @@ importers:
         version: link:../../qti-utilities
     devDependencies:
       '@lit/context':
-        specifier: ^1.1.6
+        specifier: 'catalog:'
         version: 1.1.6
       lit:
-        specifier: ^3.3.3
+        specifier: 'catalog:'
         version: 3.3.3
 
   packages/interactions/position-object-interaction:
@@ -637,10 +649,10 @@ importers:
         version: link:../../qti-utilities
     devDependencies:
       '@lit/context':
-        specifier: ^1.1.6
+        specifier: 'catalog:'
         version: 1.1.6
       lit:
-        specifier: ^3.3.3
+        specifier: 'catalog:'
         version: 3.3.3
 
   packages/interactions/select-point-interaction:
@@ -656,10 +668,10 @@ importers:
         version: link:../../qti-utilities
     devDependencies:
       '@lit/context':
-        specifier: ^1.1.6
+        specifier: 'catalog:'
         version: 1.1.6
       lit:
-        specifier: ^3.3.3
+        specifier: 'catalog:'
         version: 3.3.3
 
   packages/interactions/slider-interaction:
@@ -675,10 +687,10 @@ importers:
         version: link:../../qti-utilities
     devDependencies:
       '@lit/context':
-        specifier: ^1.1.6
+        specifier: 'catalog:'
         version: 1.1.6
       lit:
-        specifier: ^3.3.3
+        specifier: 'catalog:'
         version: 3.3.3
 
   packages/interactions/text-entry-interaction:
@@ -694,10 +706,10 @@ importers:
         version: link:../../qti-utilities
     devDependencies:
       '@lit/context':
-        specifier: ^1.1.6
+        specifier: 'catalog:'
         version: 1.1.6
       lit:
-        specifier: ^3.3.3
+        specifier: 'catalog:'
         version: 3.3.3
 
   packages/interactions/upload-interaction:
@@ -713,10 +725,10 @@ importers:
         version: link:../../qti-utilities
     devDependencies:
       '@lit/context':
-        specifier: ^1.1.6
+        specifier: 'catalog:'
         version: 1.1.6
       lit:
-        specifier: ^3.3.3
+        specifier: 'catalog:'
         version: 3.3.3
 
   packages/qti-base:
@@ -726,22 +738,22 @@ importers:
         version: link:../qti-utilities
     devDependencies:
       '@lit/context':
-        specifier: ^1.1.6
+        specifier: 'catalog:'
         version: 1.1.6
       lit:
-        specifier: ^3.3.3
+        specifier: 'catalog:'
         version: 3.3.3
 
   packages/qti-components:
     dependencies:
       '@heximal/templates':
-        specifier: ^0.1.5
+        specifier: 'catalog:'
         version: 0.1.5
       '@lit/context':
-        specifier: ^1.1.6
+        specifier: 'catalog:'
         version: 1.1.6
       lit:
-        specifier: ^3.3.3
+        specifier: 'catalog:'
         version: 3.3.3
     devDependencies:
       '@qti-components/base':
@@ -851,10 +863,10 @@ importers:
         version: link:../qti-utilities
     devDependencies:
       '@lit/context':
-        specifier: ^1.1.6
+        specifier: 'catalog:'
         version: 1.1.6
       lit:
-        specifier: ^3.3.3
+        specifier: 'catalog:'
         version: 3.3.3
 
   packages/qti-elements:
@@ -870,10 +882,10 @@ importers:
         version: link:../qti-utilities
     devDependencies:
       '@lit/context':
-        specifier: ^1.1.6
+        specifier: 'catalog:'
         version: 1.1.6
       lit:
-        specifier: ^3.3.3
+        specifier: 'catalog:'
         version: 3.3.3
 
   packages/qti-interactions:
@@ -949,7 +961,7 @@ importers:
         version: link:../interactions/upload-interaction
     devDependencies:
       '@lit/context':
-        specifier: ^1.1.6
+        specifier: 'catalog:'
         version: 1.1.6
       '@qti-components/theme':
         specifier: workspace:^
@@ -958,7 +970,7 @@ importers:
         specifier: workspace:^
         version: link:../qti-transformers
       lit:
-        specifier: ^3.3.3
+        specifier: 'catalog:'
         version: 3.3.3
 
   packages/qti-item:
@@ -983,13 +995,13 @@ importers:
         version: link:../qti-utilities
     devDependencies:
       '@lit/context':
-        specifier: ^1.1.6
+        specifier: 'catalog:'
         version: 1.1.6
       '@qti-components/theme':
         specifier: workspace:^
         version: link:../qti-theme
       lit:
-        specifier: ^3.3.3
+        specifier: 'catalog:'
         version: 3.3.3
 
   packages/qti-loader:
@@ -1011,10 +1023,10 @@ importers:
         version: link:../qti-utilities
     devDependencies:
       '@lit/context':
-        specifier: ^1.1.6
+        specifier: 'catalog:'
         version: 1.1.6
       lit:
-        specifier: ^3.3.3
+        specifier: 'catalog:'
         version: 3.3.3
 
   packages/qti-test:
@@ -1042,13 +1054,13 @@ importers:
         version: link:../qti-utilities
     devDependencies:
       '@heximal/templates':
-        specifier: ^0.1.5
+        specifier: 'catalog:'
         version: 0.1.5
       '@lit/context':
-        specifier: ^1.1.6
+        specifier: 'catalog:'
         version: 1.1.6
       lit:
-        specifier: ^3.3.3
+        specifier: 'catalog:'
         version: 3.3.3
 
   packages/qti-theme:
@@ -1062,7 +1074,7 @@ importers:
   packages/qti-utilities:
     devDependencies:
       lit:
-        specifier: ^3.3.3
+        specifier: 'catalog:'
         version: 3.3.3
 
 packages:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,8 +3,39 @@ packages:
   - packages/*
   - packages/interactions/*
 
+# Single source of truth for the runtime dependencies that MUST be one instance across the
+# workspace. Every package writes `"lit": "catalog:"` instead of a literal range.
+#
+# Lit was hand-written in 62 places at two different ranges — `^3.3.1` in every peerDependencies
+# block and `^3.3.3` in every devDependencies block — and the umbrella declared `^3.3.3` as a hard
+# `dependency`. A consumer pinned to 3.3.1 or 3.3.2 could satisfy the parts and not the umbrella,
+# which is how a second copy of Lit gets installed. Two copies mean two `ReactiveElement` base
+# classes (`instanceof` fails across them) and two `@lit/context` registries; because the contexts
+# in qti-base are keyed with a unique `Symbol()` rather than `Symbol.for`, every `@consume` then
+# silently never resolves — no error, no log.
+#
+# One entry, so peer and dev ranges cannot drift apart again. `^3.3.1` (the wider peer range) is
+# the correct one to keep: it still installs 3.3.3 locally, and narrowing it would exclude
+# consumers the sibling packages already accept.
+#
+# `pnpm pack`/`pnpm publish` rewrite `catalog:` to the real range in dependencies,
+# devDependencies AND peerDependencies, so published manifests are unaffected. `npm pack` does
+# NOT — it ships the literal string `"lit": "catalog:"` — so any tooling that packs this workspace
+# must use pnpm. See tools/testing/consumer-types.mjs.
+#
+# Only cross-cutting runtime deps belong here. Build tooling lives in the root package.json alone,
+# where there is no second copy to drift from, and single-use deps (sass, observable-polyfill)
+# gain nothing.
+catalog:
+  lit: ^3.3.1
+  '@lit/context': ^1.1.6
+  '@heximal/templates': ^0.1.5
+  storybook: ^10.6.0
+
 overrides:
-  storybook: $storybook
+  # `catalog:` rather than the `$storybook` version-reference syntax, which pnpm has deprecated
+  # (publint flags it).
+  storybook: 'catalog:'
   caniuse-lite: 1.0.30001805
   esbuild@>=0.27.3 <0.28.1: ^0.28.1
   mdx-mermaid>puppeteer: '-'

--- a/tools/testing/consumer-types.mjs
+++ b/tools/testing/consumer-types.mjs
@@ -14,6 +14,14 @@
  * So: pack the package, install the tarball into a scratch project outside the workspace,
  * and run tsc over a fixture that uses the public API. Any unresolvable import shows up as
  * the member types collapsing, which the fixture's assignments then reject.
+ *
+ * Pack with `pnpm pack`, never `npm pack`. Workspace manifests declare their cross-cutting
+ * runtime deps as `"lit": "catalog:"` (see the catalog in pnpm-workspace.yaml). pnpm rewrites
+ * that to the real range while packing — in dependencies, devDependencies AND peerDependencies
+ * — exactly as `pnpm publish` does. npm knows nothing about the protocol and copies the literal
+ * string through, so an npm-packed tarball declares `"lit": "catalog:"`, which is not a version
+ * range. That tarball is not what gets published, so testing it would prove nothing about the
+ * real artifact.
  */
 import { execFileSync } from 'node:child_process';
 import { mkdtempSync, cpSync, readFileSync, writeFileSync, rmSync } from 'node:fs';
@@ -32,7 +40,25 @@ const scratch = mkdtempSync(join(tmpdir(), 'qti-consumer-types-'));
 let failed = false;
 try {
   console.log(`consumer-types: packing @citolab/qti-components…`);
-  const packed = run('npm', ['pack', '--silent', '--pack-destination', scratch], pkgDir).trim().split('\n').pop();
+  // `--out` rather than parsing stdout: pnpm pack prints a "Tarball Details" report, not a bare
+  // filename the way `npm pack --silent` does.
+  const packed = join(scratch, 'package.tgz');
+  run('pnpm', ['pack', '--out', packed], pkgDir);
+
+  // The packed manifest is the artifact consumers actually get. Assert pnpm resolved every
+  // workspace-only protocol out of it — a literal `catalog:` or `workspace:` range would make the
+  // tarball uninstallable, and reaching this point with one means something packed it with npm.
+  const packedManifest = JSON.parse(run('tar', ['xzOf', packed, 'package/package.json'], scratch));
+  for (const field of ['dependencies', 'peerDependencies', 'optionalDependencies']) {
+    for (const [name, range] of Object.entries(packedManifest[field] ?? {})) {
+      if (/^(catalog|workspace):/.test(range)) {
+        throw new Error(
+          `consumer-types: the packed manifest still declares ${field}.${name} as "${range}". ` +
+            'pnpm rewrites these while packing; npm does not. Pack with pnpm.'
+        );
+      }
+    }
+  }
 
   cpSync(fixture, scratch, { recursive: true });
   writeFileSync(
@@ -53,11 +79,7 @@ try {
   writeFileSync(join(scratch, 'tsconfig.json'), JSON.stringify(config, null, 2));
 
   console.log('consumer-types: installing the tarball into a scratch project…');
-  run(
-    'npm',
-    ['install', '--silent', '--no-audit', '--no-fund', 'typescript@5.9.3', 'lit@3.3.3', join(scratch, packed)],
-    scratch
-  );
+  run('npm', ['install', '--silent', '--no-audit', '--no-fund', 'typescript@5.9.3', 'lit@3.3.3', packed], scratch);
 
   console.log('consumer-types: type-checking…');
   try {


### PR DESCRIPTION
First of a short stack that makes `@citolab/qti-components` packaging unambiguous. This one is self-contained and safe to merge on its own.

## Why

`lit` was hand-written in **62 places across 34 manifests at two different ranges** — `^3.3.1` in every `peerDependencies` block, `^3.3.3` in every `devDependencies` block — while `@citolab/qti-components` declared `^3.3.3` as a hard `dependency`.

A consumer pinned to 3.3.1 or 3.3.2 could satisfy the parts and not the umbrella, which is how a package manager ends up installing a second copy of Lit. Two copies mean two `ReactiveElement` base classes (`instanceof` fails across them) and two `@lit/context` registries — and because the contexts in `@qti-components/base` are keyed with a unique `Symbol()` rather than `Symbol.for`, every `@consume` then **silently never resolves**. No error, no log.

## What changed

`lit`, `@lit/context` and `@heximal/templates` move to the `catalog:` block of `pnpm-workspace.yaml`; every manifest references them as `"catalog:"`. Peer and dev ranges unify on `^3.3.1`, the wider of the two — it still installs 3.3.3 locally, and narrowing it would exclude consumers the sibling packages already accept.

The `storybook` override also moves to the catalog, retiring the deprecated `$storybook` version-reference syntax publint was warning about.

## Blast radius: one line of one published manifest

Only the umbrella's `dependencies.lit` changes, widening `^3.3.3` → `^3.3.1` to match its own parts. Every other packed manifest is **byte identical** and no resolved version changes — verified by packing `qti-base`, `qti-test`, `choice-interaction` and the umbrella and diffing. `pnpm pack`/`pnpm publish` resolve `catalog:` back to the real range in `dependencies`, `devDependencies` and `peerDependencies` alike.

## Two tooling fixes this forced

**npm does not understand the `catalog:` protocol — it copies the literal string through.** Verified against a real npm-packed tarball of `@qti-components/base`, which came out declaring `"lit": "catalog:"`.

- `tools/testing/consumer-types.mjs` now packs with `pnpm pack` (using `--out`, since pnpm prints a report rather than a bare filename) and asserts the packed manifest carries no leftover `catalog:`/`workspace:` range. Guard verified to fire on an npm-packed tarball.
- **`.github/workflows/prerelease-pkgr.yml` now passes `--pnpm`.** This one would have broken prereleases on merge: pkg-pr-new shells out to `` `<pm> pack` `` and that pm **defaults to npm** — only `--pnpm` flips it, as the separate `--packageManager` flag is validated but never reaches the pack call. Without it, every prerelease tarball would have declared `"lit": "catalog:"` — not a version range — and failed to install in QTI-Editor, which consumes that channel.

`publint` was already safe; it packs with pnpm internally.

## Scope note

The plan called for cataloging the shared tooling devDependencies too. A survey of all 35 workspace manifests showed that would be churn with no drift to prevent: `lit` is the **only** dependency that diverges, and every build tool lives in the root `package.json` alone. `sass` and `observable-polyfill` are single-use. Left them alone.

## Verification

- `pnpm install` clean; `sherif`, `manypkg`, `syncpack lint` all pass
- `build`, `lint`, `tsc`, `madge` green
- `publint` — all good; `attw` — 30 packages, no problems
- `consumer-types` — published types check out for a consumer
- Full suite: **1306 passed, 1 skipped**
- VRT (pre-commit): **17 baselines passed, none moved**