### PR TITLE
fix(gap-img): give the chip its shadow root, so its picture centres

### DIFF
--- a/.changeset/gap-img-centring.md
+++ b/.changeset/gap-img-centring.md
@@ -1,0 +1,12 @@
+---
+'@qti-components/interactions-core': patch
+'@citolab/qti-components': patch
+---
+
+Fix a dropped picture rendering low and hanging out of its hotspot in `qti-graphic-gap-match-interaction` (#213).
+
+`qti-gap-img` never called `super.connectedCallback()`, so Lit never enabled updating and the element had no shadow root — which made `qti-gap-img.styles.ts`, the stylesheet that centres the picture, dead code. The source already carried a note saying exactly that. Without it the authored `<img>` / `<object>` was laid out as an inline replaced element on a text baseline rather than centred: it sat low in the chip with the line box's descender space below it.
+
+On the 1EdTech "Airport Tags" example, whose hotspot `A` is authored `coords="12,108,39,121"` (27x13) around an 18x9 picture, the picture rendered 7px down from the hotspot top, 2.5px below its centre, with its bottom 3px past the box. The chip also measured 18px tall for a 9px picture, and that measurement feeds `--qti-dropzone-min-height` — so the hotspot itself was inflated to 27x18 and the box on screen was not the box in the item either.
+
+`qti-gap-img` now calls `super.connectedCallback()` and renders a `<slot part="label">`, matching `qti-gap-text`, the sibling chip that always did this correctly. The chip is the size of its picture, the hotspot keeps the size its `coords` declare, and the picture lands centred inside it.

--- a/packages/interactions/core/src/elements/qti-gap-img/qti-gap-img.ts
+++ b/packages/interactions/core/src/elements/qti-gap-img/qti-gap-img.ts
@@ -1,4 +1,4 @@
-import { LitElement } from 'lit';
+import { html, LitElement } from 'lit';
 import { property } from 'lit/decorators.js';
 
 import styles from './qti-gap-img.styles';
@@ -12,16 +12,29 @@ export class QtiGapImg extends LitElement {
 
   /**
    * `qti-gap-img` is a draggable chip, so it needs ElementInternals to carry the drag states
-   * (`dragging`, `placeholder`). It works without a shadow root.
-   *
-   * NOTE: this element never calls `super.connectedCallback()`, so Lit never enables updating
-   * and it has no shadow root — which makes `qti-gap-img.styles.ts` dead code. Fixing that means
-   * adding a `<slot>` to a `render()` first, otherwise the authored `<img>` child disappears.
+   * (`dragging`, `placeholder`).
    */
   public internals: ElementInternals = this.attachInternals();
 
   override connectedCallback() {
+    super.connectedCallback();
     this.setAttribute('slot', 'drags');
+  }
+
+  /*
+   * The slot is what makes qti-gap-img.styles.ts live.
+   *
+   * This used to skip `super.connectedCallback()`, so Lit never enabled updating, the element had
+   * no shadow root, and its own `:host { display: flex; align-items: center }` was dead code. The
+   * authored `<img>`/`<object>` was then laid out as an inline replaced element on a text baseline
+   * instead of being centred — it sat low in the chip with the line box's descender space below it,
+   * which is what pushed a placed chip out of the bottom of its hotspot.
+   *
+   * Shaped like qti-gap-text, the sibling chip that always did this correctly, so `exportparts`'
+   * `label` resolves for both.
+   */
+  override render() {
+    return html`<slot part="label"></slot>`;
   }
 }
 

--- a/packages/interactions/graphic-gap-match-interaction/src/qti-graphic-gap-match-interaction.spec.ts
+++ b/packages/interactions/graphic-gap-match-interaction/src/qti-graphic-gap-match-interaction.spec.ts
@@ -1,0 +1,159 @@
+/**
+ * Regression for the 1EdTech "Airport Tags" example: a dropped label rendered low, hanging out of
+ * the bottom of the hotspot the author drew.
+ *
+ * `qti-gap-img` skipped `super.connectedCallback()`, so Lit never enabled updating and the element
+ * had no shadow root — which made its own `:host { display: flex; align-items: center }` dead code
+ * (the source said so). The authored `<img>`/`<object>` was then laid out as an inline replaced
+ * element on a text baseline rather than centred, so a 9px picture sat 5px down in its chip with
+ * the line box's descender space below it. Measured on this item, before the fix:
+ *
+ *   hotspot A  27x18   (authored 27x13 — inflated, because the chip measured 18px tall)
+ *   image      +7px from the hotspot top, centre 2.5px low, bottom 3px past the authored box
+ *
+ * The inflated chip measurement also fed --qti-dropzone-min-height, so the hotspot grew past the
+ * coords the author gave it: the box on screen was not the box in the item either.
+ */
+import '@citolab/qti-components';
+import itemCss from '../../../qti-theme/src/item.css?inline';
+import drag from '../../../../tools/testing/drag';
+
+import type { QtiAssessmentItem } from '@qti-components/elements';
+
+// 1x1 transparent PNG. The chips carry an explicit box, so the bitmap's own size never decides
+// the geometry — a 1:1 source under a `height: auto` reset would otherwise render square.
+const PNG =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==';
+
+const CHIP_HEIGHT = 9;
+
+const graphicFor = (tag: 'object' | 'img', w: number, h: number, alt: string) =>
+  tag === 'object'
+    ? `<object type="image/png" data="${PNG}" width="${w}" height="${h}">${alt}</object>`
+    : `<img src="${PNG}" width="${w}" height="${h}" style="width:${w}px;height:${h}px" alt="${alt}"/>`;
+
+const gapImg = (id: string, w: number, tag: 'object' | 'img') =>
+  `<qti-gap-img identifier="${id}" match-max="1">${graphicFor(tag, w, CHIP_HEIGHT, id)}</qti-gap-img>`;
+
+// The 1EdTech item's own coords and image sizes.
+const airportTags = (tag: 'object' | 'img') => `
+<qti-assessment-item identifier="graphicGapfill" title="Airport Tags">
+  <qti-response-declaration identifier="RESPONSE" cardinality="multiple" base-type="directedPair"></qti-response-declaration>
+  <qti-item-body>
+    <qti-graphic-gap-match-interaction response-identifier="RESPONSE">
+      <qti-prompt>Identify the unlabelled airports.</qti-prompt>
+      ${graphicFor(tag, 206, 280, 'UK map')}
+      ${gapImg('CBG', 20, tag)}
+      ${gapImg('EBG', 18, tag)}
+      ${gapImg('EDI', 14, tag)}
+      <qti-associable-hotspot identifier="A" match-max="1" shape="rect" coords="12,108,39,121"></qti-associable-hotspot>
+      <qti-associable-hotspot identifier="C" match-max="1" shape="rect" coords="66,165,93,178"></qti-associable-hotspot>
+    </qti-graphic-gap-match-interaction>
+  </qti-item-body>
+</qti-assessment-item>`;
+
+describe.each([['object'], ['img']] as const)('graphic gap match, graphic as <%s>', tag => {
+  let host: HTMLElement;
+  let style: HTMLStyleElement;
+  let interaction: HTMLElement;
+
+  beforeEach(async () => {
+    style = document.createElement('style');
+    style.textContent = itemCss as unknown as string;
+    document.head.appendChild(style);
+
+    host = document.createElement('div');
+    host.style.cssText = 'position:relative;width:360px;padding:10px;background:#fff';
+    document.body.appendChild(host);
+    host.innerHTML = airportTags(tag);
+
+    const item = host.querySelector('qti-assessment-item') as QtiAssessmentItem;
+    interaction = host.querySelector('qti-graphic-gap-match-interaction') as HTMLElement;
+    await item.updateComplete;
+    await (interaction as HTMLElement & { updateComplete: Promise<unknown> }).updateComplete;
+    await Promise.all(
+      Array.from(host.querySelectorAll('img')).map(i => (i.complete ? Promise.resolve() : i.decode().catch(() => {})))
+    );
+    await new Promise(resolve => setTimeout(resolve, 200));
+  });
+
+  afterEach(() => {
+    host.remove();
+    style.remove();
+  });
+
+  const chip = (id: string) => interaction.querySelector(`qti-gap-img[identifier="${id}"]`) as HTMLElement;
+  const hotspot = (id: string) =>
+    interaction.querySelector(`qti-associable-hotspot[identifier="${id}"]`) as HTMLElement;
+
+  const dropInto = async (chipId: string, hotspotId: string) => {
+    await drag(chip(chipId), { to: hotspot(hotspotId), duration: 300 });
+    await new Promise(resolve => setTimeout(resolve, 200));
+    const placed = hotspot(hotspotId).shadowRoot!.querySelector('qti-gap-img') as HTMLElement;
+    return { placed, image: placed?.querySelector(tag) as HTMLElement };
+  };
+
+  // The chip's own stylesheet was dead code while the element had no shadow root.
+  it('gives every chip the shadow root its centring styles need', () => {
+    for (const id of ['CBG', 'EBG', 'EDI']) {
+      expect(chip(id).shadowRoot, `${id} has no shadow root`).toBeTruthy();
+      expect(getComputedStyle(chip(id)).display).toBe('flex');
+    }
+  });
+
+  // An inline replaced element on a text baseline made the chip taller than its picture.
+  it('sizes a chip to its picture, not to a line box', () => {
+    for (const [id, width] of [
+      ['CBG', 20],
+      ['EBG', 18],
+      ['EDI', 14]
+    ] as const) {
+      const rect = chip(id).getBoundingClientRect();
+      expect(rect.height, `chip ${id} is taller than its picture`).toBeCloseTo(CHIP_HEIGHT, 0);
+      expect(rect.width, `chip ${id} is not its picture's width`).toBeCloseTo(width, 0);
+    }
+  });
+
+  // The inflated chip measurement fed --qti-dropzone-min-height and grew the hotspot with it.
+  it('leaves a hotspot at the size its coords declare', () => {
+    const rect = hotspot('A').getBoundingClientRect();
+    expect(rect.width).toBeCloseTo(39 - 12, 0);
+    expect(rect.height).toBeCloseTo(121 - 108, 0);
+  });
+
+  it('records the drop', async () => {
+    await dropInto('EBG', 'A');
+    expect((interaction as HTMLElement & { response: unknown }).response).toEqual('EBG A');
+  });
+
+  // The reported symptom: EBG landed low and hung out of the bottom of its box.
+  it('centres the dropped picture in its hotspot', async () => {
+    const { image } = await dropInto('EBG', 'A');
+    const imageRect = image.getBoundingClientRect();
+    const hotspotRect = hotspot('A').getBoundingClientRect();
+
+    const offset = imageRect.top + imageRect.height / 2 - (hotspotRect.top + hotspotRect.height / 2);
+    expect(Math.abs(offset), `picture sits ${offset.toFixed(1)}px off centre`).toBeLessThanOrEqual(1);
+  });
+
+  it('keeps the dropped picture inside its hotspot', async () => {
+    const { image } = await dropInto('EBG', 'A');
+    const imageRect = image.getBoundingClientRect();
+    const hotspotRect = hotspot('A').getBoundingClientRect();
+
+    expect(imageRect.top, 'picture starts above its hotspot').toBeGreaterThanOrEqual(hotspotRect.top - 0.5);
+    expect(imageRect.bottom, 'picture hangs below its hotspot').toBeLessThanOrEqual(hotspotRect.bottom + 0.5);
+    expect(imageRect.left).toBeGreaterThanOrEqual(hotspotRect.left - 0.5);
+    expect(imageRect.right).toBeLessThanOrEqual(hotspotRect.right + 0.5);
+  });
+
+  // A chip is the same chip wherever it lives — the library's standing invariant.
+  it('keeps the chip the same size in the bank and in the hotspot', async () => {
+    const bankRect = chip('EBG').getBoundingClientRect();
+    const { placed } = await dropInto('EBG', 'A');
+    const placedRect = placed.getBoundingClientRect();
+
+    expect(placedRect.width).toBeCloseTo(bankRect.width, 0);
+    expect(placedRect.height).toBeCloseTo(bankRect.height, 0);
+  });
+});


### PR DESCRIPTION
Fixes #213.

On the 1EdTech "Airport Tags" graphic gap match, a dropped label rendered low and hung out of the bottom of the hotspot the author drew.

## Cause

`qti-gap-img` never called `super.connectedCallback()`, so Lit never enabled updating and the element had no shadow root — which made `qti-gap-img.styles.ts`, the stylesheet that centres the picture, dead code. The source already carried a note saying exactly that, and naming the prerequisite for fixing it:

> NOTE: this element never calls `super.connectedCallback()`, so Lit never enables updating and it has no shadow root — which makes `qti-gap-img.styles.ts` dead code. Fixing that means adding a `<slot>` to a `render()` first, otherwise the authored `<img>` child disappears.

Without that centring the authored `<img>` / `<object>` was laid out as an **inline replaced element on a text baseline**: it sat low in the chip, with the line box's descender space below it.

`qti-gap-text`, the sibling chip, has always called `super.connectedCallback()` and rendered a `<slot>`. `qti-gap-img` was the odd one out.

## Measured, on the example item

Hotspot `A` is authored `coords="12,108,39,121"` — 27×13 — around an 18×9 picture.

```
                         before            after
hotspot A rendered       27 x 18           27 x 13   (the authored box)
picture top - box top    +7px              +2px
picture centre offset    +2.5px (low)       0.0px
picture bottom           3px past the box  inside
chip box (18x9 picture)  18 x 18           18 x 9
```

Two symptoms, one cause: the chip measuring 18px tall for a 9px picture also feeds `--qti-dropzone-min-height`, so the hotspot was inflated past its own coords and the box on screen was not the box in the item either. Both go away once the chip is the size of its picture.

## What changed

`qti-gap-img` calls `super.connectedCallback()` and renders `<slot part="label">`, shaped like `qti-gap-text` so `exportparts`' `label` resolves for both.

**`dropRegion` is deliberately untouched.** "A drop container hosts a chip, it never sizes one" is a documented contract with `drag-drop.invariance.spec.ts` behind it, and centring there would be the wrong lever — once the chip is the size of its picture, the hotspot is the size of its coords and the picture lands centred anyway. I tried it first; reverted.

## Tests

`qti-graphic-gap-match-interaction.spec.ts` runs the example item against both graphic forms (`<object>`, which is what 1EdTech ships, and `<img>`): the chip has its shadow root and centring display, a chip is the size of its picture, a hotspot keeps the size its coords declare, the drop is recorded, and the dropped picture is centred in its hotspot, inside it, and the same size in the bank and placed. 8 of its 14 cases fail on `main`.

## Verification

Run by hand (pnpm cannot run in this checkout): `npx tsc --noEmit`, `npx eslint packages tools`, `npx prettier --check`, `npx vitest run --project tests` (688), `--project stories` (633), `VRT=1 --project vrt` (17), `npx madge --circular`, `node tools/qti-vocabulary/check.mjs`. All green. `custom-elements.json` deliberately not regenerated.

Independent of #210 and #212.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
