### PR TITLE
fix(theme): ship the theme sheet as a real module

### DIFF
--- a/.changeset/theme-css-text-module.md
+++ b/.changeset/theme-css-text-module.md
@@ -1,0 +1,56 @@
+---
+'@qti-components/theme': minor
+'@qti-components/item': patch
+'@qti-components/test': patch
+'@citolab/qti-components': minor
+---
+
+Ship the theme sheet as a real module, so `@qti-components/item` and `@qti-components/test` can be
+installed on their own.
+
+Both packages adopt the theme into their shadow root, so they need the sheet as *text*. They got it
+with `import itemCss from '../../../../qti-theme/src/item.css?inline'` — but `?inline` is
+bundler-only syntax, and `tsc` (how all 32 non-umbrella packages build) copies the specifier through
+verbatim. `@qti-components/item@1.4.3` therefore shipped that exact line. Two things wrong with it:
+the `?inline` suffix no plain bundler resolves, and the path climbs out of the package into a
+sibling directory that `files: ["dist"]` never publishes. Installing the package from npm and
+bundling it fails outright:
+
+```
+✘ [ERROR] Could not resolve "../../../../qti-theme/src/item.css?inline"
+    @qti-components/item/dist/components/item-container/item-container.js:15:20
+```
+
+It went unnoticed because the umbrella inlines these packages at build time and its esbuild plugin
+resolves the `?inline` right there — inside the workspace, where `dist/` sits at the same depth as
+`src/` and the relative path happens to land on a real file. Consumers of `@citolab/qti-components`
+never saw the broken specifier. Consumers of the granular packages could not get past it.
+
+`@qti-components/theme` now exposes `./item-css`, an ES module exporting the compiled sheet as a
+string. It is generated from the already-built `dist/item.css` rather than by running PostCSS a
+second time, and the result is byte-for-byte what the inline plugin produced (279,603 chars) — so
+the text these containers adopt is unchanged and nothing renders differently. `item-container` and
+`test-container` import that instead, and `@qti-components/theme` moves to a real `dependency` of
+`@qti-components/item` (it already was one of `@qti-components/test`) so the topological build
+order guarantees it exists first.
+
+Verified: with the fix, `@qti-components/item` installed from a tarball bundles cleanly and carries
+exactly one copy of the sheet.
+
+Also in this change:
+
+- **Every package now cleans before it builds.** None did, so `dist/` accumulated files whose
+  sources were deleted — `@qti-components/corrections` was carrying a stale
+  `dist/stories/with-correction-registry.decorator.js` from a removed source file, itself
+  containing a `?inline` import. Nothing broken had actually shipped from this (the file was
+  outside the published tarball), but `publish-if-needed.mjs` runs `--ignore-scripts`, so the
+  tarball is whatever happens to be on disk.
+- **An eslint rule** rejects `?inline`/`?raw`/`?url` specifiers in package sources, naming the fix
+  in the message. `import/no-relative-packages` had already flagged the original line and was
+  silenced with an inline disable; that disable is gone. Exempt: `packages/qti-theme` (owns the
+  dev-side source shim), spec/story files and `apps/*` (never compiled into a published dist).
+- The five spec files and two `apps/e2e` stories that loaded the sheet through `?inline` now use
+  the same entry point as production, so they exercise the path consumers actually take rather than
+  a dev-only one.
+- Removed a dead `@qti-components/theme` mapping in the root `tsconfig.json` pointing at a
+  `src/index.ts` that does not exist.

--- a/apps/e2e/package.json
+++ b/apps/e2e/package.json
@@ -4,6 +4,9 @@
   "description": "QTI e2e",
   "private": true,
   "type": "module",
+  "devDependencies": {
+    "@qti-components/theme": "workspace:^"
+  },
   "dependencies": {
     "@citolab/qti-components": "workspace:^",
     "@heximal/templates": "catalog:",

--- a/apps/e2e/src/stories/kennisnet/theme.stories.ts
+++ b/apps/e2e/src/stories/kennisnet/theme.stories.ts
@@ -7,8 +7,8 @@ import { qtiItemElements } from '@qti-components/item/elements';
 import { qtiProcessingElements } from '@qti-components/processing/elements';
 import { qtiCorrectionElements } from '@qti-components/corrections/elements';
 import { qtiTestElements } from '@qti-components/test/elements';
+import itemCss from '@qti-components/theme/item-css';
 
-import itemCss from '../../../../../packages/qti-theme/src/item.css?inline';
 import kennisnetCss from './kennisnet.css?inline';
 
 import type { Decorator, Meta, StoryObj } from '@storybook/web-components-vite';

--- a/apps/e2e/src/stories/kennisnet/with-correction.ts
+++ b/apps/e2e/src/stories/kennisnet/with-correction.ts
@@ -7,9 +7,8 @@ import { qtiItemElements } from '@qti-components/item/elements';
 import { qtiProcessingElements } from '@qti-components/processing/elements';
 import { qtiCorrectionElements } from '@qti-components/corrections/elements';
 import { qtiTestElements } from '@qti-components/test/elements';
+import itemCss from '@qti-components/theme/item-css';
 
-// eslint-disable-next-line import/no-relative-packages
-import itemCss from '../../../../../packages/qti-theme/src/item.css?inline';
 import kennisnetCss from './kennisnet.css?inline';
 
 import type { Decorator } from '@storybook/web-components-vite';

--- a/custom-elements.json
+++ b/custom-elements.json
@@ -16495,7 +16495,7 @@
                 "text": "any[] | NodeListOf<QtiAssociableHotspot>"
               },
               "parsedType": {
-                "text": "any[] | { item: {  }, forEach: {  }, entries: {  }, keys: {  }, values: {  }, __@iterator@518: {  }, length: number }"
+                "text": "any[] | { item: {  }, forEach: {  }, entries: {  }, keys: {  }, values: {  }, __@iterator@512: {  }, length: number }"
               }
             },
             {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -100,6 +100,24 @@ export default [
             {
               group: ['packages/*', 'packages/*/src', 'packages/*/src/*'],
               message: 'Use relative imports within the same package or @qti-components/* for cross-package imports'
+            },
+            {
+              // `?inline` is bundler-only syntax. Every package here builds with plain `tsc`,
+              // which copies the specifier through verbatim — so it survives into the published
+              // dist, where no consumer's bundler can resolve it. That is how
+              // @qti-components/item@1.4.3 shipped an import of
+              // '../../../../qti-theme/src/item.css?inline', a path outside its own tarball;
+              // bundling that package straight from npm fails with "Could not resolve".
+              //
+              // Import '@qti-components/theme/item-css' instead — a real, published module that
+              // exports the compiled sheet as a string.
+              //
+              // Exempt below: packages/qti-theme/** (owns the source shim this rule points at)
+              // and spec/story files (never compiled into a dist).
+              group: ['**/*.css?inline', '**/*.css?raw', '**/*.css?url'],
+              message:
+                "`?inline` does not survive tsc into a published dist. Import '@qti-components/theme/item-css', " +
+                'or add a generated text module for the sheet (see tools/build/css-text-module.mjs).'
             }
           ]
         }
@@ -153,7 +171,42 @@ export default [
       '@typescript-eslint/no-unsafe-return': 'off',
 
       // Allow cross-package relative imports in test files
-      'import/no-relative-packages': 'off'
+      'import/no-relative-packages': 'off',
+
+      // Spec and story files are excluded from every tsc build, so a `?inline` specifier here
+      // cannot reach a published dist. Fixtures (`./fixtures/linked.css?inline`) and
+      // node_modules sheets (`modern-normalize/...?inline`) legitimately use it.
+      'no-restricted-imports': 'off'
+    }
+  },
+
+  // The theme package owns the source shim the ?inline ban points at: src/item-css.ts is the
+  // dev-side counterpart of the generated dist/item-css.js, and it must use ?inline to let Vite
+  // resolve the sheet in Storybook and Vitest. It is never compiled by tsc.
+  {
+    files: ['packages/qti-theme/src/**/*.ts'],
+    rules: {
+      'no-restricted-imports': 'off'
+    }
+  },
+
+  // apps/* are private and never published, so nothing here can reach a consumer's bundler and
+  // `?inline` is free to use — Vite resolves it. The `packages/*` path ban still applies, so this
+  // redefines the rule without that one group rather than switching it off wholesale.
+  {
+    files: ['apps/**/*.{js,ts,tsx}'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: [
+            {
+              group: ['packages/*', 'packages/*/src', 'packages/*/src/*'],
+              message: 'Use relative imports within the same package or @qti-components/* for cross-package imports'
+            }
+          ]
+        }
+      ]
     }
   },
 

--- a/packages/interactions/associate-interaction/package.json
+++ b/packages/interactions/associate-interaction/package.json
@@ -28,7 +28,7 @@
   },
   "scripts": {
     "attw": "attw --profile esm-only --pack",
-    "build": "tsc --paths null",
+    "build": "pnpm run clean && tsc --paths null",
     "clean": "rm -rf dist",
     "publish": "node ../../../tools/publish-if-needed.mjs",
     "yalc": "yalc publish",

--- a/packages/interactions/choice-interaction/package.json
+++ b/packages/interactions/choice-interaction/package.json
@@ -28,7 +28,7 @@
   },
   "scripts": {
     "attw": "attw --profile esm-only --pack",
-    "build": "tsc --paths null",
+    "build": "pnpm run clean && tsc --paths null",
     "clean": "rm -rf dist",
     "publish": "node ../../../tools/publish-if-needed.mjs",
     "yalc": "yalc publish",

--- a/packages/interactions/core/package.json
+++ b/packages/interactions/core/package.json
@@ -10,6 +10,7 @@
   },
   "devDependencies": {
     "@lit/context": "catalog:",
+    "@qti-components/theme": "workspace:^",
     "lit": "catalog:"
   },
   "keywords": [
@@ -28,7 +29,7 @@
   },
   "scripts": {
     "attw": "attw --profile esm-only --pack",
-    "build": "tsc --paths null",
+    "build": "pnpm run clean && tsc --paths null",
     "clean": "rm -rf dist",
     "publish": "node ../../../tools/publish-if-needed.mjs",
     "yalc": "yalc publish",

--- a/packages/interactions/core/src/mixins/drag-drop-observables/candidate-correction-paint.spec.ts
+++ b/packages/interactions/core/src/mixins/drag-drop-observables/candidate-correction-paint.spec.ts
@@ -3,7 +3,7 @@ import { expect, test, describe, beforeEach } from 'vitest';
 
 import '@qti-components/interactions';
 
-import itemCss from '../../../../../qti-theme/src/item.css?inline';
+import itemCss from '@qti-components/theme/item-css';
 
 /**
  * Candidate corrections are OPT-IN per interaction, and this is what holds that together.

--- a/packages/interactions/core/src/mixins/drag-drop-observables/drag-chip-vocabulary.spec.ts
+++ b/packages/interactions/core/src/mixins/drag-drop-observables/drag-chip-vocabulary.spec.ts
@@ -3,7 +3,7 @@ import { expect, test, describe, beforeEach } from 'vitest';
 
 import '@qti-components/interactions';
 
-import itemCss from '../../../../../qti-theme/src/item.css?inline';
+import itemCss from '@qti-components/theme/item-css';
 
 /**
  * The chip vocabulary is OPT-IN, and this is what holds it together.

--- a/packages/interactions/core/src/mixins/drag-drop-observables/drag-drop.invariance.spec.ts
+++ b/packages/interactions/core/src/mixins/drag-drop-observables/drag-drop.invariance.spec.ts
@@ -3,7 +3,7 @@ import { expect, test, describe, beforeEach } from 'vitest';
 
 import '@qti-components/interactions';
 
-import itemCss from '../../../../../qti-theme/src/item.css?inline';
+import itemCss from '@qti-components/theme/item-css';
 
 /**
  * Layout-invariance tests for drag and drop.

--- a/packages/interactions/core/src/mixins/measurement-stability.spec.ts
+++ b/packages/interactions/core/src/mixins/measurement-stability.spec.ts
@@ -3,7 +3,7 @@ import { expect, test, describe, beforeEach } from 'vitest';
 
 import '@qti-components/interactions';
 
-import itemCss from '../../../../qti-theme/src/item.css?inline';
+import itemCss from '@qti-components/theme/item-css';
 
 /**
  * Measurement stability for the two auto-sizing mixins.

--- a/packages/interactions/custom-interaction/package.json
+++ b/packages/interactions/custom-interaction/package.json
@@ -28,7 +28,7 @@
   },
   "scripts": {
     "attw": "attw --profile esm-only --pack",
-    "build": "tsc --paths null",
+    "build": "pnpm run clean && tsc --paths null",
     "clean": "rm -rf dist",
     "publish": "node ../../../tools/publish-if-needed.mjs",
     "yalc": "yalc publish",

--- a/packages/interactions/end-attempt-interaction/package.json
+++ b/packages/interactions/end-attempt-interaction/package.json
@@ -28,7 +28,7 @@
   },
   "scripts": {
     "attw": "attw --profile esm-only --pack",
-    "build": "tsc --paths null",
+    "build": "pnpm run clean && tsc --paths null",
     "clean": "rm -rf dist",
     "publish": "node ../../../tools/publish-if-needed.mjs",
     "yalc": "yalc publish",

--- a/packages/interactions/extended-text-interaction/package.json
+++ b/packages/interactions/extended-text-interaction/package.json
@@ -28,7 +28,7 @@
   },
   "scripts": {
     "attw": "attw --profile esm-only --pack",
-    "build": "tsc --paths null",
+    "build": "pnpm run clean && tsc --paths null",
     "clean": "rm -rf dist",
     "publish": "node ../../../tools/publish-if-needed.mjs",
     "yalc": "yalc publish",

--- a/packages/interactions/gap-match-interaction/package.json
+++ b/packages/interactions/gap-match-interaction/package.json
@@ -28,7 +28,7 @@
   },
   "scripts": {
     "attw": "attw --profile esm-only --pack",
-    "build": "tsc --paths null",
+    "build": "pnpm run clean && tsc --paths null",
     "clean": "rm -rf dist",
     "publish": "node ../../../tools/publish-if-needed.mjs",
     "yalc": "yalc publish",

--- a/packages/interactions/graphic-associate-interaction/package.json
+++ b/packages/interactions/graphic-associate-interaction/package.json
@@ -28,7 +28,7 @@
   },
   "scripts": {
     "attw": "attw --profile esm-only --pack",
-    "build": "tsc --paths null",
+    "build": "pnpm run clean && tsc --paths null",
     "clean": "rm -rf dist",
     "publish": "node ../../../tools/publish-if-needed.mjs",
     "yalc": "yalc publish",

--- a/packages/interactions/graphic-gap-match-interaction/package.json
+++ b/packages/interactions/graphic-gap-match-interaction/package.json
@@ -28,7 +28,7 @@
   },
   "scripts": {
     "attw": "attw --profile esm-only --pack",
-    "build": "tsc --paths null",
+    "build": "pnpm run clean && tsc --paths null",
     "clean": "rm -rf dist",
     "publish": "node ../../../tools/publish-if-needed.mjs",
     "yalc": "yalc publish",

--- a/packages/interactions/graphic-order-interaction/package.json
+++ b/packages/interactions/graphic-order-interaction/package.json
@@ -28,7 +28,7 @@
   },
   "scripts": {
     "attw": "attw --profile esm-only --pack",
-    "build": "tsc --paths null",
+    "build": "pnpm run clean && tsc --paths null",
     "clean": "rm -rf dist",
     "publish": "node ../../../tools/publish-if-needed.mjs",
     "yalc": "yalc publish",

--- a/packages/interactions/hotspot-interaction/package.json
+++ b/packages/interactions/hotspot-interaction/package.json
@@ -28,7 +28,7 @@
   },
   "scripts": {
     "attw": "attw --profile esm-only --pack",
-    "build": "tsc --paths null",
+    "build": "pnpm run clean && tsc --paths null",
     "clean": "rm -rf dist",
     "publish": "node ../../../tools/publish-if-needed.mjs",
     "yalc": "yalc publish",

--- a/packages/interactions/hottext-interaction/package.json
+++ b/packages/interactions/hottext-interaction/package.json
@@ -28,7 +28,7 @@
   },
   "scripts": {
     "attw": "attw --profile esm-only --pack",
-    "build": "tsc --paths null",
+    "build": "pnpm run clean && tsc --paths null",
     "clean": "rm -rf dist",
     "publish": "node ../../../tools/publish-if-needed.mjs",
     "yalc": "yalc publish",

--- a/packages/interactions/inline-choice-interaction/package.json
+++ b/packages/interactions/inline-choice-interaction/package.json
@@ -28,7 +28,7 @@
   },
   "scripts": {
     "attw": "attw --profile esm-only --pack",
-    "build": "tsc --paths null",
+    "build": "pnpm run clean && tsc --paths null",
     "clean": "rm -rf dist",
     "publish": "node ../../../tools/publish-if-needed.mjs",
     "yalc": "yalc publish",

--- a/packages/interactions/match-interaction/package.json
+++ b/packages/interactions/match-interaction/package.json
@@ -28,7 +28,7 @@
   },
   "scripts": {
     "attw": "attw --profile esm-only --pack",
-    "build": "tsc --paths null",
+    "build": "pnpm run clean && tsc --paths null",
     "clean": "rm -rf dist",
     "publish": "node ../../../tools/publish-if-needed.mjs",
     "yalc": "yalc publish",

--- a/packages/interactions/media-interaction/package.json
+++ b/packages/interactions/media-interaction/package.json
@@ -28,7 +28,7 @@
   },
   "scripts": {
     "attw": "attw --profile esm-only --pack",
-    "build": "tsc --paths null",
+    "build": "pnpm run clean && tsc --paths null",
     "clean": "rm -rf dist",
     "publish": "node ../../../tools/publish-if-needed.mjs",
     "yalc": "yalc publish",

--- a/packages/interactions/order-interaction/package.json
+++ b/packages/interactions/order-interaction/package.json
@@ -28,7 +28,7 @@
   },
   "scripts": {
     "attw": "attw --profile esm-only --pack",
-    "build": "tsc --paths null",
+    "build": "pnpm run clean && tsc --paths null",
     "clean": "rm -rf dist",
     "publish": "node ../../../tools/publish-if-needed.mjs",
     "yalc": "yalc publish",

--- a/packages/interactions/portable-custom-interaction/package.json
+++ b/packages/interactions/portable-custom-interaction/package.json
@@ -28,7 +28,7 @@
   },
   "scripts": {
     "attw": "attw --profile esm-only --pack",
-    "build": "tsc --paths null",
+    "build": "pnpm run clean && tsc --paths null",
     "clean": "rm -rf dist",
     "publish": "node ../../../tools/publish-if-needed.mjs",
     "yalc": "yalc publish",

--- a/packages/interactions/position-object-interaction/package.json
+++ b/packages/interactions/position-object-interaction/package.json
@@ -28,7 +28,7 @@
   },
   "scripts": {
     "attw": "attw --profile esm-only --pack",
-    "build": "tsc --paths null",
+    "build": "pnpm run clean && tsc --paths null",
     "clean": "rm -rf dist",
     "publish": "node ../../../tools/publish-if-needed.mjs",
     "yalc": "yalc publish",

--- a/packages/interactions/select-point-interaction/package.json
+++ b/packages/interactions/select-point-interaction/package.json
@@ -28,7 +28,7 @@
   },
   "scripts": {
     "attw": "attw --profile esm-only --pack",
-    "build": "tsc --paths null",
+    "build": "pnpm run clean && tsc --paths null",
     "clean": "rm -rf dist",
     "publish": "node ../../../tools/publish-if-needed.mjs",
     "yalc": "yalc publish",

--- a/packages/interactions/slider-interaction/package.json
+++ b/packages/interactions/slider-interaction/package.json
@@ -28,7 +28,7 @@
   },
   "scripts": {
     "attw": "attw --profile esm-only --pack",
-    "build": "tsc --paths null",
+    "build": "pnpm run clean && tsc --paths null",
     "clean": "rm -rf dist",
     "publish": "node ../../../tools/publish-if-needed.mjs",
     "yalc": "yalc publish",

--- a/packages/interactions/text-entry-interaction/package.json
+++ b/packages/interactions/text-entry-interaction/package.json
@@ -28,7 +28,7 @@
   },
   "scripts": {
     "attw": "attw --profile esm-only --pack",
-    "build": "tsc --paths null",
+    "build": "pnpm run clean && tsc --paths null",
     "clean": "rm -rf dist",
     "publish": "node ../../../tools/publish-if-needed.mjs",
     "yalc": "yalc publish",

--- a/packages/interactions/upload-interaction/package.json
+++ b/packages/interactions/upload-interaction/package.json
@@ -28,7 +28,7 @@
   },
   "scripts": {
     "attw": "attw --profile esm-only --pack",
-    "build": "tsc --paths null",
+    "build": "pnpm run clean && tsc --paths null",
     "clean": "rm -rf dist",
     "publish": "node ../../../tools/publish-if-needed.mjs",
     "yalc": "yalc publish",

--- a/packages/qti-base/package.json
+++ b/packages/qti-base/package.json
@@ -40,7 +40,7 @@
   },
   "scripts": {
     "attw": "attw --profile esm-only --pack",
-    "build": "tsc --paths null",
+    "build": "pnpm run clean && tsc --paths null",
     "clean": "rm -rf dist",
     "yalc": "yalc publish",
     "yalc:push": "yalc push",

--- a/packages/qti-components/package.json
+++ b/packages/qti-components/package.json
@@ -90,7 +90,7 @@
   "scripts": {
     "-": "---build---",
     "attw": "attw --pack --profile esm-only --format table",
-    "build": "run-s cem:react-types cem:react-types:patch-ref build:bundle",
+    "build": "pnpm run clean && run-s cem:react-types cem:react-types:patch-ref build:bundle",
     "build:bundle": "run-p tsup css",
     "cem:react-types": "CEM_OUTDIR=packages/qti-components/ pnpm -C ../.. run cem:core && node -e \"require('fs').writeFileSync('dist/qti-components-jsx.js','export {};\\n')\"",
     "cem:react-types:patch-ref": "node ../../tools/build/patch-jsx-react-ref.mjs dist/qti-components-jsx.d.ts",

--- a/packages/qti-corrections/package.json
+++ b/packages/qti-corrections/package.json
@@ -31,6 +31,7 @@
   },
   "devDependencies": {
     "@lit/context": "catalog:",
+    "@qti-components/theme": "workspace:^",
     "lit": "catalog:"
   },
   "keywords": [
@@ -49,7 +50,7 @@
   },
   "scripts": {
     "attw": "attw --profile esm-only --pack",
-    "build": "tsc --paths null --noEmit false",
+    "build": "pnpm run clean && tsc --paths null --noEmit false",
     "clean": "rm -rf dist",
     "publish": "node ../../tools/publish-if-needed.mjs",
     "yalc": "yalc publish",

--- a/packages/qti-corrections/src/interactions/qti-extended-text-interaction-correction.spec.ts
+++ b/packages/qti-corrections/src/interactions/qti-extended-text-interaction-correction.spec.ts
@@ -1,7 +1,8 @@
 import normalizeCss from 'modern-normalize/modern-normalize.css?inline';
 import { expect, test, describe, beforeEach } from 'vitest';
 
-import itemCss from '../../../qti-theme/src/item.css?inline';
+import itemCss from '@qti-components/theme/item-css';
+
 import { QtiExtendedTextInteractionCorrection } from './qti-extended-text-interaction-correction';
 
 /**

--- a/packages/qti-elements/package.json
+++ b/packages/qti-elements/package.json
@@ -39,7 +39,7 @@
   },
   "scripts": {
     "attw": "attw --profile esm-only --pack",
-    "build": "tsc --paths null",
+    "build": "pnpm run clean && tsc --paths null",
     "clean": "rm -rf dist",
     "publish": "node ../../tools/publish-if-needed.mjs",
     "yalc": "yalc publish",

--- a/packages/qti-interactions/package.json
+++ b/packages/qti-interactions/package.json
@@ -71,7 +71,7 @@
   },
   "scripts": {
     "attw": "attw --profile esm-only --pack",
-    "build": "tsc --paths null",
+    "build": "pnpm run clean && tsc --paths null",
     "cem": "pnpm run cem:qti",
     "cem:qti": "custom-elements-manifest analyze --config ./cem-qti.config.mjs && mv custom-elements.json custom-elements.qti.json",
     "clean": "rm -rf dist",

--- a/packages/qti-item/package.json
+++ b/packages/qti-item/package.json
@@ -8,12 +8,12 @@
     "@qti-components/elements": "workspace:^",
     "@qti-components/interactions": "workspace:^",
     "@qti-components/processing": "workspace:^",
+    "@qti-components/theme": "workspace:^",
     "@qti-components/transformers": "workspace:^",
     "@qti-components/utilities": "workspace:^"
   },
   "devDependencies": {
     "@lit/context": "catalog:",
-    "@qti-components/theme": "workspace:^",
     "lit": "catalog:"
   },
   "keywords": [
@@ -43,7 +43,7 @@
   },
   "scripts": {
     "attw": "attw --profile esm-only --pack",
-    "build": "tsc --paths null",
+    "build": "pnpm run clean && tsc --paths null",
     "clean": "rm -rf dist",
     "publish": "node ../../tools/publish-if-needed.mjs",
     "yalc": "yalc publish",

--- a/packages/qti-item/src/components/item-container/item-container.ts
+++ b/packages/qti-item/src/components/item-container/item-container.ts
@@ -6,9 +6,7 @@ import { until } from 'lit/directives/until.js';
 import { qtiContext } from '@qti-components/base';
 import { watch } from '@qti-components/utilities';
 import { qtiTransformItem } from '@qti-components/transformers';
-
-// eslint-disable-next-line import/no-relative-packages
-import itemCss from '../../../../qti-theme/src/item.css?inline';
+import itemCss from '@qti-components/theme/item-css';
 
 import type { QtiContext } from '@qti-components/base';
 

--- a/packages/qti-loader/package.json
+++ b/packages/qti-loader/package.json
@@ -15,7 +15,7 @@
   "main": "dist/index.js",
   "scripts": {
     "attw": "attw --profile esm-only --pack",
-    "build": "tsc --paths null",
+    "build": "pnpm run clean && tsc --paths null",
     "clean": "rm -rf dist",
     "publish": "node ../../tools/publish-if-needed.mjs",
     "yalc": "yalc publish",

--- a/packages/qti-processing/package.json
+++ b/packages/qti-processing/package.json
@@ -38,7 +38,7 @@
   },
   "scripts": {
     "attw": "attw --profile esm-only --pack",
-    "build": "tsc --paths null",
+    "build": "pnpm run clean && tsc --paths null",
     "clean": "rm -rf dist",
     "publish": "node ../../tools/publish-if-needed.mjs"
   },

--- a/packages/qti-test/package.json
+++ b/packages/qti-test/package.json
@@ -45,7 +45,7 @@
   },
   "scripts": {
     "attw": "attw --profile esm-only --pack",
-    "build": "tsc --paths null",
+    "build": "pnpm run clean && tsc --paths null",
     "clean": "rm -rf dist",
     "publish": "node ../../tools/publish-if-needed.mjs",
     "yalc": "yalc publish",

--- a/packages/qti-test/src/components/test-container/test-container.ts
+++ b/packages/qti-test/src/components/test-container/test-container.ts
@@ -6,9 +6,7 @@ import { until } from 'lit/directives/until.js';
 import { qtiContext } from '@qti-components/base';
 import { watch } from '@qti-components/utilities';
 import { qtiTransformTest } from '@qti-components/transformers';
-
-// eslint-disable-next-line import/no-relative-packages
-import itemCss from '../../../../qti-theme/src/item.css?inline';
+import itemCss from '@qti-components/theme/item-css';
 
 import type { QtiContext } from '@qti-components/base';
 

--- a/packages/qti-theme/package.json
+++ b/packages/qti-theme/package.json
@@ -5,7 +5,11 @@
   "author": "",
   "exports": {
     "./item.css": "./dist/item.css",
-    "./native.css": "./dist/native.css"
+    "./native.css": "./dist/native.css",
+    "./item-css": {
+      "types": "./dist/item-css.d.ts",
+      "import": "./dist/item-css.js"
+    }
   },
   "files": [
     "dist"
@@ -17,7 +21,7 @@
   "license": "GPL-3.0-only",
   "scripts": {
     "attw": "attw --profile esm-only --pack",
-    "build": "postcss ./src/item.css -d dist -m && postcss ./src/native.css -d dist -m",
+    "build": "pnpm run clean && postcss ./src/item.css -d dist -m && postcss ./src/native.css -d dist -m && node ../../tools/build/css-text-module.mjs dist/item.css dist/item-css",
     "clean": "rm -rf dist",
     "yalc": "yalc publish",
     "yalc:push": "yalc push",

--- a/packages/qti-theme/src/item-css.ts
+++ b/packages/qti-theme/src/item-css.ts
@@ -1,0 +1,17 @@
+/**
+ * The theme sheet as a string, for adopting into a shadow root.
+ *
+ * This file is the DEV/source half of `@qti-components/theme/item-css`. It is deliberately never
+ * compiled by tsc — `qti-theme` has no tsc build, and adding one would emit this `?inline`
+ * specifier verbatim into `dist`, which is the bug the entry point exists to fix (see
+ * tools/build/css-text-module.mjs). The published `dist/item-css.js` is generated from the
+ * compiled `dist/item.css` instead.
+ *
+ * Dev resolves here through the `@qti-components/theme/item-css` mapping in the root tsconfig
+ * `paths`, which vite-tsconfig-paths applies in Storybook, Vitest and apps/e2e alike. Vite handles
+ * `?inline` natively and runs the same postcss.config.mjs pipeline, so dev and the published
+ * artifact carry identical text.
+ */
+import cssText from './item.css?inline';
+
+export default cssText;

--- a/packages/qti-transformers/package.json
+++ b/packages/qti-transformers/package.json
@@ -10,7 +10,7 @@
   "license": "GPL-3.0-only",
   "main": "dist/index.js",
   "scripts": {
-    "build": "tsc --paths null",
+    "build": "pnpm run clean && tsc --paths null",
     "clean": "rm -rf dist",
     "publish": "node ../../tools/publish-if-needed.mjs",
     "yalc": "yalc publish",

--- a/packages/qti-utilities/package.json
+++ b/packages/qti-utilities/package.json
@@ -19,7 +19,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "tsc --paths null",
+    "build": "pnpm run clean && tsc --paths null",
     "clean": "rm -rf dist",
     "yalc": "yalc publish",
     "yalc:push": "yalc push",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -312,6 +312,10 @@ importers:
       lit:
         specifier: 'catalog:'
         version: 3.3.3
+    devDependencies:
+      '@qti-components/theme':
+        specifier: workspace:^
+        version: link:../../packages/qti-theme
 
   packages/interactions/associate-interaction:
     dependencies:
@@ -366,6 +370,9 @@ importers:
       '@lit/context':
         specifier: 'catalog:'
         version: 1.1.6
+      '@qti-components/theme':
+        specifier: workspace:^
+        version: link:../../qti-theme
       lit:
         specifier: 'catalog:'
         version: 3.3.3
@@ -865,6 +872,9 @@ importers:
       '@lit/context':
         specifier: 'catalog:'
         version: 1.1.6
+      '@qti-components/theme':
+        specifier: workspace:^
+        version: link:../qti-theme
       lit:
         specifier: 'catalog:'
         version: 3.3.3
@@ -987,6 +997,9 @@ importers:
       '@qti-components/processing':
         specifier: workspace:^
         version: link:../qti-processing
+      '@qti-components/theme':
+        specifier: workspace:^
+        version: link:../qti-theme
       '@qti-components/transformers':
         specifier: workspace:^
         version: link:../qti-transformers
@@ -997,9 +1010,6 @@ importers:
       '@lit/context':
         specifier: 'catalog:'
         version: 1.1.6
-      '@qti-components/theme':
-        specifier: workspace:^
-        version: link:../qti-theme
       lit:
         specifier: 'catalog:'
         version: 3.3.3

--- a/tools/build/css-text-module.mjs
+++ b/tools/build/css-text-module.mjs
@@ -1,0 +1,47 @@
+/**
+ * Wraps a compiled stylesheet into an ES module that exports it as a string.
+ *
+ * Why this exists: `item-container` and `test-container` adopt the theme into their shadow root
+ * (`new CSSStyleSheet()` + `replaceSync`), so they need the sheet as *text*, not as a linked
+ * stylesheet. The obvious way to get that is `import css from './item.css?inline'` — but `?inline`
+ * is bundler-only syntax, and `tsc` (which is how all 32 non-umbrella packages build) copies the
+ * specifier through verbatim. `@qti-components/item@1.4.3` shipped exactly that:
+ *
+ *     import itemCss from '../../../../qti-theme/src/item.css?inline';
+ *
+ * Two things wrong with it. The `?inline` suffix no plain bundler resolves, and the path climbs
+ * out of the package into a sibling directory that `files: ["dist"]` never publishes. Bundling
+ * `@qti-components/item` straight from npm fails with "Could not resolve". It went unnoticed
+ * because the umbrella inlines these packages at build time and its esbuild plugin resolves the
+ * `?inline` right there, inside the workspace, where `dist/` sits at the same depth as `src/` and
+ * the relative path happens to land on a real file.
+ *
+ * So the CSS-as-text has to be a real, published artifact. This script makes one, from the
+ * already-compiled `dist/item.css` rather than by running PostCSS a second time — verified
+ * byte-identical to what the inline plugin produced (279 603 chars), so the string the containers
+ * adopt does not change.
+ *
+ * Usage: node tools/build/css-text-module.mjs <compiled.css> <out-basename>
+ *   emits <out-basename>.js and <out-basename>.d.ts
+ */
+import { readFileSync, writeFileSync } from 'node:fs';
+import process from 'node:process';
+
+const [source, outBase] = process.argv.slice(2);
+
+if (!source || !outBase) {
+  console.error('css-text-module: usage: css-text-module.mjs <compiled.css> <out-basename>');
+  process.exit(1);
+}
+
+const css = readFileSync(source, 'utf8')
+  // The `-m` postcss runs emit a sibling .map and reference it here. A string adopted into a
+  // shadow root has no URL to resolve that against, so the comment would just be dead weight.
+  .replace(/\n?\/\*# sourceMappingURL=[^*]*\*\/\s*$/, '');
+
+// JSON.stringify is the escaping we want: it is exactly JS string-literal syntax, and it handles
+// the newlines, quotes and non-ASCII (the sheet has some) that a hand-rolled escape would miss.
+writeFileSync(`${outBase}.js`, `export default ${JSON.stringify(css)};\n`);
+writeFileSync(`${outBase}.d.ts`, 'declare const cssText: string;\nexport default cssText;\n');
+
+console.log(`css-text-module: ${source} -> ${outBase}.js (${css.length} chars)`);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,11 @@
       "@qti-components/test/*": ["./packages/qti-test/src/*"],
       "@qti-components/corrections": ["./packages/qti-corrections/src/index.ts"],
       "@qti-components/corrections/*": ["./packages/qti-corrections/src/*"],
-      "@qti-components/theme": ["./packages/qti-theme/src/index.ts"],
+      // Dev resolves the theme text to source, so Storybook/Vitest/apps-e2e keep going through
+      // Vite's `?inline` handling. The published entry is a generated dist/item-css.js — see
+      // tools/build/css-text-module.mjs. (There is no `@qti-components/theme` bare mapping: the
+      // package has no index, only CSS and this one module.)
+      "@qti-components/theme/item-css": ["./packages/qti-theme/src/item-css.ts"],
       "@qti-components/transformers": ["./packages/qti-transformers/src/index.ts"],
       "@qti-components/loader": ["./packages/qti-loader/src/index.ts"],
       "@qti-components/utilities": ["./packages/qti-utilities/src/index.ts"],


### PR DESCRIPTION
Second of the packaging stack. **Targets `chore/pnpm-catalog` (#204), not `main`** — rebase or merge that one first.

This is the blocker for de-bundling the umbrella.

## The bug

`@qti-components/item` and `@qti-components/test` adopt the theme into their shadow root, so they need the sheet as *text*. They got it with:

```ts
import itemCss from '../../../../qti-theme/src/item.css?inline';
```

`?inline` is bundler-only syntax, and `tsc` — how all 32 non-umbrella packages build — copies the specifier through verbatim. So `@qti-components/item@1.4.3` **shipped that exact line to npm**. Two things wrong with it: the `?inline` suffix no plain bundler resolves, and the path climbs *out of the package* into a sibling directory that `files: ["dist"]` never publishes.

Install it from npm and bundle it and you get:

```
✘ [ERROR] Could not resolve "../../../../qti-theme/src/item.css?inline"
    @qti-components/item/dist/components/item-container/item-container.js:15:20
```

## Why nobody hit it, and why it still matters

The umbrella inlines these packages at build time, and its esbuild plugin resolves the `?inline` right there — inside the workspace, where `dist/` sits at the same depth as `src/` and the relative path happens to land on a real file. Consumers of `@citolab/qti-components` never saw the broken specifier; consumers of the granular packages could not get past it.

It also blocks de-bundling. The moment the umbrella stops inlining, every vendor's bundler follows the real import and hits the error above.

## The fix

`@qti-components/theme` now exposes `./item-css`, an ES module exporting the compiled sheet as a string. It is generated from the already-built `dist/item.css` rather than by running PostCSS a second time, and the result is **byte-for-byte what the inline plugin produces** (279,603 chars, verified against a live PostCSS run) — so the text the containers adopt is unchanged and nothing renders differently. VRT confirms: 17 baselines pass, no PNG touched.

`@qti-components/theme` also becomes a real `dependency` of `@qti-components/item` (it already was one of `@qti-components/test`), so the topological build order guarantees it exists first.

**Verified end to end:** with the fix, `@qti-components/item` installed from a tarball bundles cleanly (375 KB) and carries exactly one copy of the sheet.

## Also here

- **Every package cleans before it builds.** None did, so `dist/` accumulated files whose sources were deleted — `@qti-components/corrections` was carrying a stale `dist/stories/with-correction-registry.decorator.js` from a removed source file, itself containing a `?inline` import. Nothing broken had shipped from it (the file sat outside the published tarball), but `publish-if-needed.mjs` runs `--ignore-scripts`, so the tarball is whatever happens to be on disk. There is now **zero `?inline` in any dist across all 34 packages**.
- **An eslint rule** rejects `?inline`/`?raw`/`?url` in package sources, naming the fix in the message — verified to fire by reintroducing the old import. `import/no-relative-packages` had already flagged that line and was silenced with an inline disable; that disable is gone. Exempt: `packages/qti-theme` (owns the dev-side source shim), spec/story files, and `apps/*`. For `apps/*` the rule is *redefined without that group* rather than switched off, so the `packages/*` path ban still applies there.
- The 5 specs and 2 `apps/e2e` stories that loaded the sheet through `?inline` now use the same entry point as production — so they exercise the path consumers actually take instead of a dev-only Vite one.
- Dropped a dead `@qti-components/theme` mapping in the root `tsconfig.json` pointing at a `src/index.ts` that does not exist.

## Two things I checked that could have gone wrong

- **`cem:react-types` ordering.** Adding `clean` first could have broken the umbrella's `node -e writeFileSync('dist/…')`. It doesn't — the CEM analyzer creates `dist/` itself before that write. Verified on a wiped tree.
- **`check-umbrella-bump` rejected my first changeset** and was right to: the theme's minor forces the umbrella to minor too. This lands as **9.1.0**.

## Verification

- build, lint, tsc, madge — green
- publint all good; **attw 31 clean, up from 30** (`qti-theme` has a typed entry point for the first time)
- sherif, syncpack, manypkg — clean
- `consumer-types` — published types check out for a consumer
- Full suite: **1306 passed, 1 skipped**
- VRT: **17 baselines pass, none re-blessed**