### PR TITLE
fix(test): make @heximal/templates a dependency, not a peer

### DIFF
--- a/.changeset/heximal-templates-dependency.md
+++ b/.changeset/heximal-templates-dependency.md
@@ -1,0 +1,25 @@
+---
+'@qti-components/test': patch
+'@citolab/qti-components': patch
+---
+
+Make `@heximal/templates` a dependency of `@qti-components/test` instead of a peer.
+
+A peerDependency says "there must be exactly one of these, and you own the choice". Neither half is
+true here: `@heximal/templates` is a templating library used by seven files inside one package, it
+has no singleton requirement, and no consumer has any reason to hold an opinion about its version.
+Peering it just forced every consumer to install a transitive implementation detail by hand.
+
+That was a real failure, not a theoretical one. Under an install that does not auto-install peers —
+Yarn 2+, or pnpm with `auto-install-peers=false` — the published `@qti-components/test@1.6.1` cannot
+resolve its own import:
+
+```
+@heximal/templates  ->  MODULE_NOT_FOUND
+```
+
+As a plain dependency it now installs automatically, and the consumer declares nothing.
+
+`lit` and `@lit/context` stay peers, where the reasoning does hold: two copies of Lit mean two
+`ReactiveElement` base classes, so `instanceof` fails across them, and Lit's own multi-version
+warning fires.

--- a/packages/qti-test/package.json
+++ b/packages/qti-test/package.json
@@ -4,6 +4,7 @@
   "version": "1.6.1",
   "author": "",
   "dependencies": {
+    "@heximal/templates": "catalog:",
     "@qti-components/base": "workspace:^",
     "@qti-components/elements": "workspace:^",
     "@qti-components/interactions": "workspace:^",
@@ -13,7 +14,6 @@
     "@qti-components/utilities": "workspace:^"
   },
   "devDependencies": {
-    "@heximal/templates": "catalog:",
     "@lit/context": "catalog:",
     "lit": "catalog:"
   },
@@ -39,7 +39,6 @@
     "./*": "./dist/*"
   },
   "peerDependencies": {
-    "@heximal/templates": "catalog:",
     "@lit/context": "catalog:",
     "lit": "catalog:"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1041,6 +1041,9 @@ importers:
 
   packages/qti-test:
     dependencies:
+      '@heximal/templates':
+        specifier: 'catalog:'
+        version: 0.1.5
       '@qti-components/base':
         specifier: workspace:^
         version: link:../qti-base
@@ -1063,9 +1066,6 @@ importers:
         specifier: workspace:^
         version: link:../qti-utilities
     devDependencies:
-      '@heximal/templates':
-        specifier: 'catalog:'
-        version: 0.1.5
       '@lit/context':
         specifier: 'catalog:'
         version: 1.1.6


### PR DESCRIPTION
A three-line manifest change that fixes a real install failure, and tightens up what "peer" means here before PR B locks the dependency shape in.

## Why

A `peerDependency` says *"there must be exactly one of these, and you own the choice."* Neither half holds for `@heximal/templates`: it is a templating library used by seven files inside `@qti-components/test`, it has no singleton requirement, and no consumer has any reason to hold an opinion about its version. Peering it just forced every consumer to hand-install a transitive implementation detail.

## It was actually broken

Under an install that does not auto-install peers — Yarn 2+, or pnpm with `auto-install-peers=false` — the published `@qti-components/test@1.6.1` cannot resolve its own import.

Scratch consumer installing only the package plus `lit` and `@lit/context`:

```
BEFORE (published 1.6.1, heximal peered)
  @heximal/templates  ->  MODULE_NOT_FOUND
  lit                 ->  OK

AFTER (this change)
  @heximal/templates  ->  OK
  lit                 ->  OK
  @lit/context        ->  OK
```

The consumer declares nothing; it just installs.

## What stays a peer

`lit` and `@lit/context`, where the reasoning does hold: two copies of Lit mean two `ReactiveElement` base classes, so `instanceof` fails across them, two `@lit/context` registries, and Lit's own multi-version warning. That is a genuine "exactly one, and you own it" dependency.

After this, the umbrella's peer set in PR B is exactly `lit` + `@lit/context` — nothing else.

## Verification

- build, lint, tsc — green
- publint all good; attw 31 clean
- sherif, syncpack, manypkg — clean
- Full suite: **1306 passed, 1 skipped**
- VRT (pre-commit): 17 baselines pass, none re-blessed
- Packed manifest confirmed: `dependencies: {"@heximal/templates": "^0.1.5"}`, `peerDependencies: {lit, @lit/context}`