### PR TITLE
fix(transformers): report a malformed item instead of rendering the parse error

### DIFF
--- a/.changeset/graphic-order-response-and-object-graphic.md
+++ b/.changeset/graphic-order-response-and-object-graphic.md
@@ -1,0 +1,17 @@
+---
+'@qti-components/graphic-order-interaction': patch
+'@qti-components/interactions-core': patch
+'@citolab/qti-components': patch
+---
+
+Fix `qti-graphic-order-interaction` on the QTI 3 spec form of an ordering item (#209). Two defects, either of which broke it on its own.
+
+**RESPONSE ignored the candidate's ordering.** The interaction only wrote `aria-ordervalue` on each hotspot; the response itself was published by `ChoicesMixin` as the set of _checked_ choices in **DOM order** — the one thing an ordering must not do. `ChoicesMixin.maxChoices` also defaults to `1`, so each click cleared the previous hotspot and made the interaction a `radiogroup` of `radio`s. Clicking A, D, C, B left `RESPONSE` as the single identifier `"B"` where the `ordered` cardinality declaration expects `["A","D","C","B"]`, so response processing never scored the item — while the pins painted 1-2-3-4 and made it look right.
+
+The response is now the ordering: `max-choices` defaults to `0` (no limit, QTI's default for an ordering), the interaction publishes the ordered identifier list itself, and pins plus `aria-ordervalue` are derived from the response rather than kept as a second copy of it. Deselecting a hotspot renumbers the rest by falling out of the array, and a response set from anywhere else — a restored attempt, a correct-response display, an author setting the property — now repaints the pins.
+
+**An `<object>` graphic left every hotspot unpositioned.** QTI 3 carries the graphic as `<object type="image/png" data="…">`, which is what the spec's own graphic interaction examples use, but the hotspots were positioned against `querySelector('img')`. On a spec-form item that is `null`, `positionShapes` threw, and no hotspot got a position — so all of them collapsed onto the theme's `100%x100%` and stacked as one large box below the graphic. Only items that had been through a converter rendered at all.
+
+`findGraphic` now accepts `<img>` and `<object type="image/*">` alike, and `positionShapes` resolves the coordinate space from either. It also reports a graphic with no usable width/height instead of silently writing `NaN%` and leaving the hotspots full-size.
+
+`qti-hotspot-interaction`, `qti-graphic-associate-interaction` and `qti-select-point-interaction` make the same `img`-only assumption and are not covered here.

--- a/.changeset/report-xml-parse-errors.md
+++ b/.changeset/report-xml-parse-errors.md
@@ -1,0 +1,12 @@
+---
+'@qti-components/transformers': patch
+'@citolab/qti-components': patch
+---
+
+Report a malformed item instead of rendering the browser's XML parse error as the item (#211).
+
+`DOMParser.parseFromString(text, 'text/xml')` never throws: on a malformed document it returns a _document describing the failure_, an HTML page reading "This page contains the following errors…". `parseXML` and `loadXML` handed that straight back, `toHTML` copied it into the DOM node by node, and the player rendered the browser's error page as the item's content — silently, because `item-container` wraps both entry points in a `try`/`catch` that nothing ever reached.
+
+Both now detect the parser-error document and throw, carrying the parser's own message so the line and column of the real problem survive. The error document is matched by its namespace rather than by tag name, so an item that legitimately contains an element named `parsererror` is not mistaken for a failure.
+
+Leading whitespace and a BOM before the XML declaration are stripped before parsing. A blank line in front of `<?xml` is fatal to the letter of the XML spec, and it is also one of the most common artefacts of an item that has been through an editor or a copy and paste — the parser already tolerated the analogous BOM case. That is the input that surfaced this: it rendered as `error on line 2 at column 6: Invalid processing instruction: <?xml`.

--- a/packages/interactions/core/src/internal/hotspots/hotspot.ts
+++ b/packages/interactions/core/src/internal/hotspots/hotspot.ts
@@ -1,7 +1,52 @@
-export function positionShapes(shape: string, coordsNumber: number[], img: HTMLImageElement, hotspot: HTMLElement) {
+/** The graphic an image-based interaction draws its hotspots on. */
+export type Graphic = HTMLImageElement | HTMLObjectElement;
+
+/**
+ * Find the graphic inside an image-based interaction.
+ *
+ * QTI 3 carries it as `<object type="image/*" data="…">` — that is what the spec's own graphic
+ * interaction examples use. An item that has been through a converter usually carries the same
+ * graphic as a plain `<img>`. Both are valid input, so accept either rather than assuming the
+ * converted form: looking only for `img` left every hotspot unpositioned on a spec-form item.
+ */
+export function findGraphic(root: ParentNode): Graphic | null {
+  return root.querySelector<Graphic>('img, object[type^="image"]');
+}
+
+/**
+ * The coordinate space the `coords` attributes are expressed in.
+ *
+ * The width/height attributes come first, as they did before: `coords` are authored against the
+ * size the item declares, not against however the graphic is being laid out. `<object>` has no
+ * intrinsic size to fall back on — QTI requires width/height on it — so for that form the
+ * attributes are the only source.
+ */
+function graphicSize(graphic: Graphic): { width: number; height: number } {
+  const attribute = (name: 'width' | 'height'): number | null => {
+    const raw = graphic.getAttribute(name);
+    const parsed = raw ? parseFloat(raw) : NaN;
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+  };
+  const image = graphic as HTMLImageElement;
+  return {
+    width: attribute('width') ?? image.naturalWidth,
+    height: attribute('height') ?? image.naturalHeight
+  };
+}
+
+export function positionShapes(shape: string, coordsNumber: number[], img: Graphic, hotspot: HTMLElement) {
   // Determine the reference width and height based on the attributes or natural dimensions
-  const imgWidth = img.getAttribute('width') ? parseFloat(img.getAttribute('width')!) : img.naturalWidth;
-  const imgHeight = img.getAttribute('height') ? parseFloat(img.getAttribute('height')!) : img.naturalHeight;
+  const { width: imgWidth, height: imgHeight } = graphicSize(img);
+
+  /*
+   * Without a usable coordinate space every percentage below is NaN, which the style setters drop
+   * silently — the hotspot then keeps the theme's 100%x100% and stacks unpositioned on top of the
+   * graphic. Say so instead of leaving that to be diagnosed from the rendering.
+   */
+  if (!(imgWidth > 0) || !(imgHeight > 0)) {
+    console.error('Cannot position hotspots: the graphic has no usable width/height.', img);
+    return;
+  }
 
   switch (shape) {
     case 'circle':

--- a/packages/interactions/graphic-order-interaction/src/qti-graphic-order-interaction.spec.ts
+++ b/packages/interactions/graphic-order-interaction/src/qti-graphic-order-interaction.spec.ts
@@ -1,0 +1,177 @@
+/**
+ * Regression for issue #209, on the QTI 3 "Flying Home" example item verbatim.
+ *
+ * Two defects met there. The response was published by ChoicesMixin as the set of *checked*
+ * choices in DOM order, so the candidate's ordering — the whole point of this interaction —
+ * never reached RESPONSE; a max-choices default of 1 also cleared the previous hotspot on every
+ * click. And the graphic was looked up as `img` only, while the spec's example carries it as
+ * `<object type="image/png">`, so positionShapes ran on null and every hotspot stayed unpositioned
+ * at the theme's 100%x100%, stacked after the image.
+ */
+import '@citolab/qti-components';
+
+import type { QtiAssessmentItem } from '@qti-components/elements';
+import type { QtiGraphicOrderInteraction } from './qti-graphic-order-interaction';
+
+// 1x1 transparent PNG. The coordinate space comes from the width/height attributes, as QTI
+// requires on the graphic, so the bitmap's own size is irrelevant here.
+const PNG =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==';
+
+const flyingHome = (graphic: string) => `
+<qti-assessment-item identifier="graphicOrder" title="Flying Home" adaptive="false" time-dependent="false">
+  <qti-response-declaration identifier="RESPONSE" cardinality="ordered" base-type="identifier">
+    <qti-correct-response>
+      <qti-value>A</qti-value><qti-value>D</qti-value><qti-value>C</qti-value><qti-value>B</qti-value>
+    </qti-correct-response>
+  </qti-response-declaration>
+  <qti-outcome-declaration identifier="SCORE" cardinality="single" base-type="float">
+    <qti-default-value><qti-value>0</qti-value></qti-default-value>
+  </qti-outcome-declaration>
+  <qti-item-body>
+    <qti-graphic-order-interaction response-identifier="RESPONSE">
+      <qti-prompt>Mark the airports shown on the map according to Lorna's preferences.</qti-prompt>
+      ${graphic}
+      <qti-hotspot-choice shape="circle" coords="77,115,8" identifier="A"></qti-hotspot-choice>
+      <qti-hotspot-choice shape="circle" coords="118,184,8" identifier="B"></qti-hotspot-choice>
+      <qti-hotspot-choice shape="circle" coords="150,235,8" identifier="C"></qti-hotspot-choice>
+      <qti-hotspot-choice shape="circle" coords="96,114,8" identifier="D"></qti-hotspot-choice>
+    </qti-graphic-order-interaction>
+  </qti-item-body>
+  <qti-response-processing>
+    <qti-response-condition>
+      <qti-response-if>
+        <qti-match>
+          <qti-variable identifier="RESPONSE"></qti-variable>
+          <qti-correct identifier="RESPONSE"></qti-correct>
+        </qti-match>
+        <qti-set-outcome-value identifier="SCORE">
+          <qti-base-value base-type="float">1</qti-base-value>
+        </qti-set-outcome-value>
+      </qti-response-if>
+      <qti-response-else>
+        <qti-set-outcome-value identifier="SCORE">
+          <qti-base-value base-type="float">0</qti-base-value>
+        </qti-set-outcome-value>
+      </qti-response-else>
+    </qti-response-condition>
+  </qti-response-processing>
+</qti-assessment-item>`;
+
+const asObject = `<object type="image/png" width="206" height="280" data="${PNG}">UK Map</object>`;
+const asImg = `<img width="206" height="280" src="${PNG}" alt="UK Map"/>`;
+
+describe('qti-graphic-order-interaction', () => {
+  let host: HTMLElement;
+  let item: QtiAssessmentItem;
+  let interaction: QtiGraphicOrderInteraction;
+
+  const mount = async (graphic: string) => {
+    host = document.createElement('div');
+    host.style.cssText = 'position:relative;width:360px;padding:20px;background:#fff';
+    document.body.appendChild(host);
+    host.innerHTML = flyingHome(graphic);
+
+    item = host.querySelector('qti-assessment-item') as QtiAssessmentItem;
+    interaction = host.querySelector('qti-graphic-order-interaction') as QtiGraphicOrderInteraction;
+    await item.updateComplete;
+    await interaction.updateComplete;
+    await new Promise(resolve => setTimeout(resolve, 100));
+  };
+
+  afterEach(() => host?.remove());
+
+  const hotspot = (identifier: string) =>
+    host.querySelector(`qti-hotspot-choice[identifier="${identifier}"]`) as HTMLElement;
+
+  const click = async (...identifiers: string[]) => {
+    for (const identifier of identifiers) {
+      hotspot(identifier).click();
+      await new Promise(resolve => setTimeout(resolve, 50));
+    }
+  };
+
+  const pins = () => Array.from(host.querySelectorAll('.cito-graphic-order-marker')).map(pin => pin.textContent);
+
+  const score = () =>
+    item['_context'].variables.find((variable: { identifier: string }) => variable.identifier === 'SCORE');
+
+  describe.each([
+    ['<object>', asObject],
+    ['<img>', asImg]
+  ])('with the graphic as %s', (_label, graphic) => {
+    beforeEach(() => mount(graphic));
+
+    // Defect 2: an unpositioned hotspot keeps the theme's 100%x100% and stacks after the graphic.
+    it('positions every hotspot against the graphic', () => {
+      for (const identifier of ['A', 'B', 'C', 'D']) {
+        const style = hotspot(identifier).style;
+        expect(parseFloat(style.left), `hotspot ${identifier} has no left`).toBeGreaterThan(0);
+        expect(parseFloat(style.top), `hotspot ${identifier} has no top`).toBeGreaterThan(0);
+        // coords put each circle at r=8 in a 206x280 space — a dot, not the whole graphic.
+        expect(parseFloat(style.width), `hotspot ${identifier} spans the graphic`).toBeLessThan(20);
+      }
+      // The left-to-right order of the coords, so the mapping is not just "some number".
+      const left = (identifier: string) => parseFloat(hotspot(identifier).style.left);
+      expect(left('A')).toBeLessThan(left('D'));
+      expect(left('D')).toBeLessThan(left('B'));
+      expect(left('B')).toBeLessThan(left('C'));
+    });
+
+    // Defect 1: RESPONSE used to be a single identifier, the last hotspot clicked.
+    it('publishes the candidate ordering as the response', async () => {
+      await click('A', 'D', 'C', 'B');
+      expect(interaction.response).toEqual(['A', 'D', 'C', 'B']);
+      expect(pins()).toEqual(['1', '2', '3', '4']);
+    });
+
+    it('scores the ordered response through response processing', async () => {
+      await click('A', 'D', 'C', 'B');
+      item.processResponse();
+      expect(score()!.value).toBe('1');
+    });
+
+    it('scores a wrong ordering as incorrect', async () => {
+      await click('A', 'B', 'C', 'D');
+      expect(interaction.response).toEqual(['A', 'B', 'C', 'D']);
+      item.processResponse();
+      expect(score()!.value).toBe('0');
+    });
+
+    it('renumbers the rest when a hotspot is unset', async () => {
+      await click('A', 'D', 'C', 'B');
+      await click('D');
+      expect(interaction.response).toEqual(['A', 'C', 'B']);
+      expect(pins()).toEqual(['1', '2', '3']);
+    });
+
+    it('clears the response when every hotspot is unset', async () => {
+      await click('A', 'D');
+      await click('A', 'D');
+      expect(interaction.response).toEqual([]);
+      expect(pins()).toEqual([]);
+    });
+
+    // Orders follow the response, so a restored attempt repaints the pins.
+    it('repaints the pins from a response set programmatically', async () => {
+      interaction.response = ['C', 'A'];
+      await interaction.updateComplete;
+      await new Promise(resolve => setTimeout(resolve, 50));
+      expect(pins()).toEqual(['1', '2']);
+      expect(hotspot('C').getAttribute('aria-ordervalue')).toBe('1');
+      expect(hotspot('A').getAttribute('aria-ordervalue')).toBe('2');
+      expect(hotspot('B').hasAttribute('aria-ordervalue')).toBe(false);
+    });
+
+    // Ordering is not a single-select; the old ChoicesMixin default made it a radiogroup.
+    it('does not cap the ordering at one hotspot', () => {
+      expect(interaction.maxChoices).toBe(0);
+    });
+
+    it('honours an explicit max-choices', async () => {
+      interaction.maxChoices = 2;
+      await click('A', 'D', 'C');
+      expect(interaction.response).toEqual(['A', 'D']);
+    });
+  });
+});

--- a/packages/interactions/graphic-order-interaction/src/qti-graphic-order-interaction.stories.ts
+++ b/packages/interactions/graphic-order-interaction/src/qti-graphic-order-interaction.stories.ts
@@ -76,3 +76,26 @@ export const MultipleShapes: Story = {
       `
     )
 };
+
+/**
+ * The graphic as `<object type="image/png">`, which is the form QTI 3 uses and the form the
+ * spec's own "Flying Home" example ships. Hotspots position against it exactly as against an
+ * `<img>` — before issue #209 they positioned against neither and stacked below the map.
+ */
+export const SpecFormObjectGraphic: Story = {
+  name: 'Object graphic',
+  render: () =>
+    template(
+      args,
+      html`
+        <qti-prompt>Mark the airports shown on the map according to Lorna's preferences.</qti-prompt>
+        <object type="image/png" data="assets/qti-graphic-order-interaction/uk.png" width="206" height="280">
+          UK Map
+        </object>
+        <qti-hotspot-choice coords="78,102,8" identifier="A" shape="circle"></qti-hotspot-choice>
+        <qti-hotspot-choice coords="117,171,8" identifier="B" shape="circle"></qti-hotspot-choice>
+        <qti-hotspot-choice coords="166,227,8" identifier="C" shape="circle"></qti-hotspot-choice>
+        <qti-hotspot-choice coords="100,102,8" identifier="D" shape="circle"></qti-hotspot-choice>
+      `
+    )
+};

--- a/packages/interactions/graphic-order-interaction/src/qti-graphic-order-interaction.ts
+++ b/packages/interactions/graphic-order-interaction/src/qti-graphic-order-interaction.ts
@@ -1,8 +1,10 @@
 import { html } from 'lit';
+import { property } from 'lit/decorators.js';
 
+import { watch } from '@qti-components/utilities';
 import { Interaction } from '@qti-components/base';
 import { ChoicesMixin } from '@qti-components/interactions-core/mixins/choices/choices.mixin';
-import { positionShapes } from '@qti-components/interactions-core/internal/hotspots/hotspot';
+import { findGraphic, positionShapes } from '@qti-components/interactions-core/internal/hotspots/hotspot';
 
 import styles from './qti-graphic-order-interaction.styles';
 
@@ -10,7 +12,7 @@ import type { QtiHotspotChoice } from '@qti-components/interactions-core/element
 import type { Choice } from '@qti-components/interactions-core/mixins/choices/choices.mixin';
 import type { CSSResultGroup } from 'lit';
 
-type HotspotChoice = Choice & { order: number };
+type HotspotChoice = Choice & { order: number | null };
 /**
  * Graphic order interaction: candidates order hotspots on an image.
  *
@@ -24,7 +26,13 @@ export class QtiGraphicOrderInteraction extends ChoicesMixin(Interaction, 'qti-h
 
   static readonly #LOCATOR_CLASS = 'cito-graphic-order-marker';
 
-  protected choiceOrdering: boolean;
+  /*
+   * Unlimited by default, unlike ChoicesMixin's `1`. Ordering is not a single-select: a default of
+   * 1 made this interaction a `radiogroup` of `radio` hotspots and let only one hotspot carry an
+   * order at a time. QTI's own `max-choices` default for an ordering is "no limit", i.e. 0.
+   */
+  @property({ type: Number, attribute: 'max-choices' })
+  public override maxChoices = 0;
 
   protected _choiceElements: Choice[] = [];
 
@@ -36,44 +44,53 @@ export class QtiGraphicOrderInteraction extends ChoicesMixin(Interaction, 'qti-h
     `;
   }
 
-  #setHotspotOrder(e: CustomEvent<{ identifier: string }>): void {
-    const { identifier } = e.detail;
+  /*
+   * Shadows ChoicesMixin's handler, deliberately without calling up to it.
+   *
+   * The mixin publishes the response as the set of *checked* choices in DOM order, which is
+   * exactly what an ordering interaction must not do: the candidate's sequence never reached
+   * RESPONSE, and with the mixin's max-choices default of 1 each click also cleared the previous
+   * hotspot. Here the response IS the ordering, so the interaction owns it — and because the
+   * response is the ordered list of identifiers, removing one renumbers the rest by itself.
+   */
+  protected _choiceElementSelectedHandler(event: CustomEvent<{ identifier: string }>): void {
+    const { identifier } = event.detail;
 
-    const hotspot = this._choiceElements.find(el => el.getAttribute('identifier') === identifier) as HotspotChoice;
+    if (!this._choiceElements.some(choice => choice.identifier === identifier)) return;
 
-    if (!hotspot) return;
+    const ordered = [...this.#orderedResponse()];
+    const position = ordered.indexOf(identifier);
 
-    const maxSelection = this._choiceElements.length;
-
-    if (!this.choiceOrdering) {
-      this.choiceOrdering = true;
-
-      if (hotspot.order == null) {
-        // Hotspot is not selected, so assign the next available order
-        const currentSelection = (this._choiceElements as HotspotChoice[]).filter(i => i.order != null).length;
-
-        if (currentSelection >= maxSelection) {
-          this.choiceOrdering = false;
-          return; // Maximum selection reached
-        }
-
-        hotspot.order = currentSelection + 1;
-      } else {
-        // Hotspot is already selected, so remove its order and renumber the rest
-        const removedOrder = hotspot.order;
-
-        hotspot.order = null;
-
-        (this._choiceElements as HotspotChoice[]).forEach(hotspot => {
-          if (hotspot.order != null && hotspot.order > removedOrder) {
-            hotspot.order--;
-          }
-        });
-      }
-
-      this.refreshLocatorPins();
-      this.choiceOrdering = false;
+    if (position >= 0) {
+      ordered.splice(position, 1);
+    } else {
+      // 0 means "no limit" — QTI's default for an ordering — so cap at the hotspots that exist.
+      const maxSelection = this.maxChoices > 0 ? this.maxChoices : this._choiceElements.length;
+      if (ordered.length >= maxSelection) return;
+      ordered.push(identifier);
     }
+
+    this.response = ordered;
+
+    this.validate();
+    this.reportValidity();
+    this.saveResponse(this.response);
+  }
+
+  /** The response as the ordered identifier list this interaction always treats it as. */
+  #orderedResponse(): string[] {
+    if (Array.isArray(this.response)) return this.response;
+    return this.response ? [this.response] : [];
+  }
+
+  /*
+   * Pins and `aria-ordervalue` are a pure function of the response, so any route into it repaints
+   * them: a candidate's click, a restored attempt, a correct-response display, an author setting
+   * the property. Nothing has to remember to keep a second copy of the ordering in step.
+   */
+  @watch('response')
+  protected handleOrderedResponseChange(): void {
+    this.refreshLocatorPins();
   }
 
   #anchorNameForChoice(choice: HotspotChoice): string {
@@ -88,16 +105,44 @@ export class QtiGraphicOrderInteraction extends ChoicesMixin(Interaction, 'qti-h
   }
 
   protected refreshLocatorPins() {
-    // Remove previous markers and anchor names managed by this component.
-    this.querySelectorAll(`.${QtiGraphicOrderInteraction.#LOCATOR_CLASS}`).forEach(marker => marker.remove());
+    const ordered = this.#orderedResponse();
 
-    (this._choiceElements as HotspotChoice[]).forEach(choice => {
-      choice.style.removeProperty('anchor-name');
-    });
+    for (const choice of this._choiceElements as HotspotChoice[]) {
+      const position = ordered.indexOf(choice.identifier);
+      choice.order = position >= 0 ? position + 1 : null;
+    }
 
     const orderedChoices = (this._choiceElements as HotspotChoice[])
       .filter(choice => choice.order != null)
       .sort((a, b) => a.order - b.order);
+
+    const markers = Array.from(this.querySelectorAll<HTMLElement>(`.${QtiGraphicOrderInteraction.#LOCATOR_CLASS}`));
+
+    /*
+     * Idempotent on purpose, because the pins are light-DOM children of an element ChoicesMixin
+     * watches with a subtree MutationObserver: appending a marker feeds a mutation straight back
+     * into _syncChoicesFromDOM -> _updateChoiceSelection -> here. Rebuilding unconditionally would
+     * mutate again on every round and never settle.
+     */
+    const unchanged =
+      markers.length === orderedChoices.length &&
+      orderedChoices.every((choice, index) => {
+        const marker = markers[index];
+        return (
+          marker.textContent === String(choice.order) &&
+          marker.style.getPropertyValue('position-anchor') === this.#anchorNameForChoice(choice) &&
+          marker.style.getPropertyValue('--qti-graphic-order-pin-color') === this.resolvePinColor(choice)
+        );
+      });
+
+    if (unchanged) return;
+
+    // Remove previous markers and anchor names managed by this component.
+    markers.forEach(marker => marker.remove());
+
+    (this._choiceElements as HotspotChoice[]).forEach(choice => {
+      choice.style.removeProperty('anchor-name');
+    });
 
     orderedChoices.forEach(choice => {
       const anchorName = this.#anchorNameForChoice(choice);
@@ -117,21 +162,30 @@ export class QtiGraphicOrderInteraction extends ChoicesMixin(Interaction, 'qti-h
   }
 
   #positionHotspot(hotspot: QtiHotspotChoice): void {
-    const img = this.querySelector('img') as HTMLImageElement;
+    // `<object>` as well as `<img>`: the spec's own example items carry the graphic as an object.
+    const graphic = findGraphic(this);
     const coords = hotspot.getAttribute('coords');
     const shape = hotspot.getAttribute('shape');
+
+    if (!graphic) {
+      console.error('No <img> or <object type="image/*"> found in <qti-graphic-order-interaction>.');
+      return;
+    }
+
     const coordsNumber = coords.split(',').map(s => parseInt(s));
 
-    positionShapes(shape, coordsNumber, img, hotspot);
+    positionShapes(shape, coordsNumber, graphic, hotspot);
   }
 
   #positionHotspotOnRegister = (e: CustomEvent<QtiHotspotChoice>): void => {
     this.#positionHotspot(e.target as QtiHotspotChoice);
+    // A hotspot can upgrade after the response is already set — a restored attempt, say — so give
+    // the newcomer its order and pin rather than waiting for the next response change.
+    this.refreshLocatorPins();
   };
 
   override connectedCallback(): void {
     super.connectedCallback();
-    this.addEventListener('activate-qti-hotspot-choice', this.#setHotspotOrder);
     this.addEventListener('register-qti-hotspot-choice', this.#positionHotspotOnRegister);
     this.refreshLocatorPins();
     // qti-hotspot-choice registers itself (and dispatches this event) as soon as it's
@@ -144,7 +198,6 @@ export class QtiGraphicOrderInteraction extends ChoicesMixin(Interaction, 'qti-h
   override disconnectedCallback() {
     this.querySelectorAll(`.${QtiGraphicOrderInteraction.#LOCATOR_CLASS}`).forEach(marker => marker.remove());
     super.disconnectedCallback();
-    this.removeEventListener('activate-qti-hotspot-choice', this.#setHotspotOrder);
     this.removeEventListener('register-qti-hotspot-choice', this.#positionHotspotOnRegister);
   }
 }

--- a/packages/qti-transformers/src/shared/xml.ts
+++ b/packages/qti-transformers/src/shared/xml.ts
@@ -1,3 +1,37 @@
+/**
+ * Parse XML, reporting a malformed document instead of handing one on.
+ *
+ * `DOMParser.parseFromString` never throws for `text/xml`: it returns a *document describing the
+ * failure*, whose root is an HTML page reading "This page contains the following errors…". Nothing
+ * downstream distinguishes that from a real item, so `toHTML` copied the error page into the DOM
+ * and the player rendered the browser's parse error as the item — silently, past every try/catch,
+ * because nothing ever threw.
+ *
+ * Leading whitespace and a BOM are stripped first. XML forbids anything before the declaration, so
+ * a stray newline in front of `<?xml` is fatal to the letter of the spec — and it is also one of
+ * the most common artefacts of an item that has been through an editor, a template or a copy and
+ * paste. Accepting it costs nothing and keeps real authoring mistakes visible.
+ */
+function parseXMLOrThrow(text: string, describeSource: (message: string) => string): XMLDocument {
+  const parser = new DOMParser();
+  const xmlFragment = parser.parseFromString(text.replace(/^[\s\uFEFF]+/, ''), 'text/xml');
+
+  /*
+   * Matched by the error document's own namespace, so an item that legitimately contains an
+   * element named `parsererror` cannot be mistaken for a failure. Blink and WebKit put it in the
+   * XHTML namespace; Gecko has a namespace of its own.
+   */
+  const error =
+    xmlFragment.getElementsByTagNameNS('http://www.w3.org/1999/xhtml', 'parsererror')[0] ??
+    xmlFragment.getElementsByTagNameNS('http://www.mozilla.org/newlayout/xml/parsererror.xml', 'parsererror')[0];
+
+  if (error) {
+    throw new Error(describeSource(error.textContent?.replace(/\s+/g, ' ').trim() || 'malformed XML'));
+  }
+
+  return xmlFragment;
+}
+
 export function loadXML(url: string, signal?: AbortSignal): Promise<XMLDocument | null> {
   return fetch(url, { signal })
     .then(response => {
@@ -6,10 +40,7 @@ export function loadXML(url: string, signal?: AbortSignal): Promise<XMLDocument 
       }
       return response.text();
     })
-    .then(text => {
-      const parser = new DOMParser();
-      return parser.parseFromString(text, 'text/xml');
-    })
+    .then(text => parseXMLOrThrow(text, message => `is not well-formed XML: ${message}`))
     .catch(error => {
       if (error.name === 'AbortError') {
         throw error;
@@ -18,10 +49,8 @@ export function loadXML(url: string, signal?: AbortSignal): Promise<XMLDocument 
     });
 }
 
-export function parseXML(xmlDocument: string) {
-  const parser = new DOMParser();
-  const xmlFragment = parser.parseFromString(xmlDocument, 'text/xml');
-  return xmlFragment;
+export function parseXML(xmlDocument: string): XMLDocument {
+  return parseXMLOrThrow(xmlDocument, message => `Failed to parse XML: ${message}`);
 }
 
 // Function to strip unsupported namespaces (qti) from the nodes sent to the browser

--- a/packages/qti-transformers/src/shared/xml.ts
+++ b/packages/qti-transformers/src/shared/xml.ts
@@ -12,6 +12,20 @@
  * the most common artefacts of an item that has been through an editor, a template or a copy and
  * paste. Accepting it costs nothing and keeps real authoring mistakes visible.
  */
+/**
+ * The one useful sentence out of the error document — "error on line N at column M: …" — without
+ * the page boilerplate the browser wraps it in.
+ */
+function readParserMessage(error: Element): string {
+  const text = (error.textContent || '').replace(/\s+/g, ' ').trim();
+  return (
+    text
+      .replace(/^This page contains the following errors:\s*/i, '')
+      .replace(/\s*Below is a rendering of the page up to the first error\.?\s*$/i, '')
+      .trim() || 'malformed XML'
+  );
+}
+
 function parseXMLOrThrow(text: string, describeSource: (message: string) => string): XMLDocument {
   const parser = new DOMParser();
   const xmlFragment = parser.parseFromString(text.replace(/^[\s\uFEFF]+/, ''), 'text/xml');
@@ -26,7 +40,7 @@ function parseXMLOrThrow(text: string, describeSource: (message: string) => stri
     xmlFragment.getElementsByTagNameNS('http://www.mozilla.org/newlayout/xml/parsererror.xml', 'parsererror')[0];
 
   if (error) {
-    throw new Error(describeSource(error.textContent?.replace(/\s+/g, ' ').trim() || 'malformed XML'));
+    throw new Error(describeSource(readParserMessage(error)));
   }
 
   return xmlFragment;

--- a/packages/qti-transformers/test/qti-xml-parse-errors.spec.ts
+++ b/packages/qti-transformers/test/qti-xml-parse-errors.spec.ts
@@ -1,0 +1,93 @@
+/**
+ * `DOMParser.parseFromString` never throws for `text/xml` — it returns a *document describing the
+ * failure*, whose root is an HTML page reading "This page contains the following errors…". Nothing
+ * downstream told that apart from a real item, so `toHTML` copied the error page into the DOM and
+ * the player rendered the browser's parse error as the item, past every try/catch, because nothing
+ * ever threw.
+ *
+ * A leading blank line in front of `<?xml` is the case that surfaced it: fatal to the letter of the
+ * XML spec, and one of the most common artefacts of an item that has been through an editor or a
+ * copy and paste. That one is now tolerated; everything genuinely malformed is reported.
+ */
+import { qtiTransformItem } from '../src/qti-transform-item';
+import { qtiTransformTest } from '../src/qti-transform-test';
+
+const declaration = '<?xml version="1.0" encoding="UTF-8"?>';
+const item = `${declaration}
+<qti-assessment-item identifier="item1" title="Item"><qti-item-body><p>hello</p></qti-item-body></qti-assessment-item>`;
+
+const renderedText = (xml: string): string => {
+  const host = document.createElement('div');
+  host.appendChild(qtiTransformItem().parse(xml).htmlDoc());
+  return (host.textContent || '').replace(/\s+/g, ' ').trim();
+};
+
+describe('parsing a malformed item', () => {
+  it('throws instead of handing back the browser error document', () => {
+    expect(() => qtiTransformItem().parse('<qti-assessment-item><unclosed></qti-assessment-item>')).toThrow(
+      /Failed to parse XML/
+    );
+  });
+
+  it('carries the parser message, so the author can find the line', () => {
+    let message = '';
+    try {
+      qtiTransformItem().parse('<qti-assessment-item><unclosed></qti-assessment-item>');
+    } catch (error) {
+      message = (error as Error).message;
+    }
+    expect(message).toMatch(/line/i);
+  });
+
+  it('never renders the browser error page as the item', () => {
+    expect(() => renderedText('<qti-assessment-item><unclosed></qti-assessment-item>')).toThrow();
+  });
+
+  it('reports a malformed test too', () => {
+    expect(() => qtiTransformTest().parse('<qti-assessment-test><unclosed>')).toThrow(/Failed to parse XML/);
+  });
+
+  it('rejects a load() whose body is not well-formed', async () => {
+    const fetchMock = vi.fn(async () => new Response('<qti-assessment-item><unclosed>', { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+    try {
+      await expect(qtiTransformItem().load('https://example.com/items/i1.xml')).rejects.toThrow(
+        /Failed to load XML: is not well-formed XML/
+      );
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+});
+
+describe('tolerating leading whitespace before the declaration', () => {
+  // The reported case: an item that reaches the player with one blank line in front of `<?xml`.
+  it.each([
+    ['a leading newline', `\n${item}`],
+    ['a blank line and indentation', `\n     ${item}`],
+    ['leading spaces', `   ${item}`],
+    ['a BOM', `\uFEFF${item}`],
+    ['a BOM and a newline', `\uFEFF\n${item}`]
+  ])('parses an item with %s', (_label, xml) => {
+    expect(renderedText(xml)).toBe('hello');
+  });
+
+  it('leaves a well-formed item alone', () => {
+    expect(renderedText(item)).toBe('hello');
+  });
+
+  it('does not swallow an item that is malformed after the whitespace', () => {
+    expect(() => qtiTransformItem().parse(`\n${declaration}\n<qti-assessment-item><unclosed>`)).toThrow(
+      /Failed to parse XML/
+    );
+  });
+});
+
+describe('an item that legitimately mentions parsererror', () => {
+  // Matched by the error document's namespace, not by tag name, so item content cannot fake it.
+  it('is not mistaken for a parse failure', () => {
+    const xml = `${declaration}
+<qti-assessment-item identifier="item1" title="Item"><qti-item-body><parsererror>not an error</parsererror></qti-item-body></qti-assessment-item>`;
+    expect(renderedText(xml)).toBe('not an error');
+  });
+});

--- a/packages/qti-transformers/test/qti-xml-parse-errors.spec.ts
+++ b/packages/qti-transformers/test/qti-xml-parse-errors.spec.ts
@@ -36,7 +36,10 @@ describe('parsing a malformed item', () => {
     } catch (error) {
       message = (error as Error).message;
     }
-    expect(message).toMatch(/line/i);
+    expect(message).toMatch(/error on line \d+ at column \d+/i);
+    // The error document's page boilerplate is not part of the message.
+    expect(message).not.toMatch(/This page contains the following errors/i);
+    expect(message).not.toMatch(/Below is a rendering/i);
   });
 
   it('never renders the browser error page as the item', () => {


### PR DESCRIPTION
Fixes #211.

An item with a blank line in front of `<?xml` rendered the browser's XML parse error **as the item**:

```
This page contains the following errors:
error on line 2 at column 6: Invalid processing instruction: <?xml
Below is a rendering of the page up to the first error.
```

## Why it rendered instead of failing

`DOMParser.parseFromString(text, 'text/xml')` **never throws**. On a malformed document it returns a *document describing the failure* — an HTML page whose body is the text above. `parseXML` and `loadXML` handed that straight back, `toHTML` walked it node by node into the DOM, and the player rendered the error page as item content. `item-container` wraps both entry points in `try`/`catch`, but nothing ever threw, so the catch was dead code and nothing reached the console either.

That is the general defect: **any** malformed item rendered the browser's error page rather than reporting a failure. The leading blank line is only how it surfaced.

## What changed

- `parseXML` / `loadXML` detect the parser-error document and throw, carrying the parser's own message — so the line and column of the real problem survive, and `item-container`'s existing `catch` finally fires.
- The error document is matched by **namespace**, not tag name (XHTML for Blink/WebKit, Gecko's own), so an item that legitimately contains an element named `parsererror` is not mistaken for a failure.
- Leading whitespace and a BOM before the declaration are stripped before parsing.

On the last point: XML forbids anything before the declaration, so strictly the document is invalid. It is also one of the most common artefacts of an item that has been through an editor, a template or a copy and paste — and the parser already tolerated the analogous BOM case, which is why a BOM worked and a newline did not. Tolerating the whitespace costs nothing and keeps genuine authoring mistakes visible; anything malformed *after* the whitespace still throws.

## Tests

`qti-xml-parse-errors.spec.ts` covers both halves: a malformed item and test throw with the parser's message, `load()` rejects on a not-well-formed body, the error page is never rendered, five leading-whitespace/BOM shapes parse, malformed-after-whitespace still throws, and an item containing a real `parsererror` element renders normally. 10 of its 13 cases fail on `main` (the 3 that pass are the clean and BOM-only cases, which already worked).

## Verification

Run by hand (pnpm cannot run in this checkout): `npx tsc --noEmit`, `npx eslint packages tools`, `npx prettier --check`, `npx vitest run --project tests` (705), `--project stories` (634), `VRT=1 --project vrt` (17), `npx madge --circular`, `node tools/qti-vocabulary/check.mjs`. All green. `custom-elements.json` deliberately not regenerated.

Stacked on nothing — independent of #210.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
